### PR TITLE
396 - added specific error message for stopped sandbox

### DIFF
--- a/packages/b2c-tooling-sdk/src/clients/webdav.ts
+++ b/packages/b2c-tooling-sdk/src/clients/webdav.ts
@@ -286,7 +286,15 @@ export class WebDavClient {
     const response = await this.request(path, {method: 'PUT', headers, body: content});
 
     if (!response.ok) {
-      throw new HTTPError(`PUT failed: ${response.status} ${response.statusText}`, response, 'PUT');
+      const hints: Record<number, string> = {
+        413: '(sandbox may be stopped or unavailable)',
+      };
+      const hint = hints[response.status];
+      throw new HTTPError(
+        `PUT failed: ${response.status} ${response.statusText}${hint ? ` ${hint}` : ''}`,
+        response,
+        'PUT',
+      );
     }
   }
 

--- a/packages/b2c-tooling-sdk/test/clients/webdav.test.ts
+++ b/packages/b2c-tooling-sdk/test/clients/webdav.test.ts
@@ -269,6 +269,27 @@ describe('clients/webdav', () => {
           expect((error as HTTPError).message).to.include('507');
         }
       });
+
+      it('includes sandbox hint in error message on 413', async () => {
+        server.use(
+          http.all(`${BASE_URL}/*`, ({request}) => {
+            if (request.method === 'PUT') {
+              return new HttpResponse(null, {status: 413, statusText: 'Payload Too Large'});
+            }
+            return new HttpResponse(null, {status: 404});
+          }),
+        );
+
+        try {
+          await client.put('Cartridges/v1/large.zip', Buffer.from('content'));
+          expect.fail('Should have thrown');
+        } catch (error) {
+          expect(error).to.be.instanceOf(HTTPError);
+          expect((error as HTTPError).message).to.include('PUT failed');
+          expect((error as HTTPError).message).to.include('413');
+          expect((error as HTTPError).message).to.include('sandbox may be stopped');
+        }
+      });
     });
 
     describe('get', () => {


### PR DESCRIPTION
## Summary

Adds a hint if a sandbox is down and one tries to upload to webdav in that state

## Testing
Unit Testing

## Dependencies

- [ Y ] No net-new third-party dependencies were added
---

- [ Y ] Tests pass (`pnpm test`)
- [ Y ] Code is formatted (`pnpm run format`)
