### PR TITLE
@W-20936652 feat: add two-factor client certificate (mTLS) support for WebDAV

### DIFF
--- a/.changeset/two-factor-mtls-support.md
+++ b/.changeset/two-factor-mtls-support.md
@@ -1,0 +1,18 @@
+---
+'@salesforce/b2c-tooling-sdk': minor
+'@salesforce/b2c-cli': minor
+---
+
+Add two-factor client certificate (mTLS) support for WebDAV operations
+
+New CLI flags for instance commands:
+- `--certificate <path>`: Path to PKCS12 (.p12/.pfx) certificate file
+- `--passphrase <string>`: Passphrase for the certificate
+- `--selfsigned`: Disable SSL certificate verification (for self-signed certs)
+- `--no-verify`: Alias for --selfsigned
+
+Environment variables: `SFCC_CERTIFICATE`, `SFCC_CERTIFICATE_PASSPHRASE`, `SFCC_SELFSIGNED`
+
+dw.json fields: `certificate`, `certificate-passphrase`, `self-signed`
+
+**SDK Note**: The `AuthStrategy.fetch` method signature changed from `RequestInit` to `FetchInit`. Custom `AuthStrategy` implementations should update their type annotations.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -68,6 +68,9 @@ You can configure the CLI using environment variables:
 | `SFCC_AUTH_METHODS` | Comma-separated list of allowed auth methods |
 | `SFCC_OAUTH_SCOPES` | OAuth scopes to request |
 | `SFCC_CODE_VERSION` | Code version for deployments |
+| `SFCC_CERTIFICATE` | Path to PKCS12 certificate for two-factor auth (mTLS) |
+| `SFCC_CERTIFICATE_PASSPHRASE` | Passphrase for the certificate |
+| `SFCC_SELFSIGNED` | Allow self-signed server certificates |
 
 ## .env File
 
@@ -142,7 +145,7 @@ If no instance is specified, the config with `"active": true` is used.
 | Field | Description |
 |-------|-------------|
 | `hostname` | B2C instance hostname |
-| `webdav-hostname` | Separate hostname for WebDAV (if different from main hostname). Also accepts `secureHostname` or `secure-server`. |
+| `webdav-hostname` | Separate hostname for WebDAV (if different from main hostname). Also accepts `webdav-server`, `secureHostname`, or `secure-server`. |
 | `code-version` | Code version for deployments |
 | `client-id` | OAuth client ID |
 | `client-secret` | OAuth client secret |
@@ -151,6 +154,27 @@ If no instance is specified, the config with `"active": true` is used.
 | `oauth-scopes` | OAuth scopes (array of strings) |
 | `auth-methods` | Authentication methods in priority order (array of strings) |
 | `shortCode` | SCAPI short code. Also accepts `short-code` or `scapi-shortcode`. |
+| `certificate` | Path to PKCS12 certificate for two-factor auth (mTLS) |
+| `certificate-passphrase` | Passphrase for the certificate. Also accepts `passphrase`. |
+| `self-signed` | Allow self-signed server certificates. Also accepts `selfsigned`. |
+
+### Two-Factor Authentication (mTLS)
+
+For instances that require client certificate authentication:
+
+```json
+{
+  "hostname": "cert.staging.example.demandware.net",
+  "code-version": "version1",
+  "username": "your-username",
+  "password": "your-access-key",
+  "certificate": "/path/to/client-cert.p12",
+  "certificate-passphrase": "cert-password",
+  "self-signed": true
+}
+```
+
+The certificate must be in PKCS12 format (`.p12` or `.pfx`). The `self-signed` option is often needed for staging environments with internal certificates.
 
 ::: tip MRT Configuration
 Managed Runtime API key is not stored in `dw.json`. It is loaded from `~/.mobify`. You can specify `mrtProject` and `mrtEnvironment` in `dw.json` for project/environment selection.

--- a/packages/b2c-tooling-sdk/package.json
+++ b/packages/b2c-tooling-sdk/package.json
@@ -293,6 +293,7 @@
     "openapi-fetch": "^0.15.0",
     "pino": "^10.1.0",
     "pino-pretty": "^13.1.2",
+    "undici": "^7.0.0",
     "xml2js": "^0.6.2"
   }
 }

