### PR TITLE
@W-21274558 add and fix e2e tests for sandbox and mrt

### DIFF
--- a/packages/b2c-cli/test/functional/e2e/mrt-lifecycle.test.ts
+++ b/packages/b2c-cli/test/functional/e2e/mrt-lifecycle.test.ts
@@ -479,6 +479,21 @@ describe('MRT Lifecycle E2E Tests', function () {
         {timeout: TIMEOUTS.DEFAULT, env: MRT_TEST_ENV},
       );
 
+      // In some environments, the delete operation can be retried by Mocha.
+      // If a previous attempt already deleted the variable, the backend will
+      // return an error indicating that the variable does not exist. Treat
+      // this specific case as acceptable instead of failing the test.
+      if (result.exitCode !== 0) {
+        const errorText = String(result.stderr || result.stdout || '');
+        if (errorText.includes('does not exist')) {
+          console.log(
+            `  ⚠ Environment variable ${testVarKey} was already deleted (does not exist), treating as success`,
+          );
+          varCreated = false;
+          return;
+        }
+      }
+
       expect(result.exitCode, `Env var delete command failed: ${result.stderr}`).to.equal(0);
 
       const response = parseJSONOutput(result);


### PR DESCRIPTION
## Summary

Brief description of what this PR does.

Added end to end tests for newly added realm, reset, usage, alias commands for sandbox and fixing the flaky mrt test

## Testing

How was this tested?

## Dependencies

- [x] No net-new third-party dependencies were added
- [x] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
