### PR TITLE
fix(mrt-utilities): emit true CJS for Node 22 and split data-store/express entrypoints

### DIFF
--- a/.changeset/mrt-utilities-node22-cjs-compat.md
+++ b/.changeset/mrt-utilities-node22-cjs-compat.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/mrt-utilities': patch
+---
+
+Fixed CommonJS packaging for Node 22 by ensuring `require` entrypoints under `dist/cjs` are emitted as true CJS modules. Added dedicated `@salesforce/mrt-utilities/data-store` and `@salesforce/mrt-utilities/middleware/express` entrypoints so data-store imports do not have to load the Express middleware barrel during startup.

--- a/packages/mrt-utilities/package.json
+++ b/packages/mrt-utilities/package.json
@@ -40,6 +40,28 @@
         "default": "./dist/cjs/middleware/index.js"
       }
     },
+    "./middleware/express": {
+      "development": "./src/middleware/express.ts",
+      "import": {
+        "types": "./dist/esm/middleware/express.d.ts",
+        "default": "./dist/esm/middleware/express.js"
+      },
+      "require": {
+        "types": "./dist/cjs/middleware/express.d.ts",
+        "default": "./dist/cjs/middleware/express.js"
+      }
+    },
+    "./data-store": {
+      "development": "./src/data-store/index.ts",
+      "import": {
+        "types": "./dist/esm/data-store/index.d.ts",
+        "default": "./dist/esm/data-store/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/data-store/index.d.ts",
+        "default": "./dist/cjs/data-store/index.js"
+      }
+    },
     "./metrics": {
       "development": "./src/metrics/index.ts",
       "import": {

--- a/packages/mrt-utilities/src/data-store/index.ts
+++ b/packages/mrt-utilities/src/data-store/index.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import {DynamoDBClient} from '@aws-sdk/client-dynamodb';
+import {DynamoDBDocumentClient, GetCommand, type GetCommandOutput} from '@aws-sdk/lib-dynamodb';
+
+import {logMRTError} from '../utils/utils.js';
+
+export class DataStoreNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DataStoreNotFoundError';
+    Object.setPrototypeOf(this, DataStoreNotFoundError.prototype);
+  }
+}
+
+export class DataStoreServiceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DataStoreServiceError';
+    Object.setPrototypeOf(this, DataStoreServiceError.prototype);
+  }
+}
+
+export class DataStoreUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DataStoreUnavailableError';
+    Object.setPrototypeOf(this, DataStoreUnavailableError.prototype);
+  }
+}
+
+/**
+ * A class for reading entries from the data store.
+ *
+ * This class uses a singleton pattern.
+ * Use DataStore.getDataStore() to get the singleton instance.
+ */
+export class DataStore {
+  private _tableName: string = '';
+  private _ddb: DynamoDBDocumentClient | null = null;
+  private static _instance: DataStore | null = null;
+
+  /** @internal Test hook: inject a document client for unit tests */
+  static _testDocumentClient: DynamoDBDocumentClient | null = null;
+  /** @internal Test hook: inject logMRTError for unit tests */
+  static _testLogMRTError: ((namespace: string, err: unknown, context?: Record<string, unknown>) => void) | null = null;
+
+  private constructor() {
+    // Private constructor for singleton; use DataStore.getDataStore() instead.
+  }
+
+  /**
+   * Get or create a DynamoDB document client (for abstraction of attribute values).
+   *
+   * @private
+   * @returns The DynamoDB document client
+   * @throws {DataStoreUnavailableError} The data store is unavailable
+   */
+  private getClient(): DynamoDBDocumentClient {
+    if (!this.isDataStoreAvailable()) {
+      throw new DataStoreUnavailableError('The data store is unavailable.');
+    }
+
+    if (DataStore._testDocumentClient) {
+      this._tableName = `DataAccessLayer-${process.env.AWS_REGION}`;
+      return DataStore._testDocumentClient;
+    }
+
+    if (!this._ddb) {
+      this._tableName = `DataAccessLayer-${process.env.AWS_REGION}`;
+      this._ddb = DynamoDBDocumentClient.from(
+        new DynamoDBClient({
+          region: process.env.AWS_REGION,
+        }),
+      );
+    }
+
+    return this._ddb;
+  }
+
+  /**
+   * Get or create the singleton DataStore instance.
+   *
+   * @returns The singleton DataStore instance
+   */
+  static getDataStore(): DataStore {
+    if (!DataStore._instance) {
+      DataStore._instance = new DataStore();
+    }
+    return DataStore._instance;
+  }
+
+  /**
+   * Whether the data store can be used in the current environment.
+   *
+   * @returns true if the data store is available, false otherwise
+   */
+  isDataStoreAvailable(): boolean {
+    return Boolean(process.env.AWS_REGION && process.env.MOBIFY_PROPERTY_ID && process.env.DEPLOY_TARGET);
+  }
+
+  /**
+   * Fetch an entry from the data store.
+   *
+   * @param key The data store entry's key
+   * @returns An object containing the entry's key and value
+   * @throws {DataStoreUnavailableError} The data store is unavailable
+   * @throws {DataStoreNotFoundError} An entry with the given key cannot be found
+   * @throws {DataStoreServiceError} An internal error occurred
+   */
+  async getEntry(key: string): Promise<Record<string, unknown> | undefined> {
+    if (!this.isDataStoreAvailable()) {
+      throw new DataStoreUnavailableError('The data store is unavailable.');
+    }
+
+    const ddb = this.getClient();
+    let response: GetCommandOutput;
+    try {
+      response = await ddb.send(
+        new GetCommand({
+          TableName: this._tableName,
+          Key: {
+            projectEnvironment: `${process.env.MOBIFY_PROPERTY_ID} ${process.env.DEPLOY_TARGET}`,
+            key,
+          },
+        }),
+      );
+    } catch (error) {
+      const logFn = DataStore._testLogMRTError ?? logMRTError;
+      logFn('data_store', error, {key, tableName: this._tableName});
+      throw new DataStoreServiceError('Data store request failed.');
+    }
+
+    if (!response.Item?.value) {
+      throw new DataStoreNotFoundError(`Data store entry '${key}' not found.`);
+    }
+
+    return {key, value: response.Item.value};
+  }
+}

--- a/packages/mrt-utilities/src/middleware/express.ts
+++ b/packages/mrt-utilities/src/middleware/express.ts
@@ -4,8 +4,5 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 
-/**
- * @deprecated Import data-store symbols from `@salesforce/mrt-utilities/data-store`.
- * This compatibility path is kept for backward compatibility.
- */
-export * from '../data-store/index.js';
+export * from './middleware.js';
+export {type ProxyConfig} from '../utils/configure-proxying.js';

--- a/packages/mrt-utilities/src/middleware/index.ts
+++ b/packages/mrt-utilities/src/middleware/index.ts
@@ -4,6 +4,5 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 
-export * from './data-store.js';
-export * from './middleware.js';
-export {type ProxyConfig} from '../utils/configure-proxying.js';
+export * from '../data-store/index.js';
+export * from './express.js';

--- a/packages/mrt-utilities/tsconfig.cjs.json
+++ b/packages/mrt-utilities/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "outDir": "dist/cjs",
     "rootDir": "src",
     "verbatimModuleSyntax": false


### PR DESCRIPTION
## Summary

This updates `@salesforce/mrt-utilities` packaging and module boundaries to fix Node 22 CommonJS consumption and reduce startup coupling between DataStore and Express middleware.

## Why

CJS consumers (notably SSR code paths) were resolving to `dist/cjs` entries that were not reliably emitted as true CommonJS for Node 22 expectations, and `middleware` barrel imports forced DataStore imports to load Express middleware concerns.

## Changes

- **CJS emit fix**
  - Updated `tsconfig.cjs.json`:
    - `module: "CommonJS"`
    - `moduleResolution: "Node"`
- **New focused exports**
  - Added `@salesforce/mrt-utilities/data-store`
  - Added `@salesforce/mrt-utilities/middleware/express`
- **Backward-compatible module move**
  - Moved DataStore implementation to `src/data-store/index.ts`
  - Kept `src/middleware/data-store.ts` as a compatibility re-export shim
- **Middleware barrel cleanup**
  - `src/middleware/index.ts` now re-exports from:
    - `../data-store/index.js`
    - `./express.js`
- **Release note**
  - Added patch changeset for `@salesforce/mrt-utilities`

## Compatibility / Risk

- **Non-breaking for existing public imports**:
  - `@salesforce/mrt-utilities`
  - `@salesforce/mrt-utilities/middleware`
- New entrypoints are additive and recommended for clearer dependency boundaries.
- DataStore old path remains available via compatibility re-export.

## Validation Performed

- `pnpm --filter @salesforce/mrt-utilities run build` ✅
- `pnpm --filter @salesforce/mrt-utilities run test:agent` ✅ (`508 passing`)
- `pnpm --filter @salesforce/mrt-utilities run typecheck:agent` ✅
- Node require smoke tests (from built output) ✅
  - `require('./dist/cjs/middleware/index.js')`
  - `require('./dist/cjs/data-store/index.js')`
  - `require('./dist/cjs/middleware/data-store.js')`