--- a/packages/b2c-tooling-sdk/src/auth/api-key.ts
+++ b/packages/b2c-tooling-sdk/src/auth/api-key.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
-import type {AuthStrategy} from './types.js';
+import type {AuthStrategy, FetchInit} from './types.js';
 import {getLogger} from '../logging/logger.js';
 
 /**
@@ -40,10 +40,11 @@ export class ApiKeyStrategy implements AuthStrategy {
     logger.debug({headerName, keyPreview}, `[Auth] Using API Key authentication (${headerName}): ${keyPreview}`);
   }
 
-  async fetch(url: string, init: RequestInit = {}): Promise<Response> {
+  async fetch(url: string, init: FetchInit = {}): Promise<Response> {
     const headers = new Headers(init.headers);
     headers.set(this.headerName, this.headerValue);
-    return fetch(url, {...init, headers});
+    // Pass through dispatcher for TLS/mTLS support
+    return fetch(url, {...init, headers} as RequestInit);
   }
 
   /**

--- a/packages/b2c-tooling-sdk/src/auth/basic.ts
+++ b/packages/b2c-tooling-sdk/src/auth/basic.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
-import type {AuthStrategy} from './types.js';
+import type {AuthStrategy, FetchInit} from './types.js';
 import {getLogger} from '../logging/logger.js';
 
 export class BasicAuthStrategy implements AuthStrategy {
@@ -16,10 +16,12 @@ export class BasicAuthStrategy implements AuthStrategy {
     logger.debug({username: user}, `[Auth] Using Basic authentication for user: ${user}`);
   }
 
-  async fetch(url: string, init: RequestInit = {}): Promise<Response> {
+  async fetch(url: string, init: FetchInit = {}): Promise<Response> {
     const headers = new Headers(init.headers);
     headers.set('Authorization', `Basic ${this.encoded}`);
-    return fetch(url, {...init, headers});
+    // Pass through dispatcher for TLS/mTLS support
+    // Node.js fetch accepts dispatcher as an undocumented option
+    return fetch(url, {...init, headers} as RequestInit);
   }
 
   async getAuthorizationHeader(): Promise<string> {

--- a/packages/b2c-tooling-sdk/src/auth/index.ts
+++ b/packages/b2c-tooling-sdk/src/auth/index.ts
@@ -62,6 +62,7 @@
 // Types
 export type {
   AuthStrategy,
+  FetchInit,
   AccessTokenResponse,
   DecodedJWT,
   AuthConfig,

--- a/packages/b2c-tooling-sdk/src/auth/types.ts
+++ b/packages/b2c-tooling-sdk/src/auth/types.ts
@@ -3,12 +3,23 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
+
+/**
+ * Extended RequestInit that supports undici dispatcher for TLS/mTLS.
+ * Uses `unknown` for dispatcher to avoid type conflicts between undici package
+ * and @types/node/undici-types.
+ */
+export type FetchInit = Omit<RequestInit, 'dispatcher'> & {
+  /** undici dispatcher for custom TLS options (mTLS, self-signed certs) */
+  dispatcher?: unknown;
+};
+
 export interface AuthStrategy {
   /**
    * Performs a fetch request with authentication.
    * Implementations MUST handle header injection and 401 retries (token refresh) internally.
    */
-  fetch(url: string, init?: RequestInit): Promise<Response>;
+  fetch(url: string, init?: FetchInit): Promise<Response>;
 
   /**
    * Optional: Helper for legacy clients (like a strict WebDAV lib) that need the raw header.

--- a/packages/b2c-tooling-sdk/src/cli/config.ts
+++ b/packages/b2c-tooling-sdk/src/cli/config.ts
@@ -90,6 +90,10 @@ export function extractInstanceFlags(flags: ParsedFlags): Partial<NormalizedConf
     codeVersion: flags['code-version'] as string | undefined,
     username: flags.username as string | undefined,
     password: flags.password as string | undefined,
+    // TLS/mTLS options
+    certificate: flags.certificate as string | undefined,
+    certificatePassphrase: flags.passphrase as string | undefined,
+    selfSigned: (flags.selfsigned as boolean) || !(flags.verify as boolean),
     // Include OAuth flags (instance operations often need OAuth too)
     ...extractOAuthFlags(flags),
   };

--- a/packages/b2c-tooling-sdk/src/cli/instance-command.ts
+++ b/packages/b2c-tooling-sdk/src/cli/instance-command.ts
@@ -79,6 +79,28 @@ export abstract class InstanceCommand<T extends typeof Command> extends OAuthCom
       env: 'SFCC_PASSWORD',
       helpGroup: 'AUTH',
     }),
+    certificate: Flags.string({
+      description: 'Path to PKCS12 certificate for two-factor auth',
+      env: 'SFCC_CERTIFICATE',
+      helpGroup: 'AUTH',
+    }),
+    passphrase: Flags.string({
+      description: 'Passphrase for the certificate',
+      env: 'SFCC_CERTIFICATE_PASSPHRASE',
+      helpGroup: 'AUTH',
+    }),
+    selfsigned: Flags.boolean({
+      description: 'Allow self-signed server certificates',
+      env: 'SFCC_SELFSIGNED',
+      helpGroup: 'AUTH',
+      default: false,
+    }),
+    verify: Flags.boolean({
+      description: 'Verify SSL certificates',
+      default: true,
+      allowNo: true,
+      helpGroup: 'AUTH',
+    }),
   };
 
   private _instance?: B2CInstance;

--- a/packages/b2c-tooling-sdk/src/clients/index.ts
+++ b/packages/b2c-tooling-sdk/src/clients/index.ts
@@ -234,3 +234,6 @@ export type {
 } from './mrt-b2c.js';
 
 export {getApiErrorMessage} from './error-utils.js';
+
+export {createTlsDispatcher} from './tls-dispatcher.js';
+export type {TlsOptions} from './tls-dispatcher.js';

--- a/packages/b2c-tooling-sdk/src/clients/tls-dispatcher.ts
+++ b/packages/b2c-tooling-sdk/src/clients/tls-dispatcher.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+/**
+ * TLS/mTLS dispatcher utilities for client certificate authentication.
+ *
+ * This module provides utilities for creating undici Agents with custom
+ * TLS options, enabling two-factor authentication via client certificates.
+ *
+ * @module clients/tls-dispatcher
+ */
+import {Agent} from 'undici';
+import * as fs from 'node:fs';
+import * as tls from 'node:tls';
+import {getLogger} from '../logging/logger.js';
+
+/**
+ * TLS options for creating a dispatcher.
+ */
+export interface TlsOptions {
+  /** Path to PKCS12 (.p12/.pfx) certificate file */
+  certificate?: string;
+  /** Passphrase for the certificate */
+  passphrase?: string;
+  /** Whether to reject unauthorized (invalid/self-signed) certificates */
+  rejectUnauthorized?: boolean;
+}
+
+/**
+ * Validates a PKCS12 certificate file by attempting to create a secure context.
+ * This catches errors like missing/wrong passphrase early with a clear message.
+ *
+ * @param pfxData - The raw PKCS12 file data
+ * @param passphrase - Optional passphrase for the certificate
+ * @param certificatePath - Path to the certificate (for error messages)
+ * @throws Error with a user-friendly message if validation fails
+ */
+function validatePkcs12(pfxData: Buffer, passphrase: string | undefined, certificatePath: string): void {
+  try {
+    tls.createSecureContext({
+      pfx: pfxData,
+      passphrase: passphrase,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    // Detect common PKCS12 errors and provide helpful messages
+    if (message.includes('mac verify failure') || message.includes('bad decrypt')) {
+      if (passphrase) {
+        throw new Error(
+          `Invalid passphrase for certificate "${certificatePath}". ` + `The provided passphrase is incorrect.`,
+        );
+      } else {
+        throw new Error(
+          `Certificate "${certificatePath}" requires a passphrase. ` +
+            `Use --passphrase to provide it, or set SFCC_CERTIFICATE_PASSPHRASE.`,
+        );
+      }
+    }
+
+    if (message.includes('not enough data') || message.includes('wrong tag')) {
+      throw new Error(
+        `Invalid certificate file "${certificatePath}". ` +
+          `The file does not appear to be a valid PKCS12 (.p12/.pfx) certificate.`,
+      );
+    }
+
+    // Re-throw with context for other errors
+    throw new Error(`Failed to load certificate "${certificatePath}": ${message}`);
+  }
+}
+
+/**
+ * Creates an undici Agent with custom TLS options for mTLS/self-signed cert support.
+ *
+ * Returns undefined if no TLS options are needed (default fetch behavior).
+ *
+ * @param options - TLS configuration options
+ * @returns An undici Agent configured for TLS, or undefined if not needed
+ *
+ * @example
+ * // Client certificate authentication
+ * const dispatcher = createTlsDispatcher({
+ *   certificate: './my-cert.p12',
+ *   passphrase: 'secret',
+ * });
+ *
+ * @example
+ * // Self-signed certificate support
+ * const dispatcher = createTlsDispatcher({
+ *   rejectUnauthorized: false,
+ * });
+ */
+export function createTlsDispatcher(options: TlsOptions): Agent | undefined {
+  const logger = getLogger();
+  const {certificate, passphrase, rejectUnauthorized} = options;
+
+  // If no TLS customization needed, return undefined to use default fetch
+  if (!certificate && rejectUnauthorized !== false) {
+    return undefined;
+  }
+
+  const connect: Record<string, unknown> = {};
+
+  if (rejectUnauthorized === false) {
+    logger.debug('[TLS] Disabling SSL certificate verification (self-signed mode)');
+    connect.rejectUnauthorized = false;
+  }
+
+  if (certificate) {
+    logger.debug({certificate}, `[TLS] Loading client certificate from: ${certificate}`);
+
+    // Read the certificate file
+    let pfxData: Buffer;
+    try {
+      pfxData = fs.readFileSync(certificate);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to read certificate file "${certificate}": ${message}`);
+    }
+
+    // Validate the certificate upfront to catch passphrase issues early
+    validatePkcs12(pfxData, passphrase, certificate);
+
+    connect.pfx = pfxData;
+    if (passphrase) {
+      connect.passphrase = passphrase;
+    }
+  }
+
+  return new Agent({connect});
+}

--- a/packages/b2c-tooling-sdk/src/config/dw-json.ts
+++ b/packages/b2c-tooling-sdk/src/config/dw-json.ts
@@ -27,6 +27,8 @@ export interface DwJsonConfig {
   active?: boolean;
   /** B2C instance hostname */
   hostname?: string;
+  /** B2C instance hostname (alias for CLI flag consistency) */
+  server?: string;
   /** Code version for deployments */
   'code-version'?: string;
   /** Username for Basic auth (WebDAV) */
@@ -47,6 +49,8 @@ export interface DwJsonConfig {
   'scapi-shortcode'?: string;
   /** Alternate hostname for WebDAV (if different from main hostname) */
   'webdav-hostname'?: string;
+  /** Alternate hostname for WebDAV (matches CLI flag name) */
+  'webdav-server'?: string;
   /** Alternate hostname for WebDAV (legacy camelCase format) */
   secureHostname?: string;
   /** Alternate hostname for WebDAV (legacy kebab-case format) */
@@ -65,6 +69,16 @@ export interface DwJsonConfig {
   cloudOrigin?: string;
   /** Tenant/Organization ID for SCAPI */
   'tenant-id'?: string;
+  /** Path to PKCS12 certificate file for mTLS (two-factor auth) */
+  certificate?: string;
+  /** Passphrase for the certificate (kebab-case) */
+  'certificate-passphrase'?: string;
+  /** Passphrase for the certificate (legacy) */
+  passphrase?: string;
+  /** Allow self-signed certificates (kebab-case) */
+  'self-signed'?: boolean;
+  /** Allow self-signed certificates (legacy) */
+  selfsigned?: boolean;
 }
 
 /**

--- a/packages/b2c-tooling-sdk/src/config/types.ts
+++ b/packages/b2c-tooling-sdk/src/config/types.ts
@@ -67,6 +67,14 @@ export interface NormalizedConfig {
   // Metadata
   /** Instance name (from multi-config supporting sources) */
   instanceName?: string;
+
+  // TLS/mTLS
+  /** Path to PKCS12 certificate file for client mTLS (two-factor auth) */
+  certificate?: string;
+  /** Passphrase for the certificate */
+  certificatePassphrase?: string;
+  /** Whether to skip SSL/TLS certificate verification (self-signed certs) */
+  selfSigned?: boolean;
 }
 
 /**

--- a/packages/b2c-tooling-sdk/src/instance/index.ts
+++ b/packages/b2c-tooling-sdk/src/instance/index.ts
@@ -47,6 +47,7 @@ import {BasicAuthStrategy} from '../auth/basic.js';
 import {resolveAuthStrategy} from '../auth/resolve.js';
 import {WebDavClient} from '../clients/webdav.js';
 import {createOcapiClient, type OcapiClient} from '../clients/ocapi.js';
+import {createTlsDispatcher, type TlsOptions} from '../clients/tls-dispatcher.js';
 
 /**
  * Instance configuration (hostname, code version, etc.)
@@ -58,6 +59,8 @@ export interface InstanceConfig {
   codeVersion?: string;
   /** Separate hostname for WebDAV (if different from main hostname) */
   webdavHostname?: string;
+  /** TLS options for mTLS/self-signed certificate support */
+  tlsOptions?: TlsOptions;
 }
 
 /**
@@ -118,7 +121,11 @@ export class B2CInstance {
    */
   get webdav(): WebDavClient {
     if (!this._webdav) {
-      this._webdav = new WebDavClient(this.webdavHostname, this.getWebDavAuthStrategy());
+      // Create TLS dispatcher if TLS options are configured
+      const dispatcher = this.config.tlsOptions ? createTlsDispatcher(this.config.tlsOptions) : undefined;
+      this._webdav = new WebDavClient(this.webdavHostname, this.getWebDavAuthStrategy(), {
+        dispatcher,
+      });
     }
     return this._webdav;
   }
@@ -194,3 +201,4 @@ export class B2CInstance {
 
 // Re-export types for convenience
 export type {AuthConfig};
+export type {TlsOptions};

--- a/packages/b2c-tooling-sdk/test/clients/tls-dispatcher.test.ts
+++ b/packages/b2c-tooling-sdk/test/clients/tls-dispatcher.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {expect} from 'chai';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {Agent} from 'undici';
+import {createTlsDispatcher} from '../../src/clients/tls-dispatcher.js';
+
+describe('tls-dispatcher', () => {
+  describe('createTlsDispatcher', () => {
+    it('returns undefined when no TLS options are needed', () => {
+      const result = createTlsDispatcher({});
+      expect(result).to.be.undefined;
+    });
+
+    it('returns undefined when only rejectUnauthorized is true (default behavior)', () => {
+      const result = createTlsDispatcher({rejectUnauthorized: true});
+      expect(result).to.be.undefined;
+    });
+
+    it('returns an Agent when rejectUnauthorized is false (self-signed mode)', () => {
+      const result = createTlsDispatcher({rejectUnauthorized: false});
+      expect(result).to.be.instanceOf(Agent);
+    });
+
+    describe('error handling', () => {
+      it('throws an error when certificate file does not exist', () => {
+        expect(() => {
+          createTlsDispatcher({certificate: '/nonexistent/path/to/cert.p12'});
+        }).to.throw(/Failed to read certificate file/);
+      });
+
+      describe('with invalid certificate files', () => {
+        let tempDir: string;
+
+        beforeEach(() => {
+          tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tls-test-'));
+        });
+
+        afterEach(() => {
+          // Clean up temp directory
+          if (fs.existsSync(tempDir)) {
+            for (const file of fs.readdirSync(tempDir)) {
+              fs.unlinkSync(path.join(tempDir, file));
+            }
+            fs.rmdirSync(tempDir);
+          }
+        });
+
+        it('throws user-friendly error for invalid PKCS12 file', () => {
+          const certPath = path.join(tempDir, 'invalid.p12');
+          fs.writeFileSync(certPath, Buffer.from('not a real certificate'));
+
+          expect(() => {
+            createTlsDispatcher({certificate: certPath});
+          }).to.throw(/does not appear to be a valid PKCS12/);
+        });
+
+        it('throws user-friendly error when passphrase is required but not provided', () => {
+          // Create a minimal encrypted PKCS12-like structure that will trigger mac verify failure
+          // This is a real-ish PKCS12 header that will be recognized but fail MAC verification
+          const pkcs12Header = Buffer.from([
+            0x30,
+            0x82,
+            0x00,
+            0x50, // SEQUENCE
+            0x02,
+            0x01,
+            0x03, // INTEGER 3 (PKCS12 version)
+            0x30,
+            0x82,
+            0x00,
+            0x30, // SEQUENCE (authSafe)
+            0x06,
+            0x09, // OID
+            0x2a,
+            0x86,
+            0x48,
+            0x86,
+            0xf7,
+            0x0d,
+            0x01,
+            0x07,
+            0x01, // pkcs7-data
+            0xa0,
+            0x82,
+            0x00,
+            0x1f, // context [0]
+            0x04,
+            0x82,
+            0x00,
+            0x1b, // OCTET STRING
+            // Some dummy encrypted content
+            ...Buffer.alloc(27, 0xff),
+          ]);
+          const certPath = path.join(tempDir, 'encrypted.p12');
+          fs.writeFileSync(certPath, pkcs12Header);
+
+          expect(() => {
+            createTlsDispatcher({certificate: certPath});
+          }).to.throw(/requires a passphrase|does not appear to be a valid PKCS12/);
+        });
+      });
+    });
+  });
+});

--- a/plugins/b2c-cli/skills/b2c-config/SKILL.md
+++ b/plugins/b2c-cli/skills/b2c-config/SKILL.md
@@ -60,6 +60,7 @@ The command displays configuration organized by category:
 - **Instance**: hostname, webdavHostname, codeVersion
 - **Authentication (Basic)**: username, password (for WebDAV)
 - **Authentication (OAuth)**: clientId, clientSecret, scopes, authMethods
+- **TLS/mTLS**: certificate, certificatePassphrase, selfSigned (for two-factor auth)
 - **SCAPI**: shortCode
 - **Managed Runtime (MRT)**: mrtProject, mrtEnvironment, mrtApiKey
 - **Metadata**: instanceName (from multi-instance configs)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
       pino-pretty:
         specifier: ^13.1.2
         version: 13.1.2
+      undici:
+        specifier: ^7.0.0
+        version: 7.19.2
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
@@ -6016,6 +6019,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.19.2:
+    resolution: {integrity: sha512-4VQSpGEGsWzk0VYxyB/wVX/Q7qf9t5znLRgs0dzszr9w9Fej/8RVNQ+S20vdXSAyra/bJ7ZQfGv6ZMj7UEbzSg==}
+    engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -12918,6 +12925,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.19.2: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 


### PR DESCRIPTION
## Summary

- Add support for client certificates (mTLS) and SSL verification control for WebDAV operations
- Enable secure connections to instances that require two-factor authentication via client certificates
- Validate certificates upfront with clear error messages for missing/wrong passphrase

## New CLI Options

| Flag | Env Variable | dw.json Field | Description |
|------|-------------|---------------|-------------|
| `--certificate <path>` | `SFCC_CERTIFICATE` | `certificate` | Path to PKCS12 (.p12/.pfx) certificate file |
| `--passphrase <string>` | `SFCC_CERTIFICATE_PASSPHRASE` | `certificate-passphrase` | Passphrase for the certificate |
| `--selfsigned` | `SFCC_SELFSIGNED` | `self-signed` | Disable SSL certificate verification |
| `--no-verify` | `SFCC_VERIFY` | - | Alias for --selfsigned |

## Usage Example

```bash
# CLI flags
./cli webdav ls --webdav-server cert.staging.example.demandware.net \
  --certificate ./my-cert.p12 --passphrase "secret" --no-verify

# Or via dw.json
{
  "hostname": "cert.staging.example.demandware.net",
  "certificate": "/path/to/client-cert.p12",
  "certificate-passphrase": "cert-password",
  "self-signed": true
}
```

## Additional Changes

- Added `server` and `webdav-server` as undocumented dw.json field aliases for consistency with CLI flags
- Updated documentation with new TLS configuration options
- Added undici dependency for TLS dispatcher

## Test plan

- [x] Manual testing with 2FA-enabled sandbox