### PR TITLE
chore: update Script API documentation to version 26.2

### DIFF
--- a/.claude/commands/update-script-api-docs.md
+++ b/.claude/commands/update-script-api-docs.md
@@ -1,0 +1,40 @@
+# Update Script API Documentation
+
+Download the latest B2C Commerce Script API documentation from the configured sandbox and update the bundled docs in the SDK.
+
+## Steps
+
+1. Download Script API docs from the configured sandbox using `./cli docs download`
+2. Replace the markdown files in `packages/b2c-tooling-sdk/data/script-api/`
+3. Regenerate the search index with `pnpm --filter @salesforce/b2c-tooling-sdk run generate:docs-index`
+4. Show the version extracted from `index.md` header
+5. Show git status/diff summary of what changed
+
+## Commands to Run
+
+```bash
+# Download to temp directory
+./cli docs download /tmp/script-api-docs-update
+
+# Check version
+head -1 /tmp/script-api-docs-update/index.md
+
+# Replace existing files
+rm -f packages/b2c-tooling-sdk/data/script-api/*.md
+cp /tmp/script-api-docs-update/*.md packages/b2c-tooling-sdk/data/script-api/
+
+# Regenerate index
+pnpm --filter @salesforce/b2c-tooling-sdk run generate:docs-index
+
+# Show changes
+git status packages/b2c-tooling-sdk/data/script-api/ --short
+git diff packages/b2c-tooling-sdk/data/script-api/*.md --stat
+
+# Cleanup
+rm -rf /tmp/script-api-docs-update
+```
+
+After running, summarize:
+- The Script API version (from index.md header like "# B2C Commerce Script API 26.2")
+- Number of files updated
+- Key changes (new classes, deprecated methods, etc.)

