### PR TITLE
@W-21435068 Add post action reminder for cartridge deploy mcp tool

### DIFF
--- a/.changeset/cartridge-deploy-bm-reminder.md
+++ b/.changeset/cartridge-deploy-bm-reminder.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-dx-mcp': patch
+---
+
+cartridge_deploy now reminds users to update the site cartridge path in Business Manager (Sites → Manage Sites → [site] → Settings tab → Cartridges) after deploy.

--- a/packages/b2c-dx-mcp/src/tools/cartridges/index.ts
+++ b/packages/b2c-dx-mcp/src/tools/cartridges/index.ts
@@ -21,6 +21,11 @@ import type {DeployResult, DeployOptions, CodeVersion} from '@salesforce/b2c-too
 import type {B2CInstance} from '@salesforce/b2c-tooling-sdk';
 import {getLogger} from '@salesforce/b2c-tooling-sdk/logging';
 
+/** Reminder shown after deploy so users add cartridges to the site cartridge path. */
+const CARTRIDGE_PATH_REMINDER =
+  "If this is a new or updated cartridge, add it to your site's cartridge path in Business Manager: " +
+  'Sites → Manage Sites → [your site] → Settings tab → Cartridges field.';
+
 /**
  * Input type for cartridge_deploy tool.
  */
