### PR TITLE
@W-21105798 Update Custom API scaffold tool to account for empty project

### DIFF
--- a/packages/b2c-dx-mcp/src/tools/scapi/scapi-custom-api-scaffold.ts
+++ b/packages/b2c-dx-mcp/src/tools/scapi/scapi-custom-api-scaffold.ts
@@ -98,19 +98,20 @@ export async function executeScaffoldCustomApi(
     };
   }
 
+  const cartridges = findCartridges(projectRoot);
+  if (cartridges.length === 0) {
+    return {
+      scaffold: CUSTOM_API_SCAFFOLD_ID,
+      outputDir: projectRoot,
+      dryRun: false,
+      files: [],
+      error:
+        'No cartridges found in project. Custom API scaffold requires an existing cartridge. Create a cartridge first: use `b2c scaffold cartridge --name app_custom`, or manually create a directory with a `.project` file (e.g., cartridges/app_custom/.project).',
+    };
+  }
+
   let cartridgeName = args.cartridgeName;
   if (!cartridgeName) {
-    const cartridges = findCartridges(projectRoot);
-    if (cartridges.length === 0) {
-      return {
-        scaffold: CUSTOM_API_SCAFFOLD_ID,
-        outputDir: projectRoot,
-        dryRun: false,
-        files: [],
-        error:
-          'No cartridges found in project. Custom API scaffold requires an existing cartridge. Create a cartridge (directory with .project file) first. You can use the `b2c scaffold cartridge` command to create a cartridge.',
-      };
-    }
     cartridgeName = cartridges[0].name;
   }
 

--- a/packages/b2c-dx-mcp/test/tools/scapi/scapi-custom-api-scaffold.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/scapi/scapi-custom-api-scaffold.test.ts
@@ -104,6 +104,19 @@ describe('tools/scapi/scapi-custom-api-scaffold', () => {
       expect(text).to.include('.project');
     });
 
+    it('should fail fast with "No cartridges found" when cartridgeName provided but project has no cartridges', async () => {
+      const tool = createScaffoldCustomApiTool(loadServices);
+      const result = await tool.handler({
+        apiName: 'my-api',
+        cartridgeName: 'app_custom',
+      });
+
+      expect(result.isError).to.be.true;
+      const text = getResultText(result);
+      expect(text).to.include('No cartridges found');
+      expect(text).not.to.include('Parameter validation failed');
+    });
+
     it('should validate apiName is required', async () => {
       const tool = createScaffoldCustomApiTool(loadServices);
       const result = await tool.handler({});


### PR DESCRIPTION
## Summary

Update Custom API scaffold tool to account for empty project

## Testing
- open Cursor in empty project with --working-directory ${workspaceFolder}
- prompt Cursor with "Use the MCP tool to create a custom admin API named inventory-sync in cartridge app_custom."
- It should response with "No cartridges found in project. ..." error and continue to create cartridges and Custom API


## Dependencies

- [ ] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [ ] Tests pass (`pnpm test`)
- [ ] Code is formatted (`pnpm run format`)