--- a/packages/b2c-tooling-sdk/data/script-api/dw.extensions.payments.SalesforcePaymentsMgr.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.extensions.payments.SalesforcePaymentsMgr.md
@@ -59,6 +59,7 @@ This class does not have a constructor, so you cannot create it directly.
 | static [handleAdyenAdditionalDetails](dw.extensions.payments.SalesforcePaymentsMgr.md#handleadyenadditionaldetailsorder-string-object)([Order](dw.order.Order.md), [String](TopLevel.String.md), [Object](TopLevel.Object.md)) | <p>  Handles the given additional Adyen payment details and associates the associated payment with the given order, if  applicable. |
 | static [onCustomerRegistered](dw.extensions.payments.SalesforcePaymentsMgr.md#oncustomerregisteredorder)([Order](dw.order.Order.md)) | Handles the account registration of the shopper who placed the given order. |
 | static [refundAdyenPayment](dw.extensions.payments.SalesforcePaymentsMgr.md#refundadyenpaymentorderpaymentinstrument-money-object)([OrderPaymentInstrument](dw.order.OrderPaymentInstrument.md), [Money](dw.value.Money.md), [Object](TopLevel.Object.md)) | Refunds previously captured funds for the given order payment instrument. |
+| static [refundPayPalOrderCapture](dw.extensions.payments.SalesforcePaymentsMgr.md#refundpaypalordercapturesalesforcepaypalorder)([SalesforcePayPalOrder](dw.extensions.payments.SalesforcePayPalOrder.md)) | Refunds the capture for the given PayPal order. |
 | static [refundPaymentIntent](dw.extensions.payments.SalesforcePaymentsMgr.md#refundpaymentintentsalesforcepaymentintent-money-object)([SalesforcePaymentIntent](dw.extensions.payments.SalesforcePaymentIntent.md), [Money](dw.value.Money.md), [Object](TopLevel.Object.md)) | Refunds previously captured funds for the given payment intent. |
 | static [removeAdyenSavedPaymentMethod](dw.extensions.payments.SalesforcePaymentsMgr.md#removeadyensavedpaymentmethodsalesforceadyensavedpaymentmethod)([SalesforceAdyenSavedPaymentMethod](dw.extensions.payments.SalesforceAdyenSavedPaymentMethod.md)) | Deletes an Adyen saved payment method. |
 | static [removeSavedPaymentMethod](dw.extensions.payments.SalesforcePaymentsMgr.md#removesavedpaymentmethodsalesforcepaymentmethod)([SalesforcePaymentMethod](dw.extensions.payments.SalesforcePaymentMethod.md)) | Removes the given saved payment method so that it is no longer presented to the given customer for reuse in  checkouts. |
@@ -67,6 +68,7 @@ This class does not have a constructor, so you cannot create it directly.
 | static [savePaymentMethod](dw.extensions.payments.SalesforcePaymentsMgr.md#savepaymentmethodcustomer-salesforcepaymentmethod)([Customer](dw.customer.Customer.md), [SalesforcePaymentMethod](dw.extensions.payments.SalesforcePaymentMethod.md)) | Saves the given payment method to be presented to the given customer for reuse in subsequent checkouts. |
 | static [setPaymentDetails](dw.extensions.payments.SalesforcePaymentsMgr.md#setpaymentdetailsorderpaymentinstrument-salesforcepaymentdetails)([OrderPaymentInstrument](dw.order.OrderPaymentInstrument.md), [SalesforcePaymentDetails](dw.extensions.payments.SalesforcePaymentDetails.md)) | Sets the details to the Salesforce Payments payment associated with the given payment instrument. |
 | static [updatePaymentIntent](dw.extensions.payments.SalesforcePaymentsMgr.md#updatepaymentintentsalesforcepaymentintent-shipment-money-string-object)([SalesforcePaymentIntent](dw.extensions.payments.SalesforcePaymentIntent.md), [Shipment](dw.order.Shipment.md), [Money](dw.value.Money.md), [String](TopLevel.String.md), [Object](TopLevel.Object.md)) | Updates the provided information in the given payment intent. |
+| static [voidPayPalOrderAuthorization](dw.extensions.payments.SalesforcePaymentsMgr.md#voidpaypalorderauthorizationsalesforcepaypalorder)([SalesforcePayPalOrder](dw.extensions.payments.SalesforcePayPalOrder.md)) | Voids the authorization for the given PayPal order. |
 
 ### Methods inherited from class Object
 
@@ -747,6 +749,29 @@ use [getSavedPaymentMethods(Customer)](dw.extensions.payments.SalesforcePayments
 
 ---
 
+### refundPayPalOrderCapture(SalesforcePayPalOrder)
+- static refundPayPalOrderCapture(paypalOrder: [SalesforcePayPalOrder](dw.extensions.payments.SalesforcePayPalOrder.md)): [Status](dw.system.Status.md)
+  - : Refunds the capture for the given PayPal order.
+      
+      
+      The PayPal order must have a capture in a status that supports refund. See the PayPal documentation for more
+      details.
+
+
+    **Parameters:**
+    - paypalOrder - PayPal order whose capture to refund
+
+    **Returns:**
+    - Status 'OK' or 'ERROR'. Status detail `'error'` contains the PayPal error information, if it
+              is available in the response.
+
+
+    **Throws:**
+    - Exception - if there was an error refunding the capture for the PayPal order
+
+
+---
+
 ### refundPaymentIntent(SalesforcePaymentIntent, Money, Object)
 - static refundPaymentIntent(paymentIntent: [SalesforcePaymentIntent](dw.extensions.payments.SalesforcePaymentIntent.md), amount: [Money](dw.value.Money.md), refundProperties: [Object](TopLevel.Object.md)): [Status](dw.system.Status.md)
   - : Refunds previously captured funds for the given payment intent.
@@ -934,6 +959,29 @@ use [getSavedPaymentMethods(Customer)](dw.extensions.payments.SalesforcePayments
 
     **Throws:**
     - Exception - if the parameter validation failed or there's an error updating the payment intent
+
+
+---
+
+### voidPayPalOrderAuthorization(SalesforcePayPalOrder)
+- static voidPayPalOrderAuthorization(paypalOrder: [SalesforcePayPalOrder](dw.extensions.payments.SalesforcePayPalOrder.md)): [Status](dw.system.Status.md)
+  - : Voids the authorization for the given PayPal order.
+      
+      
+      The PayPal order must have an authorization in a status that supports voiding. See the PayPal documentation for
+      more details.
+
+
+    **Parameters:**
+    - paypalOrder - PayPal order whose authorization to void
+
+    **Returns:**
+    - Status 'OK' or 'ERROR'. Status detail `'error'` contains the PayPal error information, if it
+              is available in the response.
+
+
+    **Throws:**
+    - Exception - if there was an error voiding the authorization for the PayPal order
 
 
 ---

--- a/packages/b2c-tooling-sdk/data/script-api/dw.system.Request.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.system.Request.md
@@ -392,6 +392,11 @@ Effectively always returns true.
 :::warning
 Use [Response.addHttpCookie(Cookie)](dw.system.Response.md#addhttpcookiecookie) instead.
 :::
+    **API Version:**
+:::note
+No longer available as of version 99.2.
+This method is deprecated and will be removed in the next API version.
+:::
 
 ---
 

--- a/packages/b2c-tooling-sdk/data/script-api/dw.web.Cookie.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.web.Cookie.md
@@ -30,7 +30,7 @@ See [Request.getHttpCookies()](dw.system.Request.md#gethttpcookies).
 
 | Property | Description |
 | --- | --- |
-| [comment](#comment): [String](TopLevel.String.md) | Returns the comment associated with the cookie. |
+| ~~[comment](#comment): [String](TopLevel.String.md)~~ | Returns the comment that was previously set for this cookie, or null if no comment was set. |
 | [domain](#domain): [String](TopLevel.String.md) | Returns the domain associated with the cookie. |
 | [httpOnly](#httponly): [Boolean](TopLevel.Boolean.md) | Identifies if the cookie is http-only. |
 | [maxAge](#maxage): [Number](TopLevel.Number.md) | Returns the maximum age of the cookie, specified in seconds. |
@@ -38,7 +38,7 @@ See [Request.getHttpCookies()](dw.system.Request.md#gethttpcookies).
 | [path](#path): [String](TopLevel.String.md) | Returns the path for the cookie. |
 | [secure](#secure): [Boolean](TopLevel.Boolean.md) | Identifies if the cookie is secure. |
 | [value](#value): [String](TopLevel.String.md) | Returns the cookie's value. |
-| [version](#version): [Number](TopLevel.Number.md) | Returns the version for the cookie. |
+| ~~[version](#version): [Number](TopLevel.Number.md)~~ | Returns the version that was previously set for this cookie. |
 
 ## Constructor Summary
 
@@ -50,23 +50,23 @@ See [Request.getHttpCookies()](dw.system.Request.md#gethttpcookies).
 
 | Method | Description |
 | --- | --- |
-| [getComment](dw.web.Cookie.md#getcomment)() | Returns the comment associated with the cookie. |
+| ~~[getComment](dw.web.Cookie.md#getcomment)()~~ | Returns the comment that was previously set for this cookie, or null if no comment was set. |
 | [getDomain](dw.web.Cookie.md#getdomain)() | Returns the domain associated with the cookie. |
 | [getMaxAge](dw.web.Cookie.md#getmaxage)() | Returns the maximum age of the cookie, specified in seconds. |
 | [getName](dw.web.Cookie.md#getname)() | Returns the cookie's name. |
 | [getPath](dw.web.Cookie.md#getpath)() | Returns the path for the cookie. |
 | [getSecure](dw.web.Cookie.md#getsecure)() | Identifies if the cookie is secure. |
 | [getValue](dw.web.Cookie.md#getvalue)() | Returns the cookie's value. |
-| [getVersion](dw.web.Cookie.md#getversion)() | Returns the version for the cookie. |
+| ~~[getVersion](dw.web.Cookie.md#getversion)()~~ | Returns the version that was previously set for this cookie. |
 | [isHttpOnly](dw.web.Cookie.md#ishttponly)() | Identifies if the cookie is http-only. |
-| [setComment](dw.web.Cookie.md#setcommentstring)([String](TopLevel.String.md)) | Sets the comment associated with the cookie. |
+| ~~[setComment](dw.web.Cookie.md#setcommentstring)([String](TopLevel.String.md))~~ | Sets a comment associated with this cookie. |
 | [setDomain](dw.web.Cookie.md#setdomainstring)([String](TopLevel.String.md)) | Sets the domain associated with the cookie. |
 | [setHttpOnly](dw.web.Cookie.md#sethttponlyboolean)([Boolean](TopLevel.Boolean.md)) | Sets the http-only state for the cookie. |
 | [setMaxAge](dw.web.Cookie.md#setmaxagenumber)([Number](TopLevel.Number.md)) | Sets the maximum age of the cookie in seconds. |
 | [setPath](dw.web.Cookie.md#setpathstring)([String](TopLevel.String.md)) | Sets the path for the cookie. |
 | [setSecure](dw.web.Cookie.md#setsecureboolean)([Boolean](TopLevel.Boolean.md)) | Sets the secure state for the cookie. |
 | [setValue](dw.web.Cookie.md#setvaluestring)([String](TopLevel.String.md)) | Sets the cookie's value. |
-| [setVersion](dw.web.Cookie.md#setversionnumber)([Number](TopLevel.Number.md)) | Sets the version for the cookie. |
+| ~~[setVersion](dw.web.Cookie.md#setversionnumber)([Number](TopLevel.Number.md))~~ | Returns the version that was previously set for this cookie. |
 
 ### Methods inherited from class Object
 
@@ -84,9 +84,24 @@ See [Request.getHttpCookies()](dw.system.Request.md#gethttpcookies).
 ## Property Details
 
 ### comment
-- comment: [String](TopLevel.String.md)
-  - : Returns the comment associated with the cookie.
+- ~~comment: [String](TopLevel.String.md)~~
+  - : Returns the comment that was previously set for this cookie, or null if no comment was set. Note that comments
+      are no longer supported in RFC 6265 and will not be sent to clients. This method is maintained for backward
+      compatibility only.
 
+
+    **Deprecated:**
+:::warning
+This method is maintained for backward compatibility only. Cookie comments were removed in RFC 6265
+            and are no longer sent to clients. The returned value only reflects what was previously set using
+            [setComment(String)](dw.web.Cookie.md#setcommentstring).
+
+:::
+    **API Version:**
+:::note
+No longer available as of version 99.2.
+This method is deprecated and will be removed in the next API version.
+:::
 
 ---
 
@@ -142,11 +157,24 @@ See [Request.getHttpCookies()](dw.system.Request.md#gethttpcookies).
 ---
 
 ### version
-- version: [Number](TopLevel.Number.md)
-  - : Returns the version for the cookie. 0 means original Netscape cookie and
-      1 means RFC 2109 compliant cookie.
+- ~~version: [Number](TopLevel.Number.md)~~
+  - : Returns the version that was previously set for this cookie. Note that the version is no longer used for
+      determining cookie compliance as the system now uses RFC 6265 by default. The returned value only reflects what
+      was previously set using [setVersion(Number)](dw.web.Cookie.md#setversionnumber).
 
 
+    **Deprecated:**
+:::warning
+This method is maintained for backward compatibility only. The version property is no longer used as
+            the system now uses RFC 6265 compliance by default. The returned value has no effect on cookie
+            behavior.
+
+:::
+    **API Version:**
+:::note
+No longer available as of version 99.2.
+This method is deprecated and will be removed in the next API version.
+:::
 
 ---
 
@@ -166,12 +194,27 @@ See [Request.getHttpCookies()](dw.system.Request.md#gethttpcookies).
 ## Method Details
 
 ### getComment()
-- getComment(): [String](TopLevel.String.md)
-  - : Returns the comment associated with the cookie.
+- ~~getComment(): [String](TopLevel.String.md)~~
+  - : Returns the comment that was previously set for this cookie, or null if no comment was set. Note that comments
+      are no longer supported in RFC 6265 and will not be sent to clients. This method is maintained for backward
+      compatibility only.
+
 
     **Returns:**
-    - the comment associated with the cookie.
+    - the comment that was previously set, or null if no comment was set
 
+    **Deprecated:**
+:::warning
+This method is maintained for backward compatibility only. Cookie comments were removed in RFC 6265
+            and are no longer sent to clients. The returned value only reflects what was previously set using
+            [setComment(String)](dw.web.Cookie.md#setcommentstring).
+
+:::
+    **API Version:**
+:::note
+No longer available as of version 99.2.
+This method is deprecated and will be removed in the next API version.
+:::
 
 ---
 
@@ -240,14 +283,27 @@ See [Request.getHttpCookies()](dw.system.Request.md#gethttpcookies).
 ---
 
 ### getVersion()
-- getVersion(): [Number](TopLevel.Number.md)
-  - : Returns the version for the cookie. 0 means original Netscape cookie and
-      1 means RFC 2109 compliant cookie.
+- ~~getVersion(): [Number](TopLevel.Number.md)~~
+  - : Returns the version that was previously set for this cookie. Note that the version is no longer used for
+      determining cookie compliance as the system now uses RFC 6265 by default. The returned value only reflects what
+      was previously set using [setVersion(Number)](dw.web.Cookie.md#setversionnumber).
 
 
     **Returns:**
-    - the version for the cookie.
+    - the version number that was set, or 0 if no version was explicitly set
 
+    **Deprecated:**
+:::warning
+This method is maintained for backward compatibility only. The version property is no longer used as
+            the system now uses RFC 6265 compliance by default. The returned value has no effect on cookie
+            behavior.
+
+:::
+    **API Version:**
+:::note
+No longer available as of version 99.2.
+This method is deprecated and will be removed in the next API version.
+:::
 
 ---
 
@@ -262,17 +318,25 @@ See [Request.getHttpCookies()](dw.system.Request.md#gethttpcookies).
 ---
 
 ### setComment(String)
-- setComment(comment: [String](TopLevel.String.md)): void
-  - : Sets the comment associated with the cookie.
-      
-      Setting a comment automatically changes the cookie to be a RFC 2109
-      (set-cookie2) compliant cookie, because comments are only supported with
-      RFC cookies and not with Netscapes original cookie.
+- ~~setComment(comment: [String](TopLevel.String.md)): void~~
+  - : Sets a comment associated with this cookie. Note that comments are no longer sent to clients as they were removed
+      in RFC 6265. This method is maintained for backward compatibility but has no effect on the cookie's behavior.
 
 
     **Parameters:**
-    - comment - the comment associated with the cookie.
+    - comment - the comment to associate with the cookie (ignored)
 
+    **Deprecated:**
+:::warning
+This method is maintained for backward compatibility only. Cookie comments were removed in RFC 6265
+            and will not be sent to clients. The value will be stored but has no effect on cookie behavior.
+
+:::
+    **API Version:**
+:::note
+No longer available as of version 99.2.
+This method is deprecated and will be removed in the next API version.
+:::
 
 ---
 
@@ -346,14 +410,27 @@ See [Request.getHttpCookies()](dw.system.Request.md#gethttpcookies).
 ---
 
 ### setVersion(Number)
-- setVersion(version: [Number](TopLevel.Number.md)): void
-  - : Sets the version for the cookie. 0 means original Netscape cookie and
-      1 means RFC 2109 compliant cookie. The default is 0.
+- ~~setVersion(version: [Number](TopLevel.Number.md)): void~~
+  - : Returns the version that was previously set for this cookie. Note that the version is no longer used for
+      determining cookie compliance as the system now uses RFC 6265 by default. The returned value only reflects what
+      was previously set using [setVersion(Number)](dw.web.Cookie.md#setversionnumber).
 
 
-    **Parameters:**
-    - version - the version for the cookie.
+    **Returns:**
+    - the version number that was set, or 0 if no version was explicitly set
 
+    **Deprecated:**
+:::warning
+This method is maintained for backward compatibility only. The version property is no longer used as
+            the system now uses RFC 6265 compliance by default. The returned value has no effect on cookie
+            behavior.
+
+:::
+    **API Version:**
+:::note
+No longer available as of version 99.2.
+This method is deprecated and will be removed in the next API version.
+:::
 
 ---
 

--- a/packages/b2c-tooling-sdk/data/script-api/index.json
+++ b/packages/b2c-tooling-sdk/data/script-api/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-01-10T22:14:13.490Z",
+  "generatedAt": "2026-01-31T17:45:14.666Z",
   "entries": [
     {
       "id": "dw.alert",
@@ -2755,7 +2755,7 @@
     },
     {
       "id": "index",
-      "title": "B2C Commerce Script API 26.1",
+      "title": "B2C Commerce Script API 26.2",
       "filePath": "index.md"
     },
     {

--- a/packages/b2c-tooling-sdk/data/script-api/index.md
+++ b/packages/b2c-tooling-sdk/data/script-api/index.md
@@ -1,4 +1,4 @@
-# B2C Commerce Script API 26.1
+# B2C Commerce Script API 26.2
 
 ## Packages
 | Package | Description |


### PR DESCRIPTION
## Summary

Update bundled Script API documentation from version 26.1 to 26.2.

## Changes

**New APIs:**
- `SalesforcePaymentsMgr.refundPayPalOrderCapture()` - Refunds capture for PayPal orders
- `SalesforcePaymentsMgr.voidPayPalOrderAuthorization()` - Voids authorization for PayPal orders

**Deprecations (RFC 6265 compliance):**
- `Cookie.comment`, `getComment()`, `setComment()` - Cookie comments removed in RFC 6265
- `Cookie.version`, `getVersion()`, `setVersion()` - Version no longer used
- `Request.addHttpCookie()` - Removed in API version 99.2

**Developer tooling:**
- Added `/update-script-api-docs` Claude command for future updates

## Test plan

- [x] `b2c docs search ProductMgr` returns results
- [x] `b2c docs read SalesforcePaymentsMgr` shows new PayPal methods