### PR TITLE
@W-21466612 fix marketplace def

### DIFF
--- a/.changeset/fix-marketplace-mcp-plugin.md
+++ b/.changeset/fix-marketplace-mcp-plugin.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-dx-mcp': patch
+---
+
+Fix marketplace schema validation for the `b2c-dx-mcp` plugin by adding the required `source` field

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -47,13 +47,9 @@
         "name": "Salesforce"
       },
       "license": "Apache-2.0",
+      "source": "./plugins/b2c-dx-mcp",
       "category": "productivity",
-      "mcpServers": {
-        "b2c-dx-mcp": {
-          "command": "npx",
-          "args": ["-y", "@salesforce/b2c-dx-mcp@latest", "--allow-non-ga-tools"]
-        }
-      }
+      "strict": false
     }
   ]
 }

--- a/plugins/b2c-dx-mcp/.mcp.json
+++ b/plugins/b2c-dx-mcp/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "b2c-dx-mcp": {
+      "command": "npx",
+      "args": ["-y", "@salesforce/b2c-dx-mcp@latest", "--allow-non-ga-tools"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fix marketplace schema validation for the `b2c-dx-mcp` plugin by adding the required `source` field

## Testing

marketplace using a local path:

`claude plugin marketplace add [your local  b2c-developer-tooling]`

If the schema validates, you can then install the MCP plugin:

`claude plugin install b2c-dx-mcp@b2c-developer-tooling`

## Dependencies

- [x] No net-new third-party dependencies were added
- [x] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
