### PR TITLE
Add Claude Code skills for CLI commands and improve webdav get

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,35 @@ Features:
 - Supports `extended` flag on columns for optional fields
 - Use `TableRenderer` class directly for column validation helpers (e.g., `--columns` flag support)
 
+## Claude Code Skills Plugin
+
+The `./plugins/b2c-cli/skills/` directory contains Claude Code skills that teach Claude about the CLI commands. Each skill has a `SKILL.md` file with examples and documentation.
+
+**When modifying CLI commands:**
+- Update the corresponding skill in `plugins/b2c-cli/skills/b2c-<topic>/SKILL.md` if it exists
+- For breaking changes (renamed flags, removed arguments, changed behavior), update all affected examples
+
+**Skill format:**
+```markdown
+---
+name: b2c-<topic>
+description: Brief description of what the skill teaches
+---
+
+# B2C <Topic> Skill
+
+Overview of the command topic.
+
+## Examples
+
+### <Use Case>
+
+\`\`\`bash
+# comment explaining the command
+b2c <topic> <command> [args] [flags]
+\`\`\`
+```
+
 ## Testing
 
 Tests use Mocha + Chai with c8 for coverage. HTTP mocking uses MSW (Mock Service Worker).

--- a/plugins/b2c-cli/skills/b2c-code/SKILL.md
+++ b/plugins/b2c-cli/skills/b2c-code/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: b2c-code
+description: Salesforce B2C Commerce code version deployment and management Skill
+---
+
+# B2C Code Skill
+
+Use the `b2c` CLI plugin to deploy and manage code versions on Salesforce B2C Commerce instances.
+
+## Examples
+
+### Deploy Cartridges
+
+```bash
+# deploy all cartridges from current directory
+b2c code deploy
+
+# deploy cartridges from a specific directory
+b2c code deploy ./my-cartridges
+
+# deploy to a specific server and code version
+b2c code deploy --server my-sandbox.demandware.net --code-version v1
+
+# deploy and reload (re-activate) the code version
+b2c code deploy --reload
+
+# delete existing cartridges before upload and reload
+b2c code deploy --delete --reload
+
+# deploy only specific cartridges
+b2c code deploy -c app_storefront_base -c plugin_applepay
+
+# exclude specific cartridges from deployment
+b2c code deploy -x test_cartridge
+```
+
+### Watch for Changes
+
+```bash
+# watch cartridges and upload changes automatically
+b2c code watch
+
+# watch a specific directory
+b2c code watch ./my-cartridges
+
+# watch with specific server and code version
+b2c code watch --server my-sandbox.demandware.net --code-version v1
+
+# watch only specific cartridges
+b2c code watch -c app_storefront_base
+
+# watch excluding specific cartridges
+b2c code watch -x test_cartridge
+```
+
+### List Code Versions
+
+```bash
+# list code versions on the instance
+b2c code list
+
+# list with JSON output
+b2c code list --json
+```
+
+### Activate Code Version
+
+```bash
+# activate a code version
+b2c code activate <version-name>
+
+# reload (re-activate) the current code version
+b2c code activate --reload
+```
+
+### Delete Code Version
+
+```bash
+# delete a code version
+b2c code delete <version-name>
+```
+
+### More Commands
+
+See `b2c code --help` for a full list of available commands and options in the `code` topic.

--- a/plugins/b2c-cli/skills/b2c-job/SKILL.md
+++ b/plugins/b2c-cli/skills/b2c-job/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: b2c-job
+description: Salesforce B2C Commerce job execution and site archive import/export (IMPEX) Skill
+---
+
+# B2C Job Skill
+
+Use the `b2c` CLI plugin to run jobs and import/export site archives on Salesforce B2C Commerce instances.
+
+## Examples
+
+### Run a Job
+
+```bash
+# run a job and return immediately
+b2c job run my-custom-job
+
+# run a job and wait for completion
+b2c job run my-custom-job --wait
+
+# run a job with a timeout (in seconds)
+b2c job run my-custom-job --wait --timeout 600
+
+# run a job with parameters
+b2c job run my-custom-job -P "SiteScope={\"all_storefront_sites\":true}" -P OtherParam=value
+
+# show job log if the job fails
+b2c job run my-custom-job --wait --show-log
+```
+
+### Import Site Archives
+
+```bash
+# import a local directory as a site archive
+b2c job import ./my-site-data
+
+# import a local zip file
+b2c job import ./export.zip
+
+# keep the archive on the instance after import
+b2c job import ./my-site-data --keep-archive
+
+# import an archive that already exists on the instance (in Impex/src/instance/)
+b2c job import existing-archive.zip --remote
+
+# show job log on failure
+b2c job import ./my-site-data --show-log
+```
+
+### Export Site Archives
+
+```bash
+# export site data using the job export command
+b2c job export
+```
+
+### Search Job Executions
+
+```bash
+# search for job executions
+b2c job search
+
+# search with JSON output
+b2c job search --json
+```
+
+### Wait for Job Completion
+
+```bash
+# wait for a specific job execution to complete
+b2c job wait <execution-id>
+```
+
+### More Commands
+
+See `b2c job --help` for a full list of available commands and options in the `job` topic.

