### PR TITLE
Add VS Code extension CI tests and VSIX release publishing

### DIFF
--- a/.github/workflows/ci-vs-extension.yml
+++ b/.github/workflows/ci-vs-extension.yml
@@ -1,0 +1,64 @@
+name: VS Extension Tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/b2c-vs-extension/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'packages/b2c-vs-extension/**'
+
+permissions:
+  contents: read
+
+env:
+  SFCC_DISABLE_TELEMETRY: ${{ vars.SFCC_DISABLE_TELEMETRY }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm -r run build
+
+      - name: Run VS Extension tests
+        working-directory: packages/b2c-vs-extension
+        run: xvfb-run -a pnpm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,11 @@ jobs:
         working-directory: packages/b2c-cli
         run: pnpm run pretest && pnpm run test:ci && pnpm run lint
 
-      - name: Run VS Extension lint
+      - name: Run VS Extension checks
         id: vs-extension-test
-        if: always() && steps.vs-extension-test.conclusion != 'cancelled'
+        if: always() && steps.cli-test.conclusion != 'cancelled'
         working-directory: packages/b2c-vs-extension
-        # Testing not currently supported on CI
-        run: pnpm run lint
+        run: pnpm run typecheck:agent && pnpm run lint
 
       - name: Test Report
         uses: dorny/test-reporter@fe45e9537387dac839af0d33ba56eed8e24189e8  # v2.3.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,17 @@ jobs:
           check_package "@salesforce/b2c-cli" "packages/b2c-cli" "cli"
           check_package "@salesforce/b2c-dx-mcp" "packages/b2c-dx-mcp" "mcp"
 
+          # VS Code extension — compare against git tags (not npm)
+          LOCAL_VSX_VERSION=$(node -p "require('./packages/b2c-vs-extension/package.json').version")
+          LAST_VSX_TAG=$(git tag -l "b2c-vs-extension@*" --sort=-v:refname | head -1 | sed 's/b2c-vs-extension@//')
+          echo "b2c-vs-extension: local=${LOCAL_VSX_VERSION} tag=${LAST_VSX_TAG:-none}"
+          if [ "$LOCAL_VSX_VERSION" != "$LAST_VSX_TAG" ]; then
+            echo "publish_vsx=true" >> $GITHUB_OUTPUT
+            echo "version_vsx=${LOCAL_VSX_VERSION}" >> $GITHUB_OUTPUT
+          else
+            echo "publish_vsx=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create snapshot versions
         if: steps.release-type.outputs.type == 'nightly'
         run: |
@@ -114,6 +125,11 @@ jobs:
         if: steps.release-type.outputs.type == 'nightly' || steps.packages.outputs.publish_mcp == 'true'
         run: pnpm --filter @salesforce/b2c-dx-mcp publish --provenance --no-git-checks --tag ${{ steps.release-type.outputs.tag }}
 
+      - name: Package VS Code extension
+        if: steps.release-type.outputs.type == 'stable' && steps.packages.outputs.publish_vsx == 'true'
+        working-directory: packages/b2c-vs-extension
+        run: pnpm run package
+
       - name: Create git tags
         if: steps.release-type.outputs.type == 'stable'
         run: |
@@ -136,6 +152,12 @@ jobs:
 
           if [[ "${{ steps.packages.outputs.publish_mcp }}" == "true" ]]; then
             TAG="@salesforce/b2c-dx-mcp@${{ steps.packages.outputs.version_mcp }}"
+            git tag "$TAG"
+            TAGS_CREATED="$TAGS_CREATED $TAG"
+          fi
+
+          if [[ "${{ steps.packages.outputs.publish_vsx }}" == "true" ]]; then
+            TAG="b2c-vs-extension@${{ steps.packages.outputs.version_vsx }}"
             git tag "$TAG"
             TAGS_CREATED="$TAGS_CREATED $TAG"
           fi
@@ -180,6 +202,13 @@ jobs:
               extract_latest packages/b2c-tooling-sdk/CHANGELOG.md
               echo ""
             fi
+
+            if [[ "${{ steps.packages.outputs.publish_vsx }}" == "true" ]]; then
+              echo "## b2c-vs-extension@${{ steps.packages.outputs.version_vsx }}"
+              echo ""
+              extract_latest packages/b2c-vs-extension/CHANGELOG.md
+              echo ""
+            fi
           } > /tmp/release-notes.md
 
       - name: Create GitHub Release
