### PR TITLE
ci: add mrt-utilities to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,15 @@ jobs:
         working-directory: packages/b2c-cli
         run: pnpm run pretest && pnpm run test:ci && pnpm run lint
 
+      - name: Run MRT Utilities tests
+        id: mrt-test
+        if: always() && steps.cli-test.conclusion != 'cancelled'
+        working-directory: packages/mrt-utilities
+        run: pnpm run pretest && pnpm run test:ci && pnpm run lint
+
       - name: Run VS Extension checks
         id: vs-extension-test
-        if: always() && steps.cli-test.conclusion != 'cancelled'
+        if: always() && steps.mrt-test.conclusion != 'cancelled'
         working-directory: packages/b2c-vs-extension
         run: pnpm run typecheck:agent && pnpm run lint
 
@@ -167,8 +173,13 @@ jobs:
         # the Linux-calibrated 70% threshold even though the tests pass.
         # Coverage is still generated and uploaded for inspection.
         run: pnpm run pretest && pnpm run test:ci:win && pnpm run lint
-      - name: Run VS Extension checks
+      - name: Run MRT Utilities tests
+        id: mrt-test
         if: always() && steps.cli-test.conclusion != 'cancelled'
+        working-directory: packages/mrt-utilities
+        run: pnpm run pretest && pnpm run test:ci && pnpm run lint
+      - name: Run VS Extension checks
+        if: always() && steps.mrt-test.conclusion != 'cancelled'
         working-directory: packages/b2c-vs-extension
         run: pnpm run typecheck:agent && pnpm run lint
       - name: Print Windows test failures

--- a/packages/mrt-utilities/package.json
+++ b/packages/mrt-utilities/package.json
@@ -100,6 +100,7 @@
     "format:check": "prettier --check .",
     "pretest": "tsc --noEmit -p test",
     "test": "c8 mocha --forbid-only \"test/**/*.test.ts\"",
+    "test:ci": "c8 mocha --forbid-only --reporter json --reporter-option output=test-results.json \"test/**/*.test.ts\"",
     "test:agent": "mocha --forbid-only --reporter min \"test/**/*.test.ts\"",
     "test:watch": "mocha --watch \"test/**/*.test.ts\""
   },

--- a/packages/mrt-utilities/test/streaming/create-lambda-adapter.test.ts
+++ b/packages/mrt-utilities/test/streaming/create-lambda-adapter.test.ts
@@ -347,7 +347,7 @@ describe('create-lambda-adapter', () => {
             //express 4 style catch-all route, throws an error when installed
             // in express 5, see https://github.com/pillarjs/path-to-regexp#errors
             mockApp.get('/*', dummyCatchAllRoute);
-          } catch (error) {
+          } catch {
             //express 5 style catch-all route
             mockApp.get('/{*splat}', dummyCatchAllRoute);
           }


### PR DESCRIPTION
## Summary
- Add `@salesforce/mrt-utilities` test + lint steps to both Linux and Windows CI jobs — the package was completely absent from CI
- Fix existing lint error: unused `error` variable in `create-lambda-adapter.test.ts`
- Add `test:ci` script to mrt-utilities `package.json` for JSON reporter output (matches other packages)