@@ -33,6 +38,12 @@ interface CartridgeDeployInput {
   exclude?: string[];
   /** Reload code version after deploy */
   reload?: boolean;
+}
+
+/** Output type: deploy result plus reminder to update site cartridge path. */
+interface CartridgeDeployOutput extends DeployResult {
+  /** Reminder to add deployed cartridges to the site cartridge path in Business Manager. */
+  postInstructions?: string;
 }
 
 /**
@@ -61,7 +72,7 @@ interface CartridgeToolInjections {
 function createCartridgeDeployTool(loadServices: () => Services, injections?: CartridgeToolInjections): McpTool {
   const findAndDeployCartridgesFn = injections?.findAndDeployCartridges || findAndDeployCartridges;
   const getActiveCodeVersionFn = injections?.getActiveCodeVersion || getActiveCodeVersion;
-  return createToolAdapter<CartridgeDeployInput, DeployResult>(
+  return createToolAdapter<CartridgeDeployInput, CartridgeDeployOutput>(
     {
       name: 'cartridge_deploy',
       description:
@@ -69,7 +80,8 @@ function createCartridgeDeployTool(loadServices: () => Services, injections?: Ca
         'Searches the directory for cartridges (by .project files), applies include/exclude filters, ' +
         'creates a zip archive, uploads via WebDAV, and optionally reloads the code version. ' +
         'Use this tool to deploy custom code cartridges for SFRA or other B2C Commerce code. ' +
-        'Requires the instance to have a code version configured.',
+        'Requires the instance to have a code version configured. ' +
+        "After deploy, add new cartridges to your site's cartridge path in Business Manager: Sites → Manage Sites → [site] → Settings tab → Cartridges.",
       toolsets: ['CARTRIDGES'],
       isGA: false,
       requiresInstance: true,
@@ -152,7 +164,10 @@ function createCartridgeDeployTool(loadServices: () => Services, injections?: Ca
           // Deploy cartridges
           const result = await findAndDeployCartridgesFn(instance, directory, options);
 
-          return result;
+          return {
+            ...result,
+            postInstructions: CARTRIDGE_PATH_REMINDER,
+          };
         } catch (error) {
           // Handle communication and authentication errors
           const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/b2c-dx-mcp/test/tools/cartridges/index.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/cartridges/index.test.ts
@@ -15,6 +15,11 @@ import type {B2CInstance} from '@salesforce/b2c-tooling-sdk';
 import type {DeployResult, DeployOptions, CodeVersion} from '@salesforce/b2c-tooling-sdk/operations/code';
 import type {WebDavClient, OcapiClient} from '@salesforce/b2c-tooling-sdk/clients';
 
+/** Tool output: DeployResult plus postInstructions reminder. */
+interface CartridgeDeployOutput extends DeployResult {
+  postInstructions?: string;
+}
+
 /**
  * Helper to extract text from a ToolResult.
  * Throws if the first content item is not a text type.
@@ -117,6 +122,9 @@ describe('tools/cartridges', () => {
       expect(desc).to.include('Finds and deploys cartridges');
       expect(desc).to.include('B2C Commerce');
       expect(desc).to.include('WebDAV');
+      expect(desc).to.include('Sites → Manage Sites');
+      expect(desc).to.include('Settings tab');
+      expect(desc).to.include('Cartridges');
     });
 
     it('should be in CARTRIDGES toolset', () => {
@@ -166,9 +174,12 @@ describe('tools/cartridges', () => {
       expect(options.include).to.be.undefined;
       expect(options.exclude).to.be.undefined;
       expect(options.reload).to.be.undefined;
-      const jsonResult = getResultJson<DeployResult>(result);
+      const jsonResult = getResultJson<CartridgeDeployOutput>(result);
       expect(jsonResult.codeVersion).to.equal('v1');
       expect(jsonResult.cartridges).to.have.lengthOf(1);
+      expect(jsonResult.postInstructions).to.be.a('string');
+      expect(jsonResult.postInstructions).to.include('Sites → Manage Sites');
+      expect(jsonResult.postInstructions).to.include('Cartridges field');
     });
 
     it('should call findAndDeployCartridges with custom directory', async () => {
@@ -196,8 +207,9 @@ describe('tools/cartridges', () => {
       expect(findAndDeployCartridgesStub.calledOnce).to.be.true;
       const [, dir] = findAndDeployCartridgesStub.firstCall.args as [B2CInstance, string, DeployOptions];
       expect(dir).to.equal(expectedResolvedPath);
-      const jsonResult = getResultJson<DeployResult>(result);
+      const jsonResult = getResultJson<CartridgeDeployOutput>(result);
       expect(jsonResult.codeVersion).to.equal('v2');
+      expect(jsonResult.postInstructions).to.include("site's cartridge path");
     });
 
     it('should pass cartridges array as include option', async () => {
@@ -313,7 +325,7 @@ describe('tools/cartridges', () => {
       expect(options.reload).to.equal(reload);
     });
 
-    it('should return DeployResult as JSON', async () => {
+    it('should return DeployResult with postInstructions as JSON', async () => {
       const mockResult: DeployResult = {
         cartridges: [
           {name: 'app_storefront_base', src: '/path/to/app', dest: 'app_storefront_base'},
@@ -334,12 +346,17 @@ describe('tools/cartridges', () => {
       const result = await tool.handler({});
 
       expect(result.isError).to.be.undefined;
-      const jsonResult = getResultJson<DeployResult>(result);
+      const jsonResult = getResultJson<CartridgeDeployOutput>(result);
       expect(jsonResult.codeVersion).to.equal('v1.2.3');
       expect(jsonResult.cartridges).to.have.lengthOf(2);
       expect(jsonResult.reloaded).to.be.true;
       expect(jsonResult.cartridges[0].name).to.equal('app_storefront_base');
       expect(jsonResult.cartridges[1].name).to.equal('app_core');
+      expect(jsonResult.postInstructions).to.be.a('string');
+      expect(jsonResult.postInstructions).to.include('Business Manager');
+      expect(jsonResult.postInstructions).to.include('Sites → Manage Sites');
+      expect(jsonResult.postInstructions).to.include('Settings tab');
+      expect(jsonResult.postInstructions).to.include('Cartridges field');
     });
 
     it('should resolve relative directory paths relative to project directory', async () => {
@@ -485,8 +502,9 @@ describe('tools/cartridges', () => {
       expect(getActiveCodeVersionStub.calledWith(mockInstance)).to.be.true;
       expect(mockInstance.config.codeVersion).to.equal('v2');
       expect(findAndDeployCartridgesStub.calledOnce).to.be.true;
-      const jsonResult = getResultJson<DeployResult>(result);
+      const jsonResult = getResultJson<CartridgeDeployOutput>(result);
       expect(jsonResult.codeVersion).to.equal('v2');
+      expect(jsonResult.postInstructions).to.be.a('string');
     });
 
     it('should use existing codeVersion when already specified', async () => {


### PR DESCRIPTION
## Summary

Add important reminder in the success Cartridge Deployment response so that the deployed cartridge can be scanned and enabled.

It should remind user to update cartridge path in Business Manager: Sites → Manage Sites → [your site] → Settings tab → Cartridges field.

## Testing
* Create a Custom API cartridge
* Use MCP tool to deploy the cartridge
* Expect the execution response contains the reminder message 

<img width="656" height="523" alt="Screenshot 2026-03-03 at 4 43 58 PM" src="https://github.com/user-attachments/assets/1ba7b4f2-25c0-4b9c-90a0-9e5f1bafc97c" />

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
