### PR TITLE
Added code ownership for cc-sharks for the storefront-next mcp tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 #GUSINFO:CC Cosmos,B2C CLI and Developer Tools
 *       @clavery
 /packages/b2c-dx-mcp/       @yhsieh1 @patricksullivansf @wei-liu-sf
+/packages/b2c-dx-mcp/src/tools/storefrontnext/    @commerce-emu/cc-sharks
 /packages/b2c-vs-extension/    @wei-liu-sf
 /docs/mcp/       @wei-liu-sf @yhsieh1 @patricksullivansf
 /docs/.vitepress/       @wei-liu-sf @yhsieh1 @patricksullivansf


### PR DESCRIPTION
## Summary

Assigned code owners to the storefront-next MCP tools

## Testing

N/A

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