--- a/plugins/b2c-cli/skills/b2c-mrt/SKILL.md
+++ b/plugins/b2c-cli/skills/b2c-mrt/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: b2c-mrt
+description: Salesforce B2C Commerce Managed Runtime (MRT) project and deployment management Skill
+---
+
+# B2C MRT Skill
+
+Use the `b2c` CLI plugin to manage Managed Runtime (MRT) projects and deployments for PWA Kit storefronts.
+
+## Examples
+
+### Push Bundle to Managed Runtime
+
+```bash
+# push a bundle to MRT for a specific project
+b2c mrt push --project my-storefront
+
+# push to a specific environment (staging, production, etc.)
+b2c mrt push --project my-storefront --environment staging
+
+# push to production with a release message
+b2c mrt push --project my-storefront --environment production --message "Release v1.0.0"
+
+# push from a custom build directory
+b2c mrt push --project my-storefront --build-dir ./dist
+
+# specify Node.js version for SSR runtime
+b2c mrt push --project my-storefront --node-version 20.x
+
+# add SSR parameters
+b2c mrt push --project my-storefront --ssr-param SSRProxyPath=/api
+
+# use JSON output for automation
+b2c mrt push --project my-storefront --json
+```
+
+### Manage Environments
+
+```bash
+# create a new MRT environment
+b2c mrt env create
+
+# delete an MRT environment
+b2c mrt env delete
+```
+
+### Environment Variables
+
+```bash
+# manage environment variables for an MRT environment
+b2c mrt env var
+```
+
+### Configuration
+
+MRT settings can be configured in `dw.json`:
+- `mrtProject`: MRT project slug
+- `mrtEnvironment`: MRT environment name (staging, production, etc.)
+
+Environment variables:
+- `SFCC_MRT_PROJECT`: MRT project slug
+- `SFCC_MRT_ENVIRONMENT`: MRT environment
+- `SFCC_MRT_API_KEY`: MRT API key
+
+### More Commands
+
+See `b2c mrt --help` for a full list of available commands and options in the `mrt` topic.

--- a/plugins/b2c-cli/skills/b2c-sites/SKILL.md
+++ b/plugins/b2c-cli/skills/b2c-sites/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: b2c-sites
+description: Salesforce B2C Commerce storefront sites listing and inspection Skill
+---
+
+# B2C Sites Skill
+
+Use the `b2c` CLI plugin to list and inspect storefront sites on Salesforce B2C Commerce instances.
+
+## Examples
+
+### List Sites
+
+```bash
+# list all sites on the configured instance
+b2c sites list
+
+# list sites on a specific server
+b2c sites list --server my-sandbox.demandware.net
+
+# list sites with JSON output (useful for parsing/automation)
+b2c sites list --json
+
+# use a specific instance from config
+b2c sites list --instance production
+
+# enable debug logging
+b2c sites list --debug
+```
+
+### More Commands
+
+See `b2c sites --help` for a full list of available commands and options in the `sites` topic.

--- a/plugins/b2c-cli/skills/b2c-slas/SKILL.md
+++ b/plugins/b2c-cli/skills/b2c-slas/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: b2c-slas
+description: Salesforce B2C Commerce SLAS (Shopper Login and API Access Service) client management Skill
+---
+
+# B2C SLAS Skill
+
+Use the `b2c` CLI plugin to manage SLAS (Shopper Login and API Access Service) API clients and credentials.
+
+## Examples
+
+### List SLAS Clients
+
+```bash
+# list all SLAS clients for a tenant
+b2c slas client list --tenant-id abcd_123
+
+# list with JSON output
+b2c slas client list --tenant-id abcd_123 --json
+```
+
+### Get SLAS Client Details
+
+```bash
+# get details for a specific SLAS client
+b2c slas client get --tenant-id abcd_123 --client-id my-client-id
+```
+
+### Create SLAS Client
+
+```bash
+# create a new SLAS client
+b2c slas client create --tenant-id abcd_123
+```
+
+### Update SLAS Client
+
+```bash
+# update an existing SLAS client
+b2c slas client update --tenant-id abcd_123 --client-id my-client-id
+```
+
+### Delete SLAS Client
+
+```bash
+# delete a SLAS client
+b2c slas client delete --tenant-id abcd_123 --client-id my-client-id
+```
+
+### Configuration
+
+The tenant ID can be set via environment variable:
+- `SFCC_TENANT_ID`: SLAS tenant ID (organization ID)
+
+### More Commands
+
+See `b2c slas --help` for a full list of available commands and options in the `slas` topic.

