### PR TITLE
Add --extra-headers flag and env var support for HTTP requests

### DIFF
--- a/.github/workflows/e2e-shell-tests.yml
+++ b/.github/workflows/e2e-shell-tests.yml
@@ -80,6 +80,7 @@ jobs:
           SFCC_SANDBOX_API_HOST: ${{ vars.SFCC_SANDBOX_API_HOST }}
           SFCC_SHORTCODE: ${{ vars.SFCC_SHORTCODE }}
           TEST_REALM: ${{ vars.TEST_REALM }}
+          SFCC_EXTRA_HEADERS: ${{ secrets.SFCC_EXTRA_HEADERS }}
         run: |
           echo "Running E2E shell tests with realm: ${TEST_REALM}"
           cd packages/b2c-cli

--- a/packages/b2c-tooling-sdk/src/cli/base-command.ts
+++ b/packages/b2c-tooling-sdk/src/cli/base-command.ts
@@ -75,11 +75,19 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     }),
     'extra-query': Flags.string({
       description: 'Extra query parameters as JSON (e.g., \'{"debug":"true"}\')',
+      env: 'SFCC_EXTRA_QUERY',
       helpGroup: 'GLOBAL',
       hidden: true,
     }),
     'extra-body': Flags.string({
       description: 'Extra body fields to merge as JSON (e.g., \'{"_internal":true}\')',
+      env: 'SFCC_EXTRA_BODY',
+      helpGroup: 'GLOBAL',
+      hidden: true,
+    }),
+    'extra-headers': Flags.string({
+      description: 'Extra HTTP headers as JSON (e.g., \'{"X-Custom-Header": "value"}\')',
+      env: 'SFCC_EXTRA_HEADERS',
       helpGroup: 'GLOBAL',
       hidden: true,
     }),
@@ -307,7 +315,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
   }
 
   /**
-   * Parse extra params from --extra-query and --extra-body flags.
+   * Parse extra params from --extra-query, --extra-body, and --extra-headers flags.
    * Returns undefined if no extra params are specified.
    *
    * @returns ExtraParamsConfig or undefined
@@ -315,8 +323,9 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
   protected getExtraParams(): ExtraParamsConfig | undefined {
     const extraQuery = this.flags['extra-query'];
     const extraBody = this.flags['extra-body'];
+    const extraHeaders = this.flags['extra-headers'];
 
-    if (!extraQuery && !extraBody) {
+    if (!extraQuery && !extraBody && !extraHeaders) {
       return undefined;
     }
 
@@ -335,6 +344,14 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
         config.body = JSON.parse(extraBody) as Record<string, unknown>;
       } catch {
         this.error(`Invalid JSON for --extra-body: ${extraBody}`);
+      }
+    }
+
+    if (extraHeaders) {
+      try {
+        config.headers = JSON.parse(extraHeaders) as Record<string, string>;
+      } catch {
+        this.error(`Invalid JSON for --extra-headers: ${extraHeaders}`);
       }
     }
 


### PR DESCRIPTION
## Summary
- Add `--extra-headers` hidden flag with `SFCC_EXTRA_HEADERS` env var support for passing custom HTTP headers to all API requests
- Add env vars to existing `--extra-query` (`SFCC_EXTRA_QUERY`) and `--extra-body` (`SFCC_EXTRA_BODY`) flags for consistency
- Update E2E workflow to use `SFCC_EXTRA_HEADERS` secret for Cloudflare firewall bypass

This enables CI environments to pass Cloudflare firewall headers via GitHub secrets.

## Usage

```bash
# Via environment variable (recommended for CI)
SFCC_EXTRA_HEADERS='{"CF-Access-Client-Id": "xxx", "CF-Access-Client-Secret": "yyy"}' b2c code deploy

# Via flag
b2c code deploy--extra-headers '{"X-Custom-Header": "value"}'
```

## Test plan
- [x] Unit tests added for middleware header handling
- [x] Unit tests added for BaseCommand flag parsing
- [x] Configure `SFCC_EXTRA_HEADERS` secret in `e2e-dev` environment
- [x] Run E2E workflow to verify Cloudflare bypass works