### PR TITLE
@W-20599722 update tools and docs for GA

### DIFF
--- a/.changeset/mcp-ga-release.md
+++ b/.changeset/mcp-ga-release.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/b2c-dx-mcp': major
+'@salesforce/b2c-dx-docs': patch
+---
+
+Document MCP server GA availability updates. CARTRIDGES, MRT, SCAPI, and PWAV3 tools are generally available and no longer require `--allow-non-ga-tools`; STOREFRONTNEXT tools remain in preview.

--- a/docs/guide/storefront-next.md
+++ b/docs/guide/storefront-next.md
@@ -4,11 +4,11 @@ description: Set up Storefront Next development environments using the B2C CLI t
 
 # Storefront Next
 
-::: warning Pilot Preview
-Storefront Next is currently in pilot. Access to Storefront Next is limited to pilot customers. Features and configuration may change.
+::: warning Important
+Storefront Next is currently in a closed pilot. Access to Storefront Next is limited to pilot customers. Features and configuration may change.
 :::
 
-This guide walks through setting up the infrastructure for a Storefront Next project using the B2C CLI. The steps cover creating a sandbox, configuring SLAS authentication, setting up an MRT environment, configuring environment variables, and deploying. Not all steps are required — skip any that are already complete for your project.
+Set up Storefront Next development environments using the B2C CLI to create sandboxes, SLAS clients, MRT environments, and deploy.
 
 ## Prerequisites
 

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -6,7 +6,7 @@ description: MCP Server for Salesforce B2C Commerce - AI-assisted development to
 
 The B2C DX MCP Server enables AI assistants (like Claude Code, Cursor, GitHub Copilot, and others) to help with B2C Commerce development tasks. It provides toolsets for **SCAPI**, **CARTRIDGES**, **MRT**, **PWAV3**, and **STOREFRONTNEXT** development.
 
-> ⚠️ **Preview Release**: This package is in preview. Tools are functional but require `--allow-non-ga-tools` to enable. Additional tools will be added in future releases.
+> **Note:** 🚧 The STOREFRONTNEXT MCP tool is for Storefront Next. Storefront Next is part of a closed pilot and isn't available for general use.
 
 ## Quick Start
 

--- a/docs/mcp/toolsets.md
+++ b/docs/mcp/toolsets.md
@@ -6,7 +6,6 @@ description: Available toolsets and tools in the B2C DX MCP Server for SCAPI, CA
 
 The B2C DX MCP Server provides five toolsets with specialized tools for different B2C Commerce development workflows.
 
-> **Note:** Tools require `--allow-non-ga-tools` to enable (preview release).
 
 ## Overview
 
@@ -25,7 +24,7 @@ Toolsets are collections of related tools that work together to support specific
 
 Cartridge development, deployment, and code version management.
 
-**Status:** 🚧 Early Access
+**Status:** ✅ Generally Available
 
 **Auto-enabled for:** Cartridge projects (detected by `.project` file)
 
@@ -39,7 +38,7 @@ Cartridge development, deployment, and code version management.
 
 Managed Runtime operations for PWA Kit and Storefront Next deployments.
 
-**Status:** 🚧 Early Access
+**Status:** ✅ Generally Available
 
 **Auto-enabled for:** PWA Kit v3 and Storefront Next projects
 
@@ -53,7 +52,7 @@ Managed Runtime operations for PWA Kit and Storefront Next deployments.
 
 PWA Kit v3 development tools for building headless storefronts.
 
-**Status:** 🚧 Early Access (PWA Kit-specific tools planned)
+**Status:** ✅ Generally Available
 
 **Auto-enabled for:** PWA Kit v3 projects (detected by `@salesforce/pwa-kit-*` dependencies, `@salesforce/retail-react-app`, or `ccExtensibility` field in package.json)
 
@@ -71,7 +70,7 @@ PWA Kit v3 development tools for building headless storefronts.
 
 Salesforce Commerce API discovery and exploration.
 
-**Status:** 🚧 Early Access
+**Status:** ✅ Generally Available
 
 **Always enabled** - Base toolset available for all projects.
 
@@ -87,7 +86,9 @@ Salesforce Commerce API discovery and exploration.
 
 Storefront Next development tools for building modern storefronts.
 
-**Status:** 🚧 Early Access. Storefront Next is part of a closed pilot and isn't available for general use.
+> **Note:** 🚧 This MCP tool is for Storefront Next. Storefront Next is part of a closed pilot and isn't available for general use.
+
+**Status:** 🚧 Preview — requires `--allow-non-ga-tools` flag.
 
 **Auto-enabled for:** Storefront Next projects (detected by `@salesforce/storefront-next*` dependencies, package name starting with `storefront-next`, or workspace packages with these indicators)
 

--- a/packages/b2c-dx-mcp/README.md
+++ b/packages/b2c-dx-mcp/README.md
@@ -2,9 +2,6 @@
 
 MCP (Model Context Protocol) server for Salesforce B2C Commerce developer experience tools.
 
-> [!NOTE]
-> This project is currently in **Developer Preview**. Tools are functional but require `--allow-non-ga-tools` to enable. Additional tools will be added in future releases.
-
 This MCP server enables AI assistants (Cursor, Claude Code, and others) to help with B2C Commerce development tasks. It provides toolsets for **SCAPI**, **CARTRIDGES**, **MRT**, **PWAV3**, and **STOREFRONTNEXT** development.
 
 Full documentation: [https://salesforcecommercecloud.github.io/b2c-developer-tooling/mcp/](https://salesforcecommercecloud.github.io/b2c-developer-tooling/mcp/)
@@ -184,6 +181,3 @@ For MCP development, testing, and local setup, see [CONTRIBUTING.md](./CONTRIBUT
 
 This project is licensed under the Apache License 2.0. See [LICENSE.txt](../../LICENSE.txt) for full details.
 
-## Disclaimer
-
-This project is currently in **Developer Preview** and is provided "as-is" without warranty of any kind. It is not yet generally available (GA) and should not be used in production environments. Features, APIs, and functionality may change without notice in future releases.

--- a/packages/b2c-dx-mcp/src/tools/cartridges/index.ts
+++ b/packages/b2c-dx-mcp/src/tools/cartridges/index.ts
@@ -86,7 +86,7 @@ function createCartridgeDeployTool(
         'Requires the instance to have a code version configured. ' +
         "After deploy, add new cartridges to your site's cartridge path in Business Manager: Sites → Manage Sites → [site] → Settings tab → Cartridges.",
       toolsets: ['CARTRIDGES'],
-      isGA: false,
+      isGA: true,
       requiresInstance: true,
       inputSchema: {
         directory: z

--- a/packages/b2c-dx-mcp/src/tools/mrt/index.ts
+++ b/packages/b2c-dx-mcp/src/tools/mrt/index.ts
@@ -169,7 +169,7 @@ function createMrtBundlePushTool(
       description:
         'Bundle a pre-built PWA Kit or Storefront Next project and push to Managed Runtime. Optionally deploy to a target environment.',
       toolsets: ['MRT', 'PWAV3', 'STOREFRONTNEXT'],
-      isGA: false,
+      isGA: true,
       // MRT operations use ApiKeyStrategy from MRT_API_KEY or ~/.mobify
       requiresMrtAuth: true,
       inputSchema: {

--- a/packages/b2c-dx-mcp/src/tools/pwav3/pwa-kit-development-guidelines.ts
+++ b/packages/b2c-dx-mcp/src/tools/pwav3/pwa-kit-development-guidelines.ts
@@ -127,7 +127,7 @@ export function createDeveloperGuidelinesTool(loadServices: () => Promise<Servic
         'CRITICAL INSTRUCTION: ALWAYS present ALL returned content in FULL - DO NOT SUMMARIZE, DO NOT ADD SUMMARIES, ' +
         'DO NOT ADD OVERVIEWS. The returned content IS the complete answer - display it exactly as provided.',
       toolsets: ['PWAV3'],
-      isGA: false,
+      isGA: true,
       requiresInstance: false,
       inputSchema: {
         sections: z

--- a/packages/b2c-dx-mcp/src/tools/scapi/scapi-custom-api-generate-scaffold.ts
+++ b/packages/b2c-dx-mcp/src/tools/scapi/scapi-custom-api-generate-scaffold.ts
@@ -210,7 +210,7 @@ export function createScaffoldCustomApiTool(
 Required: apiName (kebab-case). Optional: cartridgeName (defaults to first cartridge found in project), apiType (shopper|admin) default to shopper, \
 apiDescription, projectRoot, outputDir.`,
       toolsets: ['PWAV3', 'SCAPI', 'STOREFRONTNEXT'],
-      isGA: false,
+      isGA: true,
       requiresInstance: false,
       inputSchema: {
         apiName: z

--- a/packages/b2c-dx-mcp/src/tools/scapi/scapi-custom-apis-get-status.ts
+++ b/packages/b2c-dx-mcp/src/tools/scapi/scapi-custom-apis-get-status.ts
@@ -142,7 +142,7 @@ Requires OAuth (sfcc.custom-apis scope) and instance config (shortCode, tenantId
 
 CLI: b2c scapi custom status`,
       toolsets: ['PWAV3', 'SCAPI', 'STOREFRONTNEXT'],
-      isGA: false,
+      isGA: true,
       requiresInstance: false,
       inputSchema: {
         status: z.enum(['active', 'not_registered']).optional().describe('Filter by status. Omit for all.'),

--- a/packages/b2c-dx-mcp/src/tools/scapi/scapi-schemas-list.ts
+++ b/packages/b2c-dx-mcp/src/tools/scapi/scapi-schemas-list.ts
@@ -306,7 +306,7 @@ export function createScapiSchemasListTool(loadServices: () => Promise<Services>
 
 **Requirements:** OAuth with sfcc.scapi-schemas scope.`,
       toolsets: ['PWAV3', 'SCAPI', 'STOREFRONTNEXT'],
-      isGA: false,
+      isGA: true,
       requiresInstance: false, // SCAPI uses OAuth directly, doesn't need B2CInstance (hostname)
       inputSchema: {
         apiFamily: z.string().optional().describe('API family (e.g., "checkout", "product", "custom").'),

--- a/packages/b2c-dx-mcp/src/tools/storefrontnext/index.ts
+++ b/packages/b2c-dx-mcp/src/tools/storefrontnext/index.ts
@@ -46,7 +46,6 @@ export function createStorefrontNextTools(loadServices: () => Promise<Services> 
     createDeveloperGuidelinesTool(loadServices),
     createPageDesignerDecoratorTool(loadServices),
     createSiteThemingTool(loadServices),
-    createPageDesignerDecoratorTool(loadServices),
     createFigmaToComponentTool(loadServices),
     createGenerateComponentTool(loadServices),
     createMapTokensToThemeTool(loadServices),

--- a/packages/b2c-dx-mcp/test/registry.test.ts
+++ b/packages/b2c-dx-mcp/test/registry.test.ts
@@ -327,16 +327,19 @@ describe('registry', () => {
     it('should skip non-GA tools when allowNonGaTools is false', async () => {
       const server = createMockServer();
       const flags: StartupFlags = {
-        toolsets: ['CARTRIDGES'],
+        toolsets: ['STOREFRONTNEXT'],
         allowNonGaTools: false,
       };
 
       const loadServices = createMockLoadServicesWrapper();
       await registerToolsets(flags, server, loadServices);
 
-      // All current CARTRIDGES tools are non-GA (isGA: false)
-      // So none should be registered
-      expect(server.registeredTools).to.have.lengthOf(0);
+      // STOREFRONTNEXT-only tools are non-GA (isGA: false), so they should be skipped.
+      // Multi-toolset GA tools (mrt_bundle_push, scapi_*) that appear in STOREFRONTNEXT are still registered.
+      const sfnextOnlyTools = ['sfnext_get_guidelines', 'sfnext_add_page_designer_decorator'];
+      for (const toolName of sfnextOnlyTools) {
+        expect(server.registeredTools).to.not.include(toolName);
+      }
     });
 
     it('should register GA tools even when allowNonGaTools is false', async () => {
@@ -349,9 +352,17 @@ describe('registry', () => {
       const loadServices = createMockLoadServicesWrapper();
       await registerToolsets(flags, server, loadServices);
 
-      // Currently all tools are non-GA placeholders
-      // This test documents expected behavior for when GA tools exist
-      // When GA tools are added, this test should be updated to verify they are registered
+      // GA tools from CARTRIDGES, MRT, SCAPI, PWAV3 should be registered
+      expect(server.registeredTools).to.include('cartridge_deploy');
+      expect(server.registeredTools).to.include('mrt_bundle_push');
+      expect(server.registeredTools).to.include('scapi_schemas_list');
+      expect(server.registeredTools).to.include('scapi_custom_apis_get_status');
+      expect(server.registeredTools).to.include('scapi_custom_api_generate_scaffold');
+      expect(server.registeredTools).to.include('pwakit_get_guidelines');
+
+      // STOREFRONTNEXT-only tools should NOT be registered (still non-GA)
+      expect(server.registeredTools).to.not.include('sfnext_get_guidelines');
+      expect(server.registeredTools).to.not.include('sfnext_add_page_designer_decorator');
     });
 
     describe('auto-discovery', () => {

--- a/packages/b2c-dx-mcp/test/tools/cartridges/index.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/cartridges/index.test.ts
@@ -132,8 +132,8 @@ describe('tools/cartridges', () => {
       expect(tool.toolsets).to.have.lengthOf(1);
     });
 
-    it('should not be GA (generally available)', () => {
-      expect(tool.isGA).to.be.false;
+    it('should be GA (generally available)', () => {
+      expect(tool.isGA).to.be.true;
     });
 
     it('should require instance', () => {

--- a/packages/b2c-dx-mcp/test/tools/mrt/index.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/mrt/index.test.ts
@@ -155,8 +155,8 @@ describe('tools/mrt', () => {
       expect(tool.toolsets).to.have.lengthOf(3);
     });
 
-    it('should not be GA (generally available)', () => {
-      expect(tool.isGA).to.be.false;
+    it('should be GA (generally available)', () => {
+      expect(tool.isGA).to.be.true;
     });
   });
 

--- a/packages/b2c-dx-mcp/test/tools/pwav3/pwa-kit-development-guidelines.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/pwav3/pwa-kit-development-guidelines.test.ts
@@ -87,9 +87,9 @@ describe('tools/pwav3/pwa-kit-development-guidelines', () => {
       expect(tool.toolsets).to.have.lengthOf(1);
     });
 
-    it('should not be GA (generally available)', () => {
+    it('should be GA (generally available)', () => {
       const tool = createDeveloperGuidelinesTool(() => services);
-      expect(tool.isGA).to.be.false;
+      expect(tool.isGA).to.be.true;
     });
 
     it('should not require B2C instance', () => {

--- a/packages/b2c-dx-mcp/test/tools/scapi/scapi-custom-api-generate-scaffold.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/scapi/scapi-custom-api-generate-scaffold.test.ts
@@ -78,7 +78,7 @@ describe('tools/scapi/scapi-custom-api-generate-scaffold', () => {
       expect(tool.inputSchema).to.exist;
       expect(tool.handler).to.be.a('function');
       expect(tool.toolsets).to.deep.equal(['PWAV3', 'SCAPI', 'STOREFRONTNEXT']);
-      expect(tool.isGA).to.be.false;
+      expect(tool.isGA).to.be.true;
     });
 
     it('should have required apiName and optional cartridgeName, apiType, apiDescription, projectRoot, outputDir', () => {

--- a/packages/b2c-dx-mcp/test/tools/scapi/scapi-custom-apis-get-status.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/scapi/scapi-custom-apis-get-status.test.ts
@@ -105,7 +105,7 @@ describe('tools/scapi/scapi-custom-apis-get-status', () => {
       expect(tool.inputSchema).to.exist;
       expect(tool.handler).to.be.a('function');
       expect(tool.toolsets).to.deep.equal(['PWAV3', 'SCAPI', 'STOREFRONTNEXT']);
-      expect(tool.isGA).to.be.false;
+      expect(tool.isGA).to.be.true;
     });
 
     it('should have optional input params: status, groupBy, columns', () => {

--- a/packages/b2c-dx-mcp/test/tools/scapi/scapi-schemas-list.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/scapi/scapi-schemas-list.test.ts
@@ -65,7 +65,7 @@ describe('tools/scapi/scapi-schemas-list', () => {
       expect(tool.inputSchema).to.exist;
       expect(tool.handler).to.be.a('function');
       expect(tool.toolsets).to.deep.equal(['PWAV3', 'SCAPI', 'STOREFRONTNEXT']);
-      expect(tool.isGA).to.be.false;
+      expect(tool.isGA).to.be.true;
     });
 
     it('has optional input params: apiFamily, apiName, apiVersion, status, includeSchemas, expandAll', () => {


### PR DESCRIPTION
## Summary

- Document MCP server GA availability updates.
- CARTRIDGES, MRT, SCAPI, and PWAV3 tools are GA
- STOREFRONTNEXT tools remain in preview
- Remove duplicated STOREFRONTNEXT tool registration

## Testing
- Start MCP tool locally and verify `--allow-non-ga-tools` is not needed for GA tools
- Verify `--allow-non-ga-tools` is needed for STOREFRONTNEXT tools
- pnpm docs:dev and review docs

## Dependencies

- [x] No net-new third-party dependencies were added
- [x] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
