### PR TITLE
Fix active config selection in multi-instance dw.json

### DIFF
--- a/.changeset/fix-active-config-selection.md
+++ b/.changeset/fix-active-config-selection.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+Fix `active: true` on `configs[]` instances being ignored unless the root object also has `active: false`

--- a/packages/b2c-tooling-sdk/src/config/dw-json.ts
+++ b/packages/b2c-tooling-sdk/src/config/dw-json.ts
@@ -227,16 +227,13 @@ function selectConfig(json: DwJsonMultiConfig, instanceName?: string): DwJsonCon
   }
 
   // Find active config
-  if (json.active === false) {
-    // Root is inactive, look for active in configs
-    const activeConfig = json.configs.find((c) => c.active === true);
-    if (activeConfig) {
-      logger.trace(
-        {selection: 'active', instanceName: activeConfig.name},
-        `[DwJsonSource] Selected config "${activeConfig.name}" by active flag`,
-      );
-      return activeConfig;
-    }
+  const activeConfig = json.configs.find((c) => c.active === true);
+  if (activeConfig) {
+    logger.trace(
+      {selection: 'active', instanceName: activeConfig.name},
+      `[DwJsonSource] Selected config "${activeConfig.name}" by active flag`,
+    );
+    return activeConfig;
   }
 
   // Default to root config

--- a/packages/b2c-tooling-sdk/test/config/dw-json.test.ts
+++ b/packages/b2c-tooling-sdk/test/config/dw-json.test.ts
@@ -150,6 +150,21 @@ describe('config/dw-json', () => {
       expect(result?.config.name).to.equal('production');
     });
 
+    it('selects active config when root has no active field', async () => {
+      const dwJsonPath = path.join(tempDir, 'dw.json');
+      const multiConfig = {
+        configs: [
+          {name: 'sandbox1', hostname: 'sandbox1.demandware.net', active: true},
+          {name: 'sandbox2', hostname: 'sandbox2.demandware.net'},
+        ],
+      };
+      fs.writeFileSync(dwJsonPath, JSON.stringify(multiConfig));
+
+      const result = await loadDwJson();
+      expect(result?.config.hostname).to.equal('sandbox1.demandware.net');
+      expect(result?.config.name).to.equal('sandbox1');
+    });
+
     it('returns root config when no active config found', async () => {
       const dwJsonPath = path.join(tempDir, 'dw.json');
       const multiConfig = {


### PR DESCRIPTION
## Summary

- Remove overly narrow `json.active === false` guard in `selectConfig()` that prevented `active: true` on `configs[]` instances from being recognized unless the root also had `active: false`
- Add test covering multi-instance dw.json where root has no `active` field

Closes #390
 
## Test plan
