### PR TITLE
MCP docs fix sidebar link for scapi_custom_api_scaffold

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -99,6 +99,7 @@ const guideSidebar = [
       {text: 'mrt_bundle_push', link: '/mcp/tools/mrt-bundle-push'},
       {text: 'pwakit_development_guidelines', link: '/mcp/tools/pwakit-development-guidelines'},
       {text: 'scapi_schemas_list', link: '/mcp/tools/scapi-schemas-list'},
+      {text: 'scapi_custom_api_scaffold', link: '/mcp/tools/scapi-custom-api-scaffold'},
       {text: 'scapi_custom_apis_status', link: '/mcp/tools/scapi-custom-apis-status'},
       {text: 'storefront_next_development_guidelines', link: '/mcp/tools/storefront-next-development-guidelines'},
       {text: 'storefront_next_page_designer_decorator', link: '/mcp/tools/storefront-next-page-designer-decorator'},


### PR DESCRIPTION
## Summary

MCP docs fix sidebar link for scapi_custom_api_scaffold.

## Testing

manually with `pnpm docs:dev`

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