@@ -192,6 +221,8 @@ jobs:
             RELEASE_TAG="@salesforce/b2c-tooling-sdk@${{ steps.packages.outputs.version_sdk }}"
           elif [[ "${{ steps.packages.outputs.publish_mcp }}" == "true" ]]; then
             RELEASE_TAG="@salesforce/b2c-dx-mcp@${{ steps.packages.outputs.version_mcp }}"
+          elif [[ "${{ steps.packages.outputs.publish_vsx }}" == "true" ]]; then
+            RELEASE_TAG="b2c-vs-extension@${{ steps.packages.outputs.version_vsx }}"
           else
             echo "No packages published, skipping release"
             exit 0
@@ -223,11 +254,34 @@ jobs:
             RELEASE_TAG="@salesforce/b2c-tooling-sdk@${{ steps.packages.outputs.version_sdk }}"
           elif [[ "${{ steps.packages.outputs.publish_mcp }}" == "true" ]]; then
             RELEASE_TAG="@salesforce/b2c-dx-mcp@${{ steps.packages.outputs.version_mcp }}"
+          elif [[ "${{ steps.packages.outputs.publish_vsx }}" == "true" ]]; then
+            RELEASE_TAG="b2c-vs-extension@${{ steps.packages.outputs.version_vsx }}"
           else
             echo "No release to upload to"
             exit 0
           fi
 
           gh release upload "$RELEASE_TAG" b2c-skills.zip b2c-cli-skills.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload VS Code extension to release
+        if: steps.release-type.outputs.type == 'stable' && steps.packages.outputs.publish_vsx == 'true'
+        run: |
+          # Determine the release tag (same logic as Create GitHub Release)
+          if [[ "${{ steps.packages.outputs.publish_cli }}" == "true" ]]; then
+            RELEASE_TAG="@salesforce/b2c-cli@${{ steps.packages.outputs.version_cli }}"
+          elif [[ "${{ steps.packages.outputs.publish_sdk }}" == "true" ]]; then
+            RELEASE_TAG="@salesforce/b2c-tooling-sdk@${{ steps.packages.outputs.version_sdk }}"
+          elif [[ "${{ steps.packages.outputs.publish_mcp }}" == "true" ]]; then
+            RELEASE_TAG="@salesforce/b2c-dx-mcp@${{ steps.packages.outputs.version_mcp }}"
+          elif [[ "${{ steps.packages.outputs.publish_vsx }}" == "true" ]]; then
+            RELEASE_TAG="b2c-vs-extension@${{ steps.packages.outputs.version_vsx }}"
+          else
+            echo "No release to upload to"
+            exit 0
+          fi
+
+          gh release upload "$RELEASE_TAG" packages/b2c-vs-extension/*.vsix
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/b2c-vs-extension/package.json
+++ b/packages/b2c-vs-extension/package.json
@@ -72,6 +72,7 @@
     "typecheck:agent": "tsc -p . --noEmit --pretty false",
     "format": "prettier --write src",
     "format:check": "prettier --check src",
+    "pretest": "tsc -p tsconfig.test.json",
     "test": "vscode-test",
     "posttest": "pnpm run lint",
     "analyze": "ANALYZE_BUNDLE=1 node scripts/esbuild-bundle.mjs"

--- a/packages/b2c-vs-extension/tsconfig.test.json
+++ b/packages/b2c-vs-extension/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"module": "Node16",
+		"target": "ES2022",
+		"outDir": "out/test",
+		"lib": ["ES2022"],
+		"sourceMap": true,
+		"rootDir": "src/test",
+		"strict": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"include": ["src/test"]
+}


### PR DESCRIPTION
## Summary

Fixed VScode testing in CI and adds publish workflow

- **Separate CI workflow** (`ci-vs-extension.yml`) for extension tests using `xvfb-run`, path-filtered to `packages/b2c-vs-extension/**`
- **Test compilation**: New `tsconfig.test.json` and `pretest` script to compile test files to `out/test/` (main tsconfig excludes `src/test`)
- **Main CI fix**: Fixed self-referencing step condition bug (`steps.vs-extension-test` → `steps.cli-test`); replaced lint-only step with typecheck + lint
- **Publish workflow**: VSIX version detection via git tags, packaging, tagging (`b2c-vs-extension@<version>`), changelog in release notes, and `.vsix` upload to GitHub releases

## Test plan

- [x] CI workflow runs typecheck + lint for the extension on all PRs
- [x] `ci-vs-extension.yml` triggers only on extension path changes and runs `xvfb-run -a pnpm run test`
- [x] `pnpm --filter b2c-vs-extension run pretest` produces `out/test/extension.test.js`
