### PR TITLE
Fix flaky test on site theming mcp tool

### DIFF
--- a/packages/b2c-dx-mcp/test/tools/storefrontnext/site-theming/theming-store.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/storefrontnext/site-theming/theming-store.test.ts
@@ -20,7 +20,7 @@ describe('tools/storefrontnext/site-theming/theming-store', () => {
   let originalThemingFiles: string | undefined;
 
   beforeEach(() => {
-    testDir = path.join(tmpdir(), `b2c-theming-store-test-${Date.now()}`);
+    testDir = path.join(tmpdir(), `b2c-theming-store-test-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`);
     mkdirSync(testDir, {recursive: true});
     originalThemingFiles = process.env.THEMING_FILES;
   });
@@ -577,7 +577,7 @@ Follow user specs exactly.
 
     it('should clear and re-load when root changes', () => {
       delete process.env.THEMING_FILES;
-      const otherDir = path.join(tmpdir(), `b2c-theming-other-${Date.now()}`);
+      const otherDir = path.join(tmpdir(), `b2c-theming-other-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`);
       mkdirSync(otherDir, {recursive: true});
       try {
         const customPath = path.join(testDir, 'first-root.md');


### PR DESCRIPTION
## Summary

Fix flaky test on site theming mcp tool

## Testing

This is a test fix.

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
