### PR TITLE
Remove B2CInstance.fromEnvironment() in favor of resolveConfig()

### DIFF
--- a/packages/b2c-tooling-sdk/README.md
+++ b/packages/b2c-tooling-sdk/README.md
@@ -15,18 +15,21 @@ npm install @salesforce/b2c-tooling-sdk
 
 ## Quick Start
 
-### From Environment Configuration (Recommended)
+### From Configuration (Recommended)
 
-The easiest way to create an instance is from environment configuration files:
+Use `resolveConfig()` to load configuration from project files (dw.json) and create a B2C instance:
 
 ```typescript
-import { B2CInstance } from '@salesforce/b2c-tooling-sdk';
+import { resolveConfig } from '@salesforce/b2c-tooling-sdk/config';
 
-// Load configuration from environment files (dw.json, etc.), override secrets from environment
-const instance = B2CInstance.fromEnvironment({
+// Load configuration, override secrets from environment
+const config = resolveConfig({
   clientId: process.env.SFCC_CLIENT_ID,
   clientSecret: process.env.SFCC_CLIENT_SECRET,
 });
+
+// Create instance from validated config
+const instance = config.createB2CInstance();
 
 // Use typed WebDAV client
 await instance.webdav.mkcol('Cartridges/v1');
@@ -40,7 +43,7 @@ const { data, error } = await instance.ocapi.GET('/sites', {
 
 ### Direct Construction
 
-You can also construct an instance directly with configuration:
+For advanced use cases, you can construct a B2CInstance directly:
 
 ```typescript
 import { B2CInstance } from '@salesforce/b2c-tooling-sdk';
@@ -129,6 +132,7 @@ The SDK provides subpath exports for tree-shaking and organization:
 | Export | Description |
 |--------|-------------|
 | `@salesforce/b2c-tooling-sdk` | Main entry point with all exports |
+| `@salesforce/b2c-tooling-sdk/config` | Configuration resolution (resolveConfig) |
 | `@salesforce/b2c-tooling-sdk/auth` | Authentication strategies (OAuth, Basic, API Key) |
 | `@salesforce/b2c-tooling-sdk/instance` | B2CInstance class |
 | `@salesforce/b2c-tooling-sdk/clients` | Low-level API clients (WebDAV, OCAPI, SLAS, ODS, MRT) |

--- a/packages/b2c-tooling-sdk/src/clients/index.ts
+++ b/packages/b2c-tooling-sdk/src/clients/index.ts
@@ -24,11 +24,13 @@
  * and provides convenient `webdav` and `ocapi` getters.
  *
  * ```typescript
- * import { B2CInstance } from '@salesforce/b2c-tooling-sdk';
+ * import { resolveConfig } from '@salesforce/b2c-tooling-sdk/config';
  *
- * const instance = B2CInstance.fromEnvironment({
+ * const config = resolveConfig({
+ *   clientId: process.env.SFCC_CLIENT_ID,
  *   clientSecret: process.env.SFCC_CLIENT_SECRET,
  * });
+ * const instance = config.createB2CInstance();
  *
  * // WebDAV operations via instance.webdav
  * await instance.webdav.put('Cartridges/v1/app.zip', content);

--- a/packages/b2c-tooling-sdk/src/clients/ocapi.ts
+++ b/packages/b2c-tooling-sdk/src/clients/ocapi.ts
@@ -91,7 +91,9 @@ export interface OcapiClientOptions {
  *
  * @example
  * // Via B2CInstance (recommended)
- * const instance = B2CInstance.fromEnvironment();
+ * import { resolveConfig } from '@salesforce/b2c-tooling-sdk/config';
+ * const config = resolveConfig();
+ * const instance = config.createB2CInstance();
  * const { data, error } = await instance.ocapi.GET('/sites', {});
  *
  * @example

--- a/packages/b2c-tooling-sdk/src/clients/webdav.ts
+++ b/packages/b2c-tooling-sdk/src/clients/webdav.ts
@@ -40,7 +40,9 @@ export interface PropfindEntry {
  *
  * @example
  * // Via B2CInstance (recommended)
- * const instance = B2CInstance.fromEnvironment();
+ * import { resolveConfig } from '@salesforce/b2c-tooling-sdk/config';
+ * const config = resolveConfig();
+ * const instance = config.createB2CInstance();
  * await instance.webdav.mkcol('Cartridges/v1');
  * await instance.webdav.put('Cartridges/v1/app.zip', zipBuffer);
  *

--- a/packages/b2c-tooling-sdk/src/index.ts
+++ b/packages/b2c-tooling-sdk/src/index.ts
@@ -60,7 +60,7 @@ export type {
 
 // Context Layer - Instance
 export {B2CInstance} from './instance/index.js';
-export type {InstanceConfig, FromEnvironmentOptions, B2CInstanceOptions} from './instance/index.js';
+export type {InstanceConfig} from './instance/index.js';
 
 // Clients
 export {

--- a/packages/b2c-tooling-sdk/src/operations/code/index.ts
+++ b/packages/b2c-tooling-sdk/src/operations/code/index.ts
@@ -39,9 +39,10 @@
  *   activateCodeVersion,
  *   watchCartridges,
  * } from '@salesforce/b2c-tooling-sdk/operations/code';
- * import { B2CInstance } from '@salesforce/b2c-tooling-sdk';
+ * import { resolveConfig } from '@salesforce/b2c-tooling-sdk/config';
  *
- * const instance = B2CInstance.fromEnvironment();
+ * const config = resolveConfig();
+ * const instance = config.createB2CInstance();
  *
  * // Deploy cartridges (requires instance.config.codeVersion to be set)
  * await findAndDeployCartridges(instance, './cartridges', { reload: true });

--- a/packages/b2c-tooling-sdk/src/operations/jobs/index.ts
+++ b/packages/b2c-tooling-sdk/src/operations/jobs/index.ts
@@ -34,9 +34,10 @@
  *   siteArchiveImport,
  *   siteArchiveExport,
  * } from '@salesforce/b2c-tooling-sdk/operations/jobs';
- * import { B2CInstance } from '@salesforce/b2c-tooling-sdk';
+ * import { resolveConfig } from '@salesforce/b2c-tooling-sdk/config';
  *
- * const instance = B2CInstance.fromEnvironment();
+ * const config = resolveConfig();
+ * const instance = config.createB2CInstance();
  *
  * // Run a custom job and wait for completion
  * const execution = await executeJob(instance, 'my-job-id');


### PR DESCRIPTION
## Summary

Following PR #30 (Unified Configuration System), this PR removes the unused `B2CInstance.fromEnvironment()` method and updates all documentation to use the new `resolveConfig()` pattern.

- Remove `FromEnvironmentOptions` interface and `fromEnvironment()` static method (had zero runtime usages)
- Update all JSDoc examples across SDK modules to use `resolveConfig()` pattern
- Restructure `docs/api-readme.md` with comprehensive documentation for the unified config system
- Add `@salesforce/b2c-tooling-sdk/config` to SDK README exports table

The `resolveConfig()` API provides better validation, warnings, and multi-source configuration loading compared to the removed method.