### PR TITLE
Keep ACH header in origin requests

### DIFF
--- a/.changeset/late-papayas-taste.md
+++ b/.changeset/late-papayas-taste.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/mrt-utilities': patch
+---
+
+Keep ACH header in request

--- a/packages/mrt-utilities/src/middleware/middleware.ts
+++ b/packages/mrt-utilities/src/middleware/middleware.ts
@@ -34,13 +34,7 @@ const CACHING_PATH_BASE = `${MOBIFY_PATH}/caching`;
 const BUNDLE_PATH_BASE = `${MOBIFY_PATH}/bundle`;
 const proxyBasePath = PROXY_PATH_BASE;
 const bundleBasePath = BUNDLE_PATH_BASE;
-const X_HEADERS_TO_REMOVE_ORIGIN = [
-  'x-api-key',
-  'x-apigateway-event',
-  'x-apigateway-context',
-  'x-mobify-access-key',
-  'x-sfdc-access-control',
-];
+const X_HEADERS_TO_REMOVE_ORIGIN = ['x-api-key', 'x-apigateway-event', 'x-apigateway-context', 'x-mobify-access-key'];
 export const X_MOBIFY_REQUEST_CLASS = 'x-mobify-request-class';
 export const X_MOBIFY_QUERYSTRING = 'x-mobify-querystring';
 export const X_MOBIFY_REQUEST_PROCESSOR_LOCAL = 'x-mobify-rp-local';

--- a/packages/mrt-utilities/src/utils/ssr-proxying.ts
+++ b/packages/mrt-utilities/src/utils/ssr-proxying.ts
@@ -777,7 +777,6 @@ export const X_HEADERS_TO_REMOVE_ORIGIN: string[] = [
   'x-apigateway-event',
   'x-apigateway-context',
   'x-mobify-access-key',
-  'x-sfdc-access-control',
 ];
 
 /**

--- a/packages/mrt-utilities/test/middleware.test.ts
+++ b/packages/mrt-utilities/test/middleware.test.ts
@@ -198,6 +198,7 @@ describe('middleware', () => {
 
           expect((mockRequest as Request).headers['x-api-key']).to.be.undefined;
           expect((mockRequest as Request).headers['x-mobify-access-key']).to.be.undefined;
+          expect((mockRequest as Request).headers['x-sfdc-access-control']).to.equal('control');
           expect((mockRequest as Request).headers['content-type']).to.equal('application/json');
         });
 


### PR DESCRIPTION
## Summary

Keep ACH header in origin requests for further forwarding

## Testing

Deployed to MRT reference app

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