--- a/plugins/b2c-cli/skills/b2c-webdav/SKILL.md
+++ b/plugins/b2c-cli/skills/b2c-webdav/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: b2c-webdav
+description: Salesforce B2C Commerce WebDAV file operations (listing, upload, download, logs) Skill
+---
+
+# B2C WebDAV Skill
+
+Use the `b2c` CLI plugin to perform WebDAV file operations on Salesforce B2C Commerce instances. This includes listing files, uploading, downloading, and managing files across different WebDAV roots.
+
+## WebDAV Roots
+
+The `--root` flag specifies the WebDAV directory:
+- `impex` (default) - Import/Export directory
+- `temp` - Temporary files
+- `cartridges` - Code cartridges
+- `realmdata` - Realm data
+- `catalogs` - Product catalogs
+- `libraries` - Content libraries
+- `static` - Static resources
+- `logs` - Application logs
+- `securitylogs` - Security logs
+
+## Examples
+
+### List Files
+
+```bash
+# list files in the default IMPEX root
+b2c webdav ls
+
+# list files in a specific path
+b2c webdav ls src/instance
+
+# list files in the cartridges root
+b2c webdav ls --root=cartridges
+
+# list files with JSON output
+b2c webdav ls --root=impex --json
+```
+
+### Reading Log Files
+
+Use the `logs` root to access instance log files:
+
+```bash
+# list all log files
+b2c webdav ls --root=logs
+
+# list log files with JSON output for parsing
+b2c webdav ls --root=logs --json
+
+# download a specific log file (e.g., customerror log)
+b2c webdav get customerror.log --root=logs
+
+# download a log file to a specific local path
+b2c webdav get error-20240115.log --root=logs -o ./downloads/error.log
+
+# output log file content to stdout (for piping to grep, etc.)
+b2c webdav get customerror.log --root=logs -o -
+
+# pipe log content to grep to search for errors
+b2c webdav get customerror.log --root=logs -o - | grep "ERROR"
+
+# download security logs
+b2c webdav ls --root=securitylogs
+b2c webdav get security-20240115.log --root=securitylogs
+```
+
+### Download Files
+
+```bash
+# download a file from IMPEX (default root)
+b2c webdav get src/instance/export.zip
+
+# download to a specific local path
+b2c webdav get src/instance/export.zip -o ./downloads/export.zip
+
+# download from a specific root
+b2c webdav get customerror.log --root=logs
+
+# output file content to stdout
+b2c webdav get src/instance/data.xml -o -
+```
+
+### Upload Files
+
+```bash
+# upload a file to IMPEX
+b2c webdav put ./local-file.zip src/instance/
+
+# upload to a specific root
+b2c webdav put ./my-cartridge.zip --root=cartridges
+```
+
+### Create Directories
+
+```bash
+# create a directory in IMPEX
+b2c webdav mkdir src/instance/my-folder
+
+# create a directory in a specific root
+b2c webdav mkdir my-folder --root=temp
+```
+
+### Delete Files
+
+```bash
+# delete a file
+b2c webdav rm src/instance/old-export.zip
+
+# delete from a specific root
+b2c webdav rm old-file.txt --root=temp
+```
+
+### Zip/Unzip Remote Files
+
+```bash
+# create a zip archive of a remote directory
+b2c webdav zip src/instance/my-folder
+
+# extract a remote zip archive
+b2c webdav unzip src/instance/archive.zip
+```
+
+### More Commands
+
+See `b2c webdav --help` for a full list of available commands and options in the `webdav` topic.


### PR DESCRIPTION
## Summary

- Add Claude Code skills plugin with documentation for CLI command topics
- Refactor `webdav get` command to support stdout output via `-o -` flag

### New Skills

Added skills to teach Claude about CLI commands in `plugins/b2c-cli/skills/`:
- `b2c-job` - Job execution and site archive import/export (IMPEX)
- `b2c-code` - Code version deployment and management
- `b2c-mrt` - Managed Runtime bundle push and environment management
- `b2c-sites` - Storefront sites listing
- `b2c-slas` - SLAS client management
- `b2c-webdav` - WebDAV file operations with log reading examples

### WebDAV Get Improvements

**Breaking change**: Replaced `local` positional argument with `-o/--output` flag.

```bash
# Default: saves to current directory with remote filename
b2c webdav get customerror.log --root=logs

# Output to specific file
b2c webdav get customerror.log --root=logs -o ./downloads/error.log

# Output to stdout (Unix convention)
b2c webdav get customerror.log --root=logs -o -
b2c webdav get customerror.log --root=logs -o - | grep "ERROR"
```

### Documentation

Updated `AGENTS.md` with guidance on maintaining skills when CLI commands change.

## Test plan

- [ ] Verify `b2c webdav get <file>` downloads to current directory
- [ ] Verify `b2c webdav get <file> -o <path>` downloads to specified path
- [ ] Verify `b2c webdav get <file> -o -` outputs to stdout
- [ ] Verify piping works: `b2c webdav get <file> -o - | grep <pattern>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)