### PR TITLE
fix: slas client list returns empty list when tenant doesn't exist

### DIFF
--- a/.changeset/slas-list-empty-on-no-tenant.md
+++ b/.changeset/slas-list-empty-on-no-tenant.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-cli': patch
+---
+
+`slas client list` now returns an empty list instead of erroring when the SLAS tenant doesn't exist yet.

--- a/packages/b2c-cli/src/commands/slas/client/list.ts
+++ b/packages/b2c-cli/src/commands/slas/client/list.ts
@@ -69,11 +69,16 @@ export default class SlasClientList extends SlasClientCommand<typeof SlasClientL
     });
 
     if (error) {
-      this.error(
-        t('commands.slas.client.list.error', 'Failed to list SLAS clients: {{message}}', {
-          message: formatApiError(error, response),
-        }),
-      );
+      const tenantExists = await this.checkTenantExists(slasClient, tenantId);
+      if (tenantExists) {
+        this.error(
+          t('commands.slas.client.list.error', 'Failed to list SLAS clients: {{message}}', {
+            message: formatApiError(error, response),
+          }),
+        );
+      }
+      // Tenant doesn't exist — no clients to list, fall through to empty handling
+      this.logger.debug({tenantId}, 'Tenant does not exist yet, returning empty client list');
     }
 
     const clients = ((data as {data?: Client[]})?.data ?? []).map((client) => normalizeClientResponse(client));


### PR DESCRIPTION
## Summary
- `slas client list` now returns an empty list instead of a confusing API error when the SLAS tenant doesn't exist yet
- Extracted `checkTenantExists()` from `ensureTenantExists()` to reuse tenant-not-found detection logic
- Added debug logging for tenant existence checks

Closes #126

## Test plan
- [x] New tests: list error + tenant not found (404) → empty list
- [x] New tests: list error + tenant not found (400 + TenantNotFoundException) → empty list
- [x] Existing test updated: list error + tenant exists → error propagated
- [x] All 456 tests pass
- [x] Typecheck clean