### PR TITLE
fix: hook scaffold issues (#247)

### DIFF
--- a/.changeset/fix-247-scaffold-hooks.md
+++ b/.changeset/fix-247-scaffold-hooks.md
@@ -1,0 +1,16 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+'@salesforce/b2c-cli': patch
+---
+
+Fix multiple issues with the hook scaffold (#247):
+
+- Merge SCAPI and OCAPI hook types into a single "SCAPI/OCAPI Hook" type
+- Fix hook extension points list to match verified B2C Commerce documentation
+- Fix hooks.json not updating when adding hooks to existing files (json-merge bug)
+- Support appending new hook functions to existing hook script files
+- Fix display paths missing leading slash in VS Code extension context
+- Filter hook extension points by selected hook type (SCAPI/OCAPI vs System)
+- Allow typing custom hook points not in the list
+- Generate correct function signatures matching commerce-cloud-docs reference
+- Show extension point value alongside label in CLI and VS Code prompts

--- a/packages/b2c-cli/src/lib/scaffold/generate-helper.ts
+++ b/packages/b2c-cli/src/lib/scaffold/generate-helper.ts
@@ -187,14 +187,18 @@ export async function executeScaffoldGenerate(
 
   // Display results
   const created = result.files.filter((f) => f.action === 'created' || f.action === 'overwritten');
-  const skipped = result.files.filter((f) => f.action === 'skipped');
+  const merged = result.files.filter((f) => f.action === 'merged');
+  // Don't show "skipped" for files that were subsequently merged by a modification
+  const mergedPaths = new Set(merged.map((f) => f.path));
+  const skipped = result.files.filter((f) => f.action === 'skipped' && !mergedPaths.has(f.path));
 
-  if (created.length > 0) {
+  const generated = [...created, ...merged];
+  if (generated.length > 0) {
     ctx.log('');
-    ctx.log(`Successfully generated ${created.length} file(s):`);
-    for (const file of created) {
-      // file.path is already relative to cwd from the executor
-      ctx.log(`  ${file.action === 'overwritten' ? '(overwritten)' : '+'} ${file.path}`);
+    ctx.log(`Successfully generated ${generated.length} file(s):`);
+    for (const file of generated) {
+      const prefix = file.action === 'overwritten' ? '(overwritten)' : file.action === 'merged' ? '(updated)' : '+';
+      ctx.log(`  ${prefix} ${file.path}`);
     }
   }
 
@@ -249,7 +253,7 @@ async function promptForParameter(
 
       return select({
         message: param.prompt,
-        choices: choices.map((c) => ({name: c.label, value: c.value})),
+        choices: choices.map((c) => ({name: formatChoiceName(c), value: c.value})),
         default: param.default as string | undefined,
       });
     }
@@ -285,7 +289,7 @@ async function promptForParameter(
           }
           return select({
             message: param.prompt,
-            choices: choices.map((c) => ({name: c.label, value: c.value})),
+            choices: choices.map((c) => ({name: formatChoiceName(c), value: c.value})),
             default: param.default as string | undefined,
           });
         }
@@ -325,17 +329,31 @@ async function promptTextInput(param: ScaffoldParameter): Promise<string | undef
 }
 
 /**
+ * Format a choice for display: shows "label (value)" when they differ, just "label" otherwise.
+ */
+function formatChoiceName(c: ScaffoldChoice): string {
+  return c.label === c.value ? c.label : `${c.label} (${c.value})`;
+}
+
+/**
  * Create a search source function for inquirer search prompt.
  */
 function createSearchSource(choices: ScaffoldChoice[]) {
   return async (term: string | undefined) => {
     if (!term) {
-      return choices.map((c) => ({name: c.label, value: c.value}));
+      return choices.map((c) => ({name: formatChoiceName(c), value: c.value}));
     }
     const lowerTerm = term.toLowerCase();
-    return choices
+    const filtered = choices
       .filter((c) => c.label.toLowerCase().includes(lowerTerm) || c.value.toLowerCase().includes(lowerTerm))
-      .map((c) => ({name: c.label, value: c.value}));
+      .map((c) => ({name: formatChoiceName(c), value: c.value}));
+
+    // Allow entering a custom value not in the list
+    if (term.length > 0 && !choices.some((c) => c.value === term)) {
+      filtered.push({name: `Custom: ${term}`, value: term});
+    }
+
+    return filtered;
   };
 }
 

--- a/packages/b2c-tooling-sdk/data/scaffolds/hook/files/hook-function.js.ejs
+++ b/packages/b2c-tooling-sdk/data/scaffolds/hook/files/hook-function.js.ejs
@@ -1,0 +1,263 @@
+<%
+var hookPoint = locals.scapiOcapiHookPoint || locals.systemHookPoint;
+var hookFunctionName = hookPoint.split('.').pop();
+
+// SCAPI/OCAPI hook signatures from commerce-api hook-method-details reference.
+// Format: { params: 'paramList', jsdoc: [{name, type, desc}] }
+var HOOK_SIGNATURES = {
+  // Auth
+  'dw.ocapi.shop.auth.beforePOST': {
+    params: 'authorizationHeader, authRequestType',
+    jsdoc: [{name: 'authorizationHeader', type: 'String', desc: 'the authorization header'}, {name: 'authRequestType', type: 'dw.value.EnumValue', desc: 'guest, login, or refresh'}]
+  },
+  'dw.ocapi.shop.auth.afterPOST': {
+    params: 'customer, authRequestType',
+    jsdoc: [{name: 'customer', type: 'dw.customer.Customer', desc: 'the authenticated customer'}, {name: 'authRequestType', type: 'dw.value.EnumValue', desc: 'guest, login, or refresh'}]
+  },
+  'dw.ocapi.shop.auth.modifyPOSTResponse': {
+    params: 'customer, customerResponse, authRequestType',
+    jsdoc: [{name: 'customer', type: 'dw.customer.Customer', desc: 'the authenticated customer'}, {name: 'customerResponse', type: 'Object', desc: 'the API response document'}, {name: 'authRequestType', type: 'dw.value.EnumValue', desc: 'guest, login, or refresh'}]
+  },
+  // Basket
+  'dw.ocapi.shop.basket.beforePOST_v2': {
+    params: 'basketRequest',
+    jsdoc: [{name: 'basketRequest', type: 'Object', desc: 'the basket request'}]
+  },
+  'dw.ocapi.shop.basket.afterPOST': {
+    params: 'basket',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the created basket'}]
+  },
+  'dw.ocapi.shop.basket.modifyPOSTResponse': {
+    params: 'basket, basketResponse',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'basketResponse', type: 'Object', desc: 'the API response document'}]
+  },
+  'dw.ocapi.shop.basket.beforePATCH': {
+    params: 'basket, basketInput',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket to update'}, {name: 'basketInput', type: 'Object', desc: 'the basket update document'}]
+  },
+  'dw.ocapi.shop.basket.afterPATCH': {
+    params: 'basket, basketInput',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the updated basket'}, {name: 'basketInput', type: 'Object', desc: 'the basket update document'}]
+  },
+  'dw.ocapi.shop.basket.modifyPATCHResponse': {
+    params: 'basket, basketResponse',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'basketResponse', type: 'Object', desc: 'the API response document'}]
+  },
+  'dw.ocapi.shop.basket.modifyGETResponse': {
+    params: 'basket, basketResponse',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'basketResponse', type: 'Object', desc: 'the API response document'}]
+  },
+  'dw.ocapi.shop.basket.validateBasket': {
+    params: 'basketResponse, duringSubmit',
+    jsdoc: [{name: 'basketResponse', type: 'Object', desc: 'the basket response document'}, {name: 'duringSubmit', type: 'boolean', desc: 'true if called during order submit'}]
+  },
+  // Basket billing address
+  'dw.ocapi.shop.basket.billing_address.beforePUT': {
+    params: 'basket, billingAddress',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'billingAddress', type: 'Object', desc: 'the billing address document'}]
+  },
+  'dw.ocapi.shop.basket.billing_address.afterPUT': {
+    params: 'basket, billingAddress',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'billingAddress', type: 'Object', desc: 'the billing address document'}]
+  },
+  // Basket items
+  'dw.ocapi.shop.basket.items.beforePOST': {
+    params: 'basket, items',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'items', type: 'Object', desc: 'the items document'}]
+  },
+  'dw.ocapi.shop.basket.items.afterPOST': {
+    params: 'basket, items',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'items', type: 'Object', desc: 'the items document'}]
+  },
+  // Basket item
+  'dw.ocapi.shop.basket.item.beforePATCH': {
+    params: 'basket, item',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'item', type: 'Object', desc: 'the item document'}]
+  },
+  'dw.ocapi.shop.basket.item.afterPATCH': {
+    params: 'basket, item',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'item', type: 'Object', desc: 'the item document'}]
+  },
+  'dw.ocapi.shop.basket.item.beforeDELETE': {
+    params: 'basket, productItemId',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'productItemId', type: 'String', desc: 'the product item ID'}]
+  },
+  'dw.ocapi.shop.basket.item.afterDELETE': {
+    params: 'basket, productItemId',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'productItemId', type: 'String', desc: 'the product item ID'}]
+  },
+  // Basket coupon
+  'dw.ocapi.shop.basket.coupon.beforePOST': {
+    params: 'basket, couponItem',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'couponItem', type: 'Object', desc: 'the coupon item document'}]
+  },
+  'dw.ocapi.shop.basket.coupon.afterPOST': {
+    params: 'basket, couponItem',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'couponItem', type: 'Object', desc: 'the coupon item document'}]
+  },
+  // Basket payment instrument
+  'dw.ocapi.shop.basket.payment_instrument.beforePOST': {
+    params: 'basket, paymentInstrument',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'paymentInstrument', type: 'Object', desc: 'the payment instrument document'}]
+  },
+  'dw.ocapi.shop.basket.payment_instrument.afterPOST': {
+    params: 'basket, paymentInstrument',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'paymentInstrument', type: 'Object', desc: 'the payment instrument document'}]
+  },
+  // Basket shipment
+  'dw.ocapi.shop.basket.shipment.beforePATCH': {
+    params: 'basket, shipment, shipmentInfo',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'shipment', type: 'dw.order.Shipment', desc: 'the shipment'}, {name: 'shipmentInfo', type: 'Object', desc: 'the shipment update document'}]
+  },
+  'dw.ocapi.shop.basket.shipment.afterPATCH': {
+    params: 'basket, shipment, shipmentInfo',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'shipment', type: 'dw.order.Shipment', desc: 'the shipment'}, {name: 'shipmentInfo', type: 'Object', desc: 'the shipment update document'}]
+  },
+  // Basket shipment shipping address
+  'dw.ocapi.shop.basket.shipment.shipping_address.beforePUT': {
+    params: 'basket, shipment, shippingAddress',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'shipment', type: 'dw.order.Shipment', desc: 'the shipment'}, {name: 'shippingAddress', type: 'Object', desc: 'the shipping address document'}]
+  },
+  'dw.ocapi.shop.basket.shipment.shipping_address.afterPUT': {
+    params: 'basket, shipment, shippingAddress',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'shipment', type: 'dw.order.Shipment', desc: 'the shipment'}, {name: 'shippingAddress', type: 'Object', desc: 'the shipping address document'}]
+  },
+  // Basket shipment shipping method
+  'dw.ocapi.shop.basket.shipment.shipping_method.beforePUT': {
+    params: 'basket, shipment, shippingMethod',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'shipment', type: 'dw.order.Shipment', desc: 'the shipment'}, {name: 'shippingMethod', type: 'Object', desc: 'the shipping method document'}]
+  },
+  'dw.ocapi.shop.basket.shipment.shipping_method.afterPUT': {
+    params: 'basket, shipment, shippingMethod',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket'}, {name: 'shipment', type: 'dw.order.Shipment', desc: 'the shipment'}, {name: 'shippingMethod', type: 'Object', desc: 'the shipping method document'}]
+  },
+  // Order
+  'dw.ocapi.shop.order.beforePOST': {
+    params: 'basket',
+    jsdoc: [{name: 'basket', type: 'dw.order.Basket', desc: 'the basket to create the order from'}]
+  },
+  'dw.ocapi.shop.order.afterPOST': {
+    params: 'order',
+    jsdoc: [{name: 'order', type: 'dw.order.Order', desc: 'the created order'}]
+  },
+  'dw.ocapi.shop.order.modifyPOSTResponse': {
+    params: 'order, orderResponse',
+    jsdoc: [{name: 'order', type: 'dw.order.Order', desc: 'the order'}, {name: 'orderResponse', type: 'Object', desc: 'the API response document'}]
+  },
+  'dw.ocapi.shop.order.modifyGETResponse': {
+    params: 'order, orderResponse',
+    jsdoc: [{name: 'order', type: 'dw.order.Order', desc: 'the order'}, {name: 'orderResponse', type: 'Object', desc: 'the API response document'}]
+  },
+  'dw.ocapi.shop.order.validateOrder': {
+    params: 'order',
+    jsdoc: [{name: 'order', type: 'Object', desc: 'the order response document'}]
+  },
+  // Order payment instrument
+  'dw.ocapi.shop.order.payment_instrument.beforePOST': {
+    params: 'order, paymentInstrument',
+    jsdoc: [{name: 'order', type: 'dw.order.Order', desc: 'the order'}, {name: 'paymentInstrument', type: 'Object', desc: 'the payment instrument document'}]
+  },
+  'dw.ocapi.shop.order.payment_instrument.afterPOST': {
+    params: 'order, paymentInstrument, successfullyAuthorized',
+    jsdoc: [{name: 'order', type: 'dw.order.Order', desc: 'the order'}, {name: 'paymentInstrument', type: 'Object', desc: 'the payment instrument document'}, {name: 'successfullyAuthorized', type: 'boolean', desc: 'true if the payment was authorized'}]
+  },
+  // Customer
+  'dw.ocapi.shop.customer.beforePOST': {
+    params: 'registration',
+    jsdoc: [{name: 'registration', type: 'Object', desc: 'the customer registration document'}]
+  },
+  'dw.ocapi.shop.customer.afterPOST': {
+    params: 'customer, registration',
+    jsdoc: [{name: 'customer', type: 'dw.customer.Customer', desc: 'the created customer'}, {name: 'registration', type: 'Object', desc: 'the customer registration document'}]
+  },
+  'dw.ocapi.shop.customer.modifyGETResponse': {
+    params: 'customer, customerResponse',
+    jsdoc: [{name: 'customer', type: 'dw.customer.Customer', desc: 'the customer'}, {name: 'customerResponse', type: 'Object', desc: 'the API response document'}]
+  },
+  'dw.ocapi.shop.customer.modifyPOSTResponse': {
+    params: 'customer, customerResponse',
+    jsdoc: [{name: 'customer', type: 'dw.customer.Customer', desc: 'the customer'}, {name: 'customerResponse', type: 'Object', desc: 'the API response document'}]
+  },
+  // Product
+  'dw.ocapi.shop.product.modifyGETResponse': {
+    params: 'product, productResponse',
+    jsdoc: [{name: 'product', type: 'dw.catalog.Product', desc: 'the product'}, {name: 'productResponse', type: 'Object', desc: 'the API response document'}]
+  },
+  // Product search
+  'dw.ocapi.shop.product_search.modifyGETResponse': {
+    params: 'searchResponse',
+    jsdoc: [{name: 'searchResponse', type: 'Object', desc: 'the API response document'}]
+  }
+};
+
+// Look up signature or generate a generic one
+var sig = HOOK_SIGNATURES[hookPoint];
+if (!sig) {
+  // Fallback: generic signature based on method pattern
+  if (hookFunctionName.indexOf('modifyGET') === 0 || hookFunctionName.indexOf('modifyPOST') === 0 || hookFunctionName.indexOf('modifyPATCH') === 0 || hookFunctionName.indexOf('modifyPUT') === 0 || hookFunctionName.indexOf('modifyDELETE') === 0) {
+    sig = {params: 'object, response', jsdoc: [{name: 'object', type: 'Object', desc: 'the object being processed'}, {name: 'response', type: 'Object', desc: 'the API response document'}]};
+  } else if (hookFunctionName.indexOf('validate') === 0) {
+    sig = {params: 'response', jsdoc: [{name: 'response', type: 'Object', desc: 'the response document'}]};
+  } else if (hookFunctionName.indexOf('before') === 0 || hookFunctionName.indexOf('after') === 0) {
+    sig = {params: 'object', jsdoc: [{name: 'object', type: 'Object', desc: 'the object being processed'}]};
+  } else {
+    sig = {params: 'object', jsdoc: [{name: 'object', type: 'Object', desc: 'the object being processed'}]};
+  }
+}
+-%>
+
+<% if (hookType === 'scapi-ocapi') { %>
+/**
+ * SCAPI/OCAPI Hook - <%= hookPoint %>
+ *
+<% sig.jsdoc.forEach(function(p) { -%>
+ * @param {<%= p.type %>} <%= p.name %> - <%= p.desc %>
+<% }); -%>
+ */
+exports.<%= hookFunctionName %> = function (<%= sig.params %>) {
+    var log = Logger.getLogger('<%= hookName %>', '<%= cartridgeName %>');
+    log.info('<%= hookFunctionName %> hook called');
+
+    try {
+        // TODO: Implement hook logic
+
+    } catch (e) {
+        log.error('<%= hookFunctionName %> hook error: ' + e.message);
+        return new Status(
+            Status.ERROR,
+            '<%= hookFunctionName.toUpperCase() %>_ERROR',
+            e.message
+        );
+    }
+
+    // WARNING: Returning Status.OK will skip the system implementation
+    // and all subsequent hooks for this extension point.
+    // Only uncomment if you intentionally want to override system behavior.
+    // return new Status(Status.OK);
+};
+<% } else { %>
+/**
+ * System Hook Implementation - <%= hookPoint %>
+ *
+ * @param {dw.order.Basket|dw.order.Order|Object} object - The object being processed
+ * @returns {dw.system.Status} - Status object
+ */
+exports.<%= hookFunctionName %> = function (object) {
+    var log = Logger.getLogger('<%= hookName %>', '<%= cartridgeName %>');
+    log.info('<%= hookFunctionName %> system hook called');
+
+    try {
+        // TODO: Implement hook logic
+
+    } catch (e) {
+        log.error('<%= hookFunctionName %> hook error: ' + e.message);
+        return new Status(
+            Status.ERROR,
+            '<%= hookFunctionName.toUpperCase() %>_ERROR',
+            e.message
+        );
+    }
+
+    return new Status(Status.OK);
+};
+<% } %>

--- a/packages/b2c-tooling-sdk/data/scaffolds/hook/files/hook.js.ejs
+++ b/packages/b2c-tooling-sdk/data/scaffolds/hook/files/hook.js.ejs
@@ -1,99 +1,16 @@
 'use strict';
-
+<%
+var hookPoint = locals.scapiOcapiHookPoint || locals.systemHookPoint;
+var hookFunctionName = hookPoint.split('.').pop();
+-%>
 /**
  * <%= hookName %> Hook Implementation
  *
  * Hook point: <%= hookPoint %>
+ * Exported function: <%= hookFunctionName %>
  *
  * @module scripts/hooks/<%= hookName %>
  */
 
 var Logger = require('dw/system/Logger');
 var Status = require('dw/system/Status');
-
-var log = Logger.getLogger('<%= hookName %>', '<%= cartridgeName %>');
-
-<% if (hookType === 'ocapi') { %>
-/**
- * OCAPI Hook - Called before/after OCAPI operations
- *
- * @param {dw.order.Basket|dw.order.Order|Object} object - The object being processed
- * @param {Object} doc - The OCAPI document
- * @returns {dw.system.Status} - Status object
- */
-exports.<%= hookName %> = function (object, doc) {
-    log.info('<%= hookName %> hook called');
-
-    try {
-        // TODO: Implement hook logic
-        // - Modify doc to add/change response fields
-        // - Validate/modify object before processing
-
-    } catch (e) {
-        log.error('<%= hookName %> hook error: ' + e.message);
-        return new Status(
-            Status.ERROR,
-            '<%= hookName.toUpperCase() %>_ERROR',
-            e.message
-        );
-    }
-
-    return new Status(Status.OK);
-};
-<% } else if (hookType === 'scapi') { %>
-/**
- * SCAPI Hook - Called for Shopper API extensions
- *
- * @param {dw.order.Basket|dw.order.Order|Object} object - The object being processed
- * @param {Object} scriptResponse - Response object to populate
- * @returns {dw.system.Status} - Status object
- */
-exports.<%= hookName %> = function (object, scriptResponse) {
-    log.info('<%= hookName %> SCAPI hook called');
-
-    try {
-        // TODO: Implement hook logic
-        // - Add custom properties to scriptResponse
-        // - Validate/enrich the response
-
-    } catch (e) {
-        log.error('<%= hookName %> hook error: ' + e.message);
-        return new Status(
-            Status.ERROR,
-            '<%= hookName.toUpperCase() %>_ERROR',
-            e.message
-        );
-    }
-
-    return new Status(Status.OK);
-};
-<% } else { %>
-/**
- * System Hook Implementation
- *
- * @param {dw.order.Basket|dw.order.Order|dw.customer.Customer|Object} object - The object being processed
- * @returns {dw.system.Status} - Status object
- */
-exports.<%= hookName %> = function (object) {
-    log.info('<%= hookName %> system hook called');
-
-    try {
-        // TODO: Implement hook logic based on extension point
-        // Common extension points:
-        // - dw.order.calculate: Basket/order calculation
-        // - dw.order.createOrder: Order creation
-        // - dw.customer.registration: Customer registration
-        // - dw.extensions.applepay: Apple Pay processing
-
-    } catch (e) {
-        log.error('<%= hookName %> hook error: ' + e.message);
-        return new Status(
-            Status.ERROR,
-            '<%= hookName.toUpperCase() %>_ERROR',
-            e.message
-        );
-    }
-
-    return new Status(Status.OK);
-};
-<% } %>

--- a/packages/b2c-tooling-sdk/data/scaffolds/hook/files/hooks-entry.json.ejs
+++ b/packages/b2c-tooling-sdk/data/scaffolds/hook/files/hooks-entry.json.ejs
@@ -1,6 +1,6 @@
 [
   {
-    "name": "<%= hookPoint %>",
+    "name": "<%= locals.scapiOcapiHookPoint || locals.systemHookPoint %>",
     "script": "./scripts/hooks/<%= hookName %>"
   }
 ]

--- a/packages/b2c-tooling-sdk/data/scaffolds/hook/scaffold.json
+++ b/packages/b2c-tooling-sdk/data/scaffolds/hook/scaffold.json
@@ -18,19 +18,28 @@
       "type": "choice",
       "required": true,
       "choices": [
-        { "value": "ocapi", "label": "OCAPI Hook (shop/data API extension)" },
-        { "value": "scapi", "label": "SCAPI Hook (shopper API extension)" },
-        { "value": "system", "label": "System Hook (order, basket, etc.)" }
+        { "value": "scapi-ocapi", "label": "SCAPI/OCAPI Hook (API extension)" },
+        { "value": "system", "label": "System Hook (order calculation, payment, etc.)" }
       ],
       "default": "system"
     },
     {
-      "name": "hookPoint",
+      "name": "scapiOcapiHookPoint",
       "prompt": "What is the hook extension point?",
       "type": "string",
       "required": true,
-      "source": "hook-points",
-      "validationMessage": "Hook point is required (e.g., dw.order.calculate, dw.ocapi.shop.order.beforePOST)"
+      "when": "hookType=scapi-ocapi",
+      "source": "scapi-ocapi-hook-points",
+      "validationMessage": "Hook point is required (e.g., dw.ocapi.shop.basket.afterPOST)"
+    },
+    {
+      "name": "systemHookPoint",
+      "prompt": "What is the hook extension point?",
+      "type": "string",
+      "required": true,
+      "when": "hookType=system",
+      "source": "system-hook-points",
+      "validationMessage": "Hook point is required (e.g., dw.order.calculate)"
     },
     {
       "name": "cartridgeName",
@@ -50,11 +59,16 @@
   ],
   "modifications": [
     {
+      "target": "{{cartridgeNamePath}}/cartridge/scripts/hooks/{{hookName}}.js",
+      "type": "append",
+      "contentTemplate": "hook-function.js.ejs"
+    },
+    {
       "target": "{{cartridgeNamePath}}/cartridge/hooks.json",
       "type": "json-merge",
       "contentTemplate": "hooks-entry.json.ejs",
       "jsonPath": "hooks"
     }
   ],
-  "postInstructions": "Hook '<%= hookName %>' has been created in '<%= cartridgeName %>'.\n\nHook point: <%= hookPoint %>\n\nNext steps:\n1. Implement the hook logic in cartridge/scripts/hooks/<%= hookName %>.js\n2. Deploy the cartridge to your instance\n3. Ensure <%= cartridgeName %> is in your cartridge path"
+  "postInstructions": "Hook '<%= hookName %>' has been created in '<%= cartridgeName %>'.\n\nHook point: <%= locals.scapiOcapiHookPoint || locals.systemHookPoint %>\n\nNext steps:\n1. Implement the hook logic in cartridge/scripts/hooks/<%= hookName %>.js\n2. Deploy the cartridge to your instance\n3. Ensure <%= cartridgeName %> is in your cartridge path\n\nTip: Run scaffold again with the same hook name to add more extension points to this file."
 }

--- a/packages/b2c-tooling-sdk/src/scaffold/executor.ts
+++ b/packages/b2c-tooling-sdk/src/scaffold/executor.ts
@@ -17,7 +17,7 @@ import type {
 } from './types.js';
 import {ScaffoldEngine} from './engine.js';
 import {evaluateCondition, validateParameters} from './validators.js';
-import {mergeJson, insertAfter, insertBefore, appendContent, prependContent} from './merge.js';
+import {mergeJson, createPath, insertAfter, insertBefore, appendContent, prependContent} from './merge.js';
 
 /**
  * Options for resolving output directory.
@@ -126,8 +126,8 @@ export async function generateFromScaffold(
     const destRendered = engine.renderPath(mapping.destination);
     // If destination is absolute path, use it directly; otherwise join with outputDir
     const destAbsolute = path.isAbsolute(destRendered) ? destRendered : path.join(outputDir, destRendered);
-    // For display purposes, show path relative to cwd
-    const destRelative = path.relative(process.cwd(), destAbsolute) || destAbsolute;
+    // For display purposes, show path relative to outputDir
+    const destRelative = path.relative(outputDir, destAbsolute) || destAbsolute;
 
     // Check if destination exists
     const exists = await fileExists(destAbsolute);
@@ -199,7 +199,7 @@ export async function generateFromScaffold(
 
       const targetRendered = engine.renderPath(modification.target);
       const targetAbsolute = path.isAbsolute(targetRendered) ? targetRendered : path.join(outputDir, targetRendered);
-      const targetRelative = path.relative(process.cwd(), targetAbsolute) || targetAbsolute;
+      const targetRelative = path.relative(outputDir, targetAbsolute) || targetAbsolute;
 
       // Get modification content
       let modContent: string;
@@ -272,8 +272,15 @@ async function processModification(
     switch (modification.type) {
       case 'json-merge': {
         if (!exists) {
-          // Create new JSON file
-          newContent = JSON.stringify(JSON.parse(content), null, 2);
+          // Create new JSON file, wrapping content in jsonPath structure if specified
+          if (modification.jsonPath) {
+            const wrapper: Record<string, unknown> = {};
+            const [parent, key] = createPath(wrapper, modification.jsonPath);
+            parent[key] = JSON.parse(content);
+            newContent = JSON.stringify(wrapper, null, 2);
+          } else {
+            newContent = JSON.stringify(JSON.parse(content), null, 2);
+          }
         } else {
           newContent = mergeJson(existingContent, content, {
             jsonPath: modification.jsonPath,

--- a/packages/b2c-tooling-sdk/src/scaffold/merge.ts
+++ b/packages/b2c-tooling-sdk/src/scaffold/merge.ts
@@ -52,7 +52,7 @@ function navigateToPath(obj: unknown, path: string): [Record<string, unknown> | 
  * @param path - Dot-separated path to create
  * @returns The parent object of the final key
  */
-function createPath(obj: Record<string, unknown>, path: string): [Record<string, unknown>, string] {
+export function createPath(obj: Record<string, unknown>, path: string): [Record<string, unknown>, string] {
   const parts = path.split('.');
   const finalKey = parts.pop()!;
   let current = obj;
@@ -113,10 +113,20 @@ export function mergeJson(
   newContent: string | Record<string, unknown>,
   options: JsonMergeOptions = {},
 ): string {
-  const existing = JSON.parse(existingJson);
+  let existing = JSON.parse(existingJson);
   const content = typeof newContent === 'string' ? JSON.parse(newContent) : newContent;
 
   if (options.jsonPath) {
+    // If existing content is a bare array but we expected an object with jsonPath,
+    // wrap it in the expected structure so the merge works correctly.
+    // This handles files that were previously created without the jsonPath wrapper.
+    if (Array.isArray(existing)) {
+      const wrapper: Record<string, unknown> = {};
+      const [newParent, newKey] = createPath(wrapper, options.jsonPath);
+      newParent[newKey] = existing;
+      existing = wrapper;
+    }
+
     const [parent, key, found] = navigateToPath(existing, options.jsonPath);
 
     if (!found) {

--- a/packages/b2c-tooling-sdk/src/scaffold/parameter-resolver.ts
+++ b/packages/b2c-tooling-sdk/src/scaffold/parameter-resolver.ts
@@ -95,8 +95,20 @@ export async function resolveScaffoldParameters(
   let cartridgePathMap: Map<string, string> | undefined;
 
   for (const param of scaffold.manifest.parameters) {
-    // Check if conditional parameter should be evaluated
+    // Check if conditional parameter should be evaluated.
+    // If the condition references a variable that hasn't been resolved yet
+    // (it's missing), include the param as missing so interactive prompts
+    // can re-evaluate the condition after earlier params are filled in.
     if (param.when && !evaluateCondition(param.when, variables)) {
+      const conditionVar = param.when.split('=')[0].replace(/^!/, '');
+      if (variables[conditionVar] !== undefined) {
+        // Condition variable is resolved but condition is false — skip entirely
+        continue;
+      }
+      // Condition variable is unresolved — add to missing so it can be prompted later
+      if (param.required) {
+        missingParameters.push(param);
+      }
       continue;
     }
 

--- a/packages/b2c-tooling-sdk/src/scaffold/sources.ts
+++ b/packages/b2c-tooling-sdk/src/scaffold/sources.ts
@@ -12,26 +12,92 @@ import type {OcapiComponents} from '../clients/index.js';
 import type {ScaffoldChoice, ScaffoldParameter, DynamicParameterSource, SourceResult} from './types.js';
 
 /**
- * Common B2C Commerce hook extension points.
+ * SCAPI/OCAPI hook extension points.
  */
-export const HOOK_POINTS: ScaffoldChoice[] = [
+export const SCAPI_OCAPI_HOOK_POINTS: ScaffoldChoice[] = [
+  // Basket
+  {value: 'dw.ocapi.shop.basket.beforePOST_v2', label: 'Basket beforePOST'},
+  {value: 'dw.ocapi.shop.basket.afterPOST', label: 'Basket afterPOST'},
+  {value: 'dw.ocapi.shop.basket.modifyPOSTResponse', label: 'Basket modifyPOSTResponse'},
+  {value: 'dw.ocapi.shop.basket.beforePATCH', label: 'Basket beforePATCH'},
+  {value: 'dw.ocapi.shop.basket.afterPATCH', label: 'Basket afterPATCH'},
+  {value: 'dw.ocapi.shop.basket.modifyPATCHResponse', label: 'Basket modifyPATCHResponse'},
+  {value: 'dw.ocapi.shop.basket.modifyGETResponse', label: 'Basket modifyGETResponse'},
+  {value: 'dw.ocapi.shop.basket.validateBasket', label: 'Basket validateBasket'},
+  // Basket sub-resources
+  {value: 'dw.ocapi.shop.basket.billing_address.beforePUT', label: 'Basket Billing Address beforePUT'},
+  {value: 'dw.ocapi.shop.basket.billing_address.afterPUT', label: 'Basket Billing Address afterPUT'},
+  {value: 'dw.ocapi.shop.basket.items.beforePOST', label: 'Basket Items beforePOST'},
+  {value: 'dw.ocapi.shop.basket.items.afterPOST', label: 'Basket Items afterPOST'},
+  {value: 'dw.ocapi.shop.basket.item.beforePATCH', label: 'Basket Item beforePATCH'},
+  {value: 'dw.ocapi.shop.basket.item.afterPATCH', label: 'Basket Item afterPATCH'},
+  {value: 'dw.ocapi.shop.basket.item.beforeDELETE', label: 'Basket Item beforeDELETE'},
+  {value: 'dw.ocapi.shop.basket.item.afterDELETE', label: 'Basket Item afterDELETE'},
+  {value: 'dw.ocapi.shop.basket.coupon.beforePOST', label: 'Basket Coupon beforePOST'},
+  {value: 'dw.ocapi.shop.basket.coupon.afterPOST', label: 'Basket Coupon afterPOST'},
+  {value: 'dw.ocapi.shop.basket.payment_instrument.beforePOST', label: 'Basket Payment Instrument beforePOST'},
+  {value: 'dw.ocapi.shop.basket.payment_instrument.afterPOST', label: 'Basket Payment Instrument afterPOST'},
+  {value: 'dw.ocapi.shop.basket.shipment.beforePATCH', label: 'Basket Shipment beforePATCH'},
+  {value: 'dw.ocapi.shop.basket.shipment.afterPATCH', label: 'Basket Shipment afterPATCH'},
+  {value: 'dw.ocapi.shop.basket.shipment.shipping_address.beforePUT', label: 'Basket Shipping Address beforePUT'},
+  {value: 'dw.ocapi.shop.basket.shipment.shipping_address.afterPUT', label: 'Basket Shipping Address afterPUT'},
+  {value: 'dw.ocapi.shop.basket.shipment.shipping_method.beforePUT', label: 'Basket Shipping Method beforePUT'},
+  {value: 'dw.ocapi.shop.basket.shipment.shipping_method.afterPUT', label: 'Basket Shipping Method afterPUT'},
+  // Order
+  {value: 'dw.ocapi.shop.order.beforePOST', label: 'Shop Order beforePOST'},
+  {value: 'dw.ocapi.shop.order.afterPOST', label: 'Shop Order afterPOST'},
+  {value: 'dw.ocapi.shop.order.modifyPOSTResponse', label: 'Shop Order modifyPOSTResponse'},
+  {value: 'dw.ocapi.shop.order.modifyGETResponse', label: 'Shop Order modifyGETResponse'},
+  {value: 'dw.ocapi.shop.order.validateOrder', label: 'Shop Order validateOrder'},
+  {value: 'dw.ocapi.shop.order.payment_instrument.beforePOST', label: 'Order Payment Instrument beforePOST'},
+  {value: 'dw.ocapi.shop.order.payment_instrument.afterPOST', label: 'Order Payment Instrument afterPOST'},
+  // Customer
+  {value: 'dw.ocapi.shop.customer.beforePOST', label: 'Customer beforePOST'},
+  {value: 'dw.ocapi.shop.customer.afterPOST', label: 'Customer afterPOST'},
+  {value: 'dw.ocapi.shop.customer.modifyGETResponse', label: 'Customer modifyGETResponse'},
+  {value: 'dw.ocapi.shop.customer.modifyPOSTResponse', label: 'Customer modifyPOSTResponse'},
+  // Auth
+  {value: 'dw.ocapi.shop.auth.beforePOST', label: 'Auth beforePOST'},
+  {value: 'dw.ocapi.shop.auth.afterPOST', label: 'Auth afterPOST'},
+  {value: 'dw.ocapi.shop.auth.modifyPOSTResponse', label: 'Auth modifyPOSTResponse'},
+  // Product
+  {value: 'dw.ocapi.shop.product.modifyGETResponse', label: 'Product modifyGETResponse'},
+  {value: 'dw.ocapi.shop.product_search.modifyGETResponse', label: 'Product Search modifyGETResponse'},
+];
+
+/**
+ * System hook extension points.
+ * Verified against Script API: CalculateHooks, PaymentHooks, OrderHooks,
+ * BasketMergeHooks, CheckoutHooks, ReturnHooks, ShippingOrderHooks, RequestHooks
+ */
+export const SYSTEM_HOOK_POINTS: ScaffoldChoice[] = [
+  // CalculateHooks
   {value: 'dw.order.calculate', label: 'Order Calculate'},
   {value: 'dw.order.calculateShipping', label: 'Calculate Shipping'},
-  {value: 'dw.order.createOrder', label: 'Create Order'},
-  {value: 'dw.order.afterPOST', label: 'OCAPI Order afterPOST'},
-  {value: 'dw.order.beforePOST', label: 'OCAPI Order beforePOST'},
-  {value: 'dw.ocapi.shop.basket.afterPOST', label: 'OCAPI Basket afterPOST'},
-  {value: 'dw.ocapi.shop.basket.modifyGETResponse', label: 'OCAPI Basket modifyGET'},
-  {value: 'dw.ocapi.shop.order.afterPOST', label: 'OCAPI Shop Order afterPOST'},
-  {value: 'dw.ocapi.shop.order.beforePOST', label: 'OCAPI Shop Order beforePOST'},
-  {value: 'dw.ocapi.data.order.afterPATCH', label: 'OCAPI Data Order afterPATCH'},
-  {value: 'dw.customer.registration', label: 'Customer Registration'},
-  {value: 'dw.customer.afterCreate', label: 'Customer afterCreate'},
-  {value: 'app.payment.processor', label: 'Payment Processor'},
-  {value: 'app.payment.form.processor', label: 'Payment Form Processor'},
+  {value: 'dw.order.calculateTax', label: 'Calculate Tax'},
+  // PaymentHooks
+  {value: 'dw.order.payment.authorize', label: 'Payment Authorize'},
+  {value: 'dw.order.payment.authorizeCreditCard', label: 'Payment Authorize Credit Card'},
+  {value: 'dw.order.payment.capture', label: 'Payment Capture'},
+  {value: 'dw.order.payment.refund', label: 'Payment Refund'},
+  {value: 'dw.order.payment.validateAuthorization', label: 'Payment Validate Authorization'},
+  {value: 'dw.order.payment.reauthorize', label: 'Payment Reauthorize'},
+  {value: 'dw.order.payment.releaseAuthorization', label: 'Payment Release Authorization'},
+  // OrderHooks
+  {value: 'dw.order.createOrderNo', label: 'Create Order Number'},
+  // BasketMergeHooks
+  {value: 'dw.order.mergeBasket', label: 'Merge Basket'},
+  // CheckoutHooks
+  {value: 'dw.order.populateCustomerDetails', label: 'Populate Customer Details'},
+  // RequestHooks
+  {value: 'dw.system.request.onRequest', label: 'On Request'},
   {value: 'dw.system.request.onSession', label: 'On Session'},
-  {value: 'dw.extensions.csv.onFileProcess', label: 'CSV File Process'},
 ];
+
+/**
+ * All hook extension points (combined).
+ */
+export const HOOK_POINTS: ScaffoldChoice[] = [...SCAPI_OCAPI_HOOK_POINTS, ...SYSTEM_HOOK_POINTS];
 
 /**
  * Resolve a local (non-remote) parameter source.
@@ -53,6 +119,12 @@ export function resolveLocalSource(source: DynamicParameterSource, projectRoot: 
     }
     case 'hook-points': {
       return {choices: HOOK_POINTS};
+    }
+    case 'scapi-ocapi-hook-points': {
+      return {choices: SCAPI_OCAPI_HOOK_POINTS};
+    }
+    case 'system-hook-points': {
+      return {choices: SYSTEM_HOOK_POINTS};
     }
     default: {
       return {choices: []};

--- a/packages/b2c-tooling-sdk/src/scaffold/types.ts
+++ b/packages/b2c-tooling-sdk/src/scaffold/types.ts
@@ -30,10 +30,17 @@ export type ScaffoldParameterType = 'string' | 'boolean' | 'choice' | 'multi-cho
  * Dynamic sources for populating parameter choices at runtime.
  *
  * - `cartridges`: Discovers cartridges in project via .project files
- * - `hook-points`: Static list of common hook extension points
+ * - `hook-points`: Static list of common hook extension points (all types)
+ * - `scapi-ocapi-hook-points`: SCAPI/OCAPI API extension hook points
+ * - `system-hook-points`: System hook extension points (order, payment, request)
  * - `sites`: Remote - fetches sites from connected B2C instance
  */
-export type DynamicParameterSource = 'cartridges' | 'hook-points' | 'sites';
+export type DynamicParameterSource =
+  | 'cartridges'
+  | 'hook-points'
+  | 'scapi-ocapi-hook-points'
+  | 'system-hook-points'
+  | 'sites';
 
 /**
  * Overwrite behavior for generated files

--- a/packages/b2c-tooling-sdk/src/scaffold/validators.ts
+++ b/packages/b2c-tooling-sdk/src/scaffold/validators.ts
@@ -18,7 +18,13 @@ const VALID_PARAMETER_TYPES = ['string', 'boolean', 'choice', 'multi-choice'];
 const RESERVED_NAMES = ['kebabCase', 'camelCase', 'pascalCase', 'snakeCase', 'year', 'date', 'uuid'];
 
 /** Valid dynamic parameter sources */
-const VALID_SOURCES: DynamicParameterSource[] = ['cartridges', 'hook-points', 'sites'];
+const VALID_SOURCES: DynamicParameterSource[] = [
+  'cartridges',
+  'hook-points',
+  'scapi-ocapi-hook-points',
+  'system-hook-points',
+  'sites',
+];
 
 /**
  * Validate a scaffold manifest


### PR DESCRIPTION
closes #247 

## Summary

Fixes multiple issues with the hook scaffold reported in #247:

- **Merged SCAPI/OCAPI hook types** into a single type (they were identical). Removed unverified SFRA type (custom hooks with no canonical list).
- **Fixed hook extension points list** — validated all entries against Script API docs (`dw.order.hooks.*` classes) and commerce-cloud-docs hook-method-details. Removed invalid entries (`dw.order.hooks.validateOrder`, `dw.order.hooks.basketMerge`, `dw.ocapi.data.order.afterPATCH`), fixed `dw.ocapi.shop.basket.beforePOST` → `beforePOST_v2`, added verified missing hooks (`dw.order.mergeBasket`, `dw.order.populateCustomerDetails`).
- **Fixed hooks.json not updating** — json-merge now wraps new files in the jsonPath structure (`{"hooks": [...]}` instead of bare `[...]`), and handles bare arrays from previously broken scaffold runs.
- **Support appending hook functions to existing files** — running the scaffold with the same hook name but a different extension point now appends the new function instead of skipping the file.
- **Fixed display paths** — uses `outputDir` instead of `process.cwd()` for relative path computation, fixing missing leading slashes in VS Code extension context.
- **Fixed conditional parameter resolution** — parameters with unresolved `when` conditions are now added to `missingParameters` for interactive prompting instead of being silently skipped.
- **Correct function signatures** — SCAPI/OCAPI hooks generate JSDoc and parameter lists matching the commerce-cloud-docs reference. System hooks use generic signatures.
- **Show extension point in choice labels** — CLI shows `Label (dw.ocapi.shop.basket.afterPOST)` format; VS Code already shows value as quickpick description.
- **Allow custom hook points** — search prompts include a "Custom: <typed value>" option for hooks not in the list.

## Test plan

- [x] `pnpm run test:agent` — all tests pass (1388 SDK + 1022 CLI + 650 MCP)
- [x] `pnpm run lint:agent` — no errors
- [x] Generate a hook into a cartridge with no existing hooks.json → verify `{"hooks": [{...}]}`
- [x] Generate a second hook with the same name → verify function appended and hooks.json updated
- [x] Verify SCAPI/OCAPI and System hook type filtering works
- [x] Verify custom hook points can be typed in search prompt