### PR TITLE
VS Code Safety Mode + content library fixes

### DIFF
--- a/.changeset/asset-query-config.md
+++ b/.changeset/asset-query-config.md
@@ -1,0 +1,7 @@
+---
+'@salesforce/b2c-tooling-sdk': minor
+'@salesforce/b2c-cli': minor
+'b2c-vs-extension': minor
+---
+
+Support `assetQuery` as a first-class config field. Set it in `dw.json` (per-instance), in `package.json` under `b2c`, or via `SFCC_ASSET_QUERY` to control which JSON dot-paths are extracted as assets during content library parsing. The VS Code Content Libraries tree and `b2c content export` both honor it automatically; the `--asset-query` flag still wins when provided, and the fallback remains `["image.path"]`.

--- a/.changeset/vscode-content-tree-instance-switch.md
+++ b/.changeset/vscode-content-tree-instance-switch.md
@@ -1,0 +1,5 @@
+---
+'b2c-vs-extension': patch
+---
+
+Fix Content Libraries tree not updating when switching instances. The tree previously kept libraries from the old instance; it now re-seeds from the newly active instance's configured `contentLibrary` on switch.

--- a/.changeset/vscode-safety-middleware.md
+++ b/.changeset/vscode-safety-middleware.md
@@ -1,0 +1,5 @@
+---
+'b2c-vs-extension': minor
+---
+
+Enforce Safety Mode in the VS Code extension. Destructive operations initiated from the extension (sandbox delete/stop/restart, WebDAV writes, jobs, etc.) now honor `SFCC_SAFETY_LEVEL`, `SFCC_SAFETY_CONFIRM`, `SFCC_SAFETY_CONFIG`, and the per-instance `safety` block in `dw.json`, consistent with the CLI. Every extension command is also evaluated against command rules (e.g. `{ "command": "b2c-dx.sandbox.delete", "action": "block" }`), and confirmation-mode policies surface a native VS Code modal before the command runs.

--- a/packages/b2c-cli/src/commands/content/export.ts
+++ b/packages/b2c-cli/src/commands/content/export.ts
@@ -48,9 +48,8 @@ export default class ContentExport extends JobCommand<typeof ContentExport> {
     }),
     'asset-query': Flags.string({
       char: 'q',
-      description: 'JSON dot-paths for asset extraction',
+      description: 'JSON dot-paths for asset extraction (falls back to config "assetQuery", then ["image.path"])',
       multiple: true,
-      default: ['image.path'],
     }),
     regex: Flags.boolean({
       char: 'r',
@@ -117,12 +116,13 @@ export default class ContentExport extends JobCommand<typeof ContentExport> {
     }
 
     const waitOptions = flags.timeout ? {timeoutSeconds: flags.timeout} : undefined;
+    const assetQuery = flags['asset-query'] ?? this.resolvedConfig.values.assetQuery ?? ['image.path'];
 
     if (flags['dry-run']) {
       const {library} = await this.operations.fetchContentLibrary(this.instance, libraryId, {
         libraryFile: flags['library-file'],
         isSiteLibrary: flags['site-library'],
-        assetQuery: flags['asset-query'],
+        assetQuery,
         keepOrphans: flags['keep-orphans'],
         waitOptions,
       });
@@ -222,7 +222,7 @@ export default class ContentExport extends JobCommand<typeof ContentExport> {
 
     const result = await this.operations.exportContent(this.instance, pageIds, libraryId, outputPath, {
       isSiteLibrary: flags['site-library'],
-      assetQuery: flags['asset-query'],
+      assetQuery,
       libraryFile: flags['library-file'],
       offline: flags.offline,
       folders: flags.folder,

--- a/packages/b2c-tooling-sdk/src/config/dw-json.ts
+++ b/packages/b2c-tooling-sdk/src/config/dw-json.ts
@@ -85,6 +85,8 @@ export interface DwJsonConfig {
   catalogs?: string[];
   /** Library IDs for WebDAV browsing */
   libraries?: string[];
+  /** JSON dot-paths for asset extraction during content library parsing (defaults to ['image.path']) */
+  assetQuery?: string[];
   /** Optional CIP analytics host override */
   cipHost?: string;
   /** Path to PKCS12 certificate file for mTLS (two-factor auth) */

--- a/packages/b2c-tooling-sdk/src/config/mapping.ts
+++ b/packages/b2c-tooling-sdk/src/config/mapping.ts
@@ -161,6 +161,7 @@ export function mapDwJsonToNormalizedConfig(json: DwJsonConfig): NormalizedConfi
     contentLibrary: json.contentLibrary,
     catalogs: json.catalogs,
     libraries: json.libraries,
+    assetQuery: json.assetQuery,
     cipHost: json.cipHost,
     instanceName: json.name,
     authMethods: json.authMethods,
@@ -290,6 +291,9 @@ export function mapNormalizedConfigToDwJson(config: Partial<NormalizedConfig>, n
   }
   if (config.libraries !== undefined) {
     result.libraries = config.libraries;
+  }
+  if (config.assetQuery !== undefined) {
+    result.assetQuery = config.assetQuery;
   }
   if (config.cipHost !== undefined) {
     result.cipHost = config.cipHost;
@@ -442,6 +446,7 @@ export function mergeConfigsWithProtection(
       contentLibrary: overrides.contentLibrary ?? base.contentLibrary,
       catalogs: overrides.catalogs ?? base.catalogs,
       libraries: overrides.libraries ?? base.libraries,
+      assetQuery: overrides.assetQuery ?? base.assetQuery,
       cipHost: overrides.cipHost ?? base.cipHost,
       sandboxApiHost: overrides.sandboxApiHost ?? base.sandboxApiHost,
       realm: overrides.realm ?? base.realm,

--- a/packages/b2c-tooling-sdk/src/config/sources/env-source.ts
+++ b/packages/b2c-tooling-sdk/src/config/sources/env-source.ts
@@ -40,6 +40,7 @@ const ENV_VAR_MAP: Record<string, keyof NormalizedConfig> = {
   SFCC_CARTRIDGES: 'cartridges',
   SFCC_CATALOGS: 'catalogs',
   SFCC_LIBRARIES: 'libraries',
+  SFCC_ASSET_QUERY: 'assetQuery',
   SFCC_AUTH_METHODS: 'authMethods',
   SFCC_ACCOUNT_MANAGER_HOST: 'accountManagerHost',
   SFCC_SANDBOX_API_HOST: 'sandboxApiHost',
@@ -59,7 +60,14 @@ const ENV_VAR_MAP: Record<string, keyof NormalizedConfig> = {
 };
 
 /** Fields that should be parsed as comma-separated arrays. */
-const ARRAY_FIELDS = new Set<keyof NormalizedConfig>(['scopes', 'authMethods', 'cartridges', 'catalogs', 'libraries']);
+const ARRAY_FIELDS = new Set<keyof NormalizedConfig>([
+  'scopes',
+  'authMethods',
+  'cartridges',
+  'catalogs',
+  'libraries',
+  'assetQuery',
+]);
 
 /** Fields that should be parsed as booleans. */
 const BOOLEAN_FIELDS = new Set<keyof NormalizedConfig>(['selfSigned']);

--- a/packages/b2c-tooling-sdk/src/config/sources/package-json-source.ts
+++ b/packages/b2c-tooling-sdk/src/config/sources/package-json-source.ts
@@ -25,6 +25,7 @@ const ALLOWED_FIELDS: (keyof NormalizedConfig)[] = [
   'shortCode',
   'clientId',
   'contentLibrary',
+  'assetQuery',
   'mrtProject',
   'mrtOrigin',
   'accountManagerHost',
@@ -39,6 +40,7 @@ interface PackageJsonB2CConfig {
   shortCode?: string;
   clientId?: string;
   contentLibrary?: string;
+  assetQuery?: string[];
   mrtProject?: string;
   mrtOrigin?: string;
   accountManagerHost?: string;

--- a/packages/b2c-tooling-sdk/src/config/types.ts
+++ b/packages/b2c-tooling-sdk/src/config/types.ts
@@ -115,6 +115,13 @@ export interface NormalizedConfig {
   /** Library IDs for WebDAV browsing */
   libraries?: string[];
 
+  /**
+   * JSON dot-paths for asset extraction from component data during
+   * content library parsing. Used by `content export` and the VS Code
+   * content library browser. Defaults to `['image.path']` when unset.
+   */
+  assetQuery?: string[];
+
   // CIP
   /** Optional CIP analytics host override */
   cipHost?: string;

--- a/packages/b2c-vs-extension/src/api-browser/index.ts
+++ b/packages/b2c-vs-extension/src/api-browser/index.ts
@@ -5,6 +5,7 @@
  */
 import * as vscode from 'vscode';
 import type {B2CExtensionConfig} from '../config-provider.js';
+import {registerSafeCommand} from '../safety.js';
 import {ApiBrowserTreeDataProvider, type SchemaEntry} from './api-browser-tree-provider.js';
 import {SwaggerWebviewManager} from './swagger-webview.js';
 
@@ -21,16 +22,13 @@ export function registerApiBrowser(
     showCollapseAll: true,
   });
 
-  const refreshDisposable = vscode.commands.registerCommand('b2c-dx.apiBrowser.refresh', () => {
+  const refreshDisposable = registerSafeCommand('b2c-dx.apiBrowser.refresh', () => {
     treeProvider.refresh();
   });
 
-  const openSwaggerDisposable = vscode.commands.registerCommand(
-    'b2c-dx.apiBrowser.openSwagger',
-    (schema: SchemaEntry) => {
-      swaggerManager.openSwaggerPanel(schema);
-    },
-  );
+  const openSwaggerDisposable = registerSafeCommand('b2c-dx.apiBrowser.openSwagger', (schema: SchemaEntry) => {
+    swaggerManager.openSwaggerPanel(schema);
+  });
 
   configProvider.onDidReset(() => {
     treeProvider.refresh();

--- a/packages/b2c-vs-extension/src/cap/cap-commands.ts
+++ b/packages/b2c-vs-extension/src/cap/cap-commands.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import type {B2CExtensionConfig} from '../config-provider.js';
 import {openJobLog} from '../job-log-viewer.js';
+import {registerSafeCommand} from '../safety.js';
 
 async function showJobError(err: unknown, instance: B2CInstance, label: string): Promise<void> {
   if (err instanceof JobExecutionError && err.execution.is_log_file_existing) {
@@ -28,7 +29,7 @@ export function registerCapCommands(
   _context: vscode.ExtensionContext,
   configProvider: B2CExtensionConfig,
 ): vscode.Disposable[] {
-  const installCap = vscode.commands.registerCommand('b2c-dx.cap.install', async (uri?: vscode.Uri) => {
+  const installCap = registerSafeCommand('b2c-dx.cap.install', async (uri?: vscode.Uri) => {
     const instance = configProvider.getInstance();
     if (!instance) {
       vscode.window.showErrorMessage('No B2C Commerce instance configured.');

--- a/packages/b2c-vs-extension/src/code-sync/cartridge-commands.ts
+++ b/packages/b2c-vs-extension/src/code-sync/cartridge-commands.ts
@@ -22,6 +22,7 @@ import type {B2CInstance} from '@salesforce/b2c-tooling-sdk/instance';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import type {B2CExtensionConfig} from '../config-provider.js';
+import {registerSafeCommand} from '../safety.js';
 import {CartridgeItem, type CartridgeTreeItem, type CartridgeTreeProvider} from './cartridge-tree-provider.js';
 
 function getInstance(configProvider: B2CExtensionConfig): B2CInstance | undefined {
@@ -420,31 +421,28 @@ export function registerCartridgeCommands(
   const tempDirs: string[] = [];
 
   const disposables = [
-    vscode.commands.registerCommand(
+    registerSafeCommand(
       'b2c-dx.codeSync.downloadCartridge',
       createDownloadCartridgeCommand(configProvider, outputChannel),
     ),
-    vscode.commands.registerCommand(
+    registerSafeCommand(
       'b2c-dx.codeSync.diffCartridge',
       createDiffCartridgeCommand(configProvider, outputChannel, tempDirs),
     ),
-    vscode.commands.registerCommand(
-      'b2c-dx.codeSync.addToSitePath',
-      createAddToSitePathCommand(configProvider, outputChannel),
-    ),
-    vscode.commands.registerCommand(
+    registerSafeCommand('b2c-dx.codeSync.addToSitePath', createAddToSitePathCommand(configProvider, outputChannel)),
+    registerSafeCommand(
       'b2c-dx.codeSync.removeFromSitePath',
       createRemoveFromSitePathCommand(configProvider, outputChannel),
     ),
-    vscode.commands.registerCommand(
+    registerSafeCommand(
       'b2c-dx.codeSync.listCodeVersions',
       createListCodeVersionsCommand(configProvider, treeView, outputChannel),
     ),
-    vscode.commands.registerCommand(
+    registerSafeCommand(
       'b2c-dx.codeSync.createCodeVersion',
       createCreateCodeVersionCommand(configProvider, treeProvider, outputChannel),
     ),
-    vscode.commands.registerCommand(
+    registerSafeCommand(
       'b2c-dx.codeSync.activateCodeVersion',
       createActivateCodeVersionCommand(configProvider, treeView, outputChannel),
     ),

--- a/packages/b2c-vs-extension/src/code-sync/index.ts
+++ b/packages/b2c-vs-extension/src/code-sync/index.ts
@@ -5,6 +5,7 @@
  */
 import * as vscode from 'vscode';
 import type {B2CExtensionConfig} from '../config-provider.js';
+import {registerSafeCommand} from '../safety.js';
 import {CodeSyncManager} from './code-sync-manager.js';
 import {CartridgeTreeProvider, CartridgeItem} from './cartridge-tree-provider.js';
 import {createDeployCommand} from './deploy-command.js';
@@ -21,7 +22,7 @@ export function registerCodeSync(
 
   // --- Core sync commands ---
 
-  const toggleCmd = vscode.commands.registerCommand('b2c-dx.codeSync.toggle', async () => {
+  const toggleCmd = registerSafeCommand('b2c-dx.codeSync.toggle', async () => {
     const instance = configProvider.getInstance();
     if (!instance) {
       vscode.window.showErrorMessage('B2C DX: No B2C Commerce instance configured.');
@@ -32,7 +33,7 @@ export function registerCodeSync(
     treeProvider.refresh();
   });
 
-  const startCmd = vscode.commands.registerCommand('b2c-dx.codeSync.start', async () => {
+  const startCmd = registerSafeCommand('b2c-dx.codeSync.start', async () => {
     const instance = configProvider.getInstance();
     if (!instance) {
       vscode.window.showErrorMessage('B2C DX: No B2C Commerce instance configured.');
@@ -44,18 +45,18 @@ export function registerCodeSync(
     treeProvider.refresh();
   });
 
-  const stopCmd = vscode.commands.registerCommand('b2c-dx.codeSync.stop', async () => {
+  const stopCmd = registerSafeCommand('b2c-dx.codeSync.stop', async () => {
     const hostname = configProvider.getConfig()?.values.hostname ?? '';
     await manager.stopWatch();
     await manager.setPersistedState(hostname, false);
   });
 
-  const deployCmd = vscode.commands.registerCommand(
+  const deployCmd = registerSafeCommand(
     'b2c-dx.codeSync.deploy',
     createDeployCommand(configProvider, manager.outputChannel),
   );
 
-  const refreshCmd = vscode.commands.registerCommand('b2c-dx.codeSync.refreshCartridges', () => {
+  const refreshCmd = registerSafeCommand('b2c-dx.codeSync.refreshCartridges', () => {
     treeProvider.refresh();
     manager.refreshCartridges(configProvider.getWorkingDirectory());
   });
@@ -70,30 +71,24 @@ export function registerCodeSync(
     treeProvider.refresh();
   });
 
-  const uploadCartridgeCmd = vscode.commands.registerCommand(
-    'b2c-dx.codeSync.uploadCartridge',
-    async (item: CartridgeItem) => {
-      const instance = configProvider.getInstance();
-      if (!instance) {
-        vscode.window.showErrorMessage('B2C DX: No B2C Commerce instance configured.');
-        return;
-      }
-      await manager.uploadSingleCartridge(instance, item.cartridge);
-    },
-  );
+  const uploadCartridgeCmd = registerSafeCommand('b2c-dx.codeSync.uploadCartridge', async (item: CartridgeItem) => {
+    const instance = configProvider.getInstance();
+    if (!instance) {
+      vscode.window.showErrorMessage('B2C DX: No B2C Commerce instance configured.');
+      return;
+    }
+    await manager.uploadSingleCartridge(instance, item.cartridge);
+  });
 
-  const uploadToInstanceCmd = vscode.commands.registerCommand(
-    'b2c-dx.codeSync.uploadToInstance',
-    async (uri?: vscode.Uri) => {
-      if (!uri) return;
-      const instance = configProvider.getInstance();
-      if (!instance) {
-        vscode.window.showErrorMessage('B2C DX: No B2C Commerce instance configured.');
-        return;
-      }
-      await manager.uploadFileOrFolder(instance, uri, configProvider.getWorkingDirectory());
-    },
-  );
+  const uploadToInstanceCmd = registerSafeCommand('b2c-dx.codeSync.uploadToInstance', async (uri?: vscode.Uri) => {
+    if (!uri) return;
+    const instance = configProvider.getInstance();
+    if (!instance) {
+      vscode.window.showErrorMessage('B2C DX: No B2C Commerce instance configured.');
+      return;
+    }
+    await manager.uploadFileOrFolder(instance, uri, configProvider.getWorkingDirectory());
+  });
 
   // --- Cartridge commands (download, diff, site path, code versions) ---
   const cartridgeCmdDisposables = registerCartridgeCommands(

--- a/packages/b2c-vs-extension/src/content-tree/content-commands.ts
+++ b/packages/b2c-vs-extension/src/content-tree/content-commands.ts
@@ -13,6 +13,7 @@ import type {ContentConfigProvider} from './content-config.js';
 import type {ContentFileSystemProvider} from './content-fs-provider.js';
 import type {ContentTreeDataProvider, ContentTreeItem} from './content-tree-provider.js';
 import {openJobLog} from '../job-log-viewer.js';
+import {registerSafeCommand} from '../safety.js';
 
 async function showJobError(err: unknown, instance: B2CInstance, label: string): Promise<void> {
   if (err instanceof JobExecutionError && err.execution.is_log_file_existing) {
@@ -33,13 +34,13 @@ export function registerContentCommands(
   treeProvider: ContentTreeDataProvider,
   _fsProvider: ContentFileSystemProvider,
 ): vscode.Disposable[] {
-  const refresh = vscode.commands.registerCommand('b2c-dx.content.refresh', () => {
+  const refresh = registerSafeCommand('b2c-dx.content.refresh', () => {
     configProvider.clearCache();
     configProvider.reset();
     treeProvider.refresh();
   });
 
-  const addLibrary = vscode.commands.registerCommand('b2c-dx.content.addLibrary', async () => {
+  const addLibrary = registerSafeCommand('b2c-dx.content.addLibrary', async () => {
     const id = await vscode.window.showInputBox({
       title: 'Add Content Library',
       prompt: 'Enter the library ID (or site ID for site-private libraries)',
@@ -62,7 +63,7 @@ export function registerContentCommands(
     treeProvider.refresh();
   });
 
-  const removeLibrary = vscode.commands.registerCommand('b2c-dx.content.removeLibrary', (node: ContentTreeItem) => {
+  const removeLibrary = registerSafeCommand('b2c-dx.content.removeLibrary', (node: ContentTreeItem) => {
     if (!node || node.nodeType !== 'library') return;
     configProvider.removeLibrary(node.libraryId);
     treeProvider.refresh();
@@ -111,6 +112,7 @@ export function registerContentCommands(
           return exportContent(instance, contentIds, libraryId, outputPath, {
             isSiteLibrary,
             offline,
+            assetQuery: configProvider.getAssetQuery(),
             onAssetProgress: (_asset, index, total) => {
               progress.report({
                 message: `Downloading asset ${index + 1}/${total}`,
@@ -154,7 +156,7 @@ export function registerContentCommands(
     }
   }
 
-  const exportCmd = vscode.commands.registerCommand(
+  const exportCmd = registerSafeCommand(
     'b2c-dx.content.export',
     async (node: ContentTreeItem, selectedNodes?: ContentTreeItem[]) => {
       const nodes = selectedNodes?.length ? selectedNodes : node ? [node] : [];
@@ -163,7 +165,7 @@ export function registerContentCommands(
     },
   );
 
-  const exportNoAssets = vscode.commands.registerCommand(
+  const exportNoAssets = registerSafeCommand(
     'b2c-dx.content.exportNoAssets',
     async (node: ContentTreeItem, selectedNodes?: ContentTreeItem[]) => {
       const nodes = selectedNodes?.length ? selectedNodes : node ? [node] : [];
@@ -172,7 +174,7 @@ export function registerContentCommands(
     },
   );
 
-  const exportAssets = vscode.commands.registerCommand(
+  const exportAssets = registerSafeCommand(
     'b2c-dx.content.exportAssets',
     async (node: ContentTreeItem, selectedNodes?: ContentTreeItem[]) => {
       const nodes = selectedNodes?.length ? selectedNodes : node ? [node] : [];
@@ -181,7 +183,7 @@ export function registerContentCommands(
     },
   );
 
-  const filter = vscode.commands.registerCommand('b2c-dx.content.filter', async () => {
+  const filter = registerSafeCommand('b2c-dx.content.filter', async () => {
     const current = treeProvider.getFilter();
     const value = await vscode.window.showInputBox({
       title: 'Filter Content',
@@ -193,11 +195,11 @@ export function registerContentCommands(
     treeProvider.setFilter(value || undefined);
   });
 
-  const clearFilter = vscode.commands.registerCommand('b2c-dx.content.clearFilter', () => {
+  const clearFilter = registerSafeCommand('b2c-dx.content.clearFilter', () => {
     treeProvider.setFilter(undefined);
   });
 
-  const importCmd = vscode.commands.registerCommand('b2c-dx.content.import', async (uri?: vscode.Uri) => {
+  const importCmd = registerSafeCommand('b2c-dx.content.import', async (uri?: vscode.Uri) => {
     const instance = configProvider.getInstance();
     if (!instance) {
       vscode.window.showErrorMessage('No B2C Commerce instance configured.');
@@ -236,7 +238,7 @@ export function registerContentCommands(
     vscode.window.showInformationMessage('Site archive imported successfully.');
   });
 
-  const browseWebdav = vscode.commands.registerCommand('b2c-dx.content.browseWebdav', async (node: ContentTreeItem) => {
+  const browseWebdav = registerSafeCommand('b2c-dx.content.browseWebdav', async (node: ContentTreeItem) => {
     if (!node) return;
 
     if (node.nodeType === 'library') {

--- a/packages/b2c-vs-extension/src/content-tree/content-config.ts
+++ b/packages/b2c-vs-extension/src/content-tree/content-config.ts
@@ -19,6 +19,11 @@ export class ContentConfigProvider {
 
   constructor(private readonly configProvider: B2CExtensionConfig) {
     configProvider.onDidReset(() => {
+      // Reset browsed libraries so the next tree refresh re-seeds from the
+      // newly active instance's contentLibrary. Libraries from the previous
+      // instance may not exist on the new one, and the user can re-add any
+      // extras via "Add Library".
+      this.libraries = [];
       this.libraryCache.clear();
     });
   }

--- a/packages/b2c-vs-extension/src/content-tree/content-config.ts
+++ b/packages/b2c-vs-extension/src/content-tree/content-config.ts
@@ -41,6 +41,10 @@ export class ContentConfigProvider {
     return config?.values.contentLibrary ?? config?.values.libraries?.[0];
   }
 
+  getAssetQuery(): string[] | undefined {
+    return this.configProvider.getConfig()?.values.assetQuery;
+  }
+
   getLibraries(): BrowsedLibrary[] {
     return this.libraries;
   }

--- a/packages/b2c-vs-extension/src/content-tree/content-tree-provider.ts
+++ b/packages/b2c-vs-extension/src/content-tree/content-tree-provider.ts
@@ -172,6 +172,7 @@ export class ContentTreeDataProvider implements vscode.TreeDataProvider<ContentT
           async () => {
             const result = await fetchContentLibrary(instance, element.libraryId, {
               isSiteLibrary: element.isSiteLibrary,
+              assetQuery: this.configProvider.getAssetQuery(),
             });
             return result.library;
           },

--- a/packages/b2c-vs-extension/src/extension.ts
+++ b/packages/b2c-vs-extension/src/extension.ts
@@ -15,6 +15,7 @@ import {registerJobLogViewer} from './job-log-viewer.js';
 import {registerContentTree} from './content-tree/index.js';
 import {registerLogs} from './logs/index.js';
 import {initializePlugins} from './plugins.js';
+import {registerSafety} from './safety.js';
 import {registerSandboxTree} from './sandbox-tree/index.js';
 import {registerScaffold} from './scaffold/index.js';
 import {registerApiBrowser} from './api-browser/index.js';
@@ -145,6 +146,8 @@ async function activateInner(context: vscode.ExtensionContext, log: vscode.Outpu
   const configProvider = new B2CExtensionConfig(log, context.workspaceState);
   context.subscriptions.push(configProvider);
   await configProvider.ensureResolved();
+
+  registerSafety(context, configProvider);
 
   const disposable = vscode.commands.registerCommand('b2c-dx.openUI', () => {
     vscode.window.showInformationMessage('B2C DX: Opening Page Designer Assistant.');

--- a/packages/b2c-vs-extension/src/logs/index.ts
+++ b/packages/b2c-vs-extension/src/logs/index.ts
@@ -5,12 +5,13 @@
  */
 import * as vscode from 'vscode';
 import type {B2CExtensionConfig} from '../config-provider.js';
+import {registerSafeCommand} from '../safety.js';
 import {LogTailManager} from './logs-tail.js';
 
 export function registerLogs(context: vscode.ExtensionContext, configProvider: B2CExtensionConfig): void {
   const logManager = new LogTailManager();
 
-  const startTail = vscode.commands.registerCommand('b2c-dx.logs.startTail', async () => {
+  const startTail = registerSafeCommand('b2c-dx.logs.startTail', async () => {
     const instance = configProvider.getInstance();
     if (!instance) {
       vscode.window.showErrorMessage('B2C DX: No B2C Commerce instance configured. Configure dw.json first.');
@@ -19,7 +20,7 @@ export function registerLogs(context: vscode.ExtensionContext, configProvider: B
     await logManager.startTail(instance);
   });
 
-  const stopTail = vscode.commands.registerCommand('b2c-dx.logs.stopTail', async () => {
+  const stopTail = registerSafeCommand('b2c-dx.logs.stopTail', async () => {
     await logManager.stopTail();
   });
 

--- a/packages/b2c-vs-extension/src/safety.ts
+++ b/packages/b2c-vs-extension/src/safety.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {
+  SafetyBlockedError,
+  SafetyConfirmationRequired,
+  SafetyGuard,
+  loadGlobalSafetyConfig,
+  resolveEffectiveSafetyConfig,
+  withSafetyConfirmation,
+} from '@salesforce/b2c-tooling-sdk';
+import {createSafetyMiddleware, globalMiddlewareRegistry} from '@salesforce/b2c-tooling-sdk/clients';
+import {getLogger} from '@salesforce/b2c-tooling-sdk/logging';
+import * as vscode from 'vscode';
+import type {B2CExtensionConfig} from './config-provider.js';
+
+const PROVIDER_NAME = 'vscode-safety-guard';
+
+let currentGuard = new SafetyGuard({level: 'NONE'});
+
+function rebuildGuard(configProvider: B2CExtensionConfig): void {
+  const instanceSafety = configProvider.getConfig()?.values.safety;
+  const globalSafety = loadGlobalSafetyConfig();
+  const effective = resolveEffectiveSafetyConfig(instanceSafety, globalSafety);
+  currentGuard = new SafetyGuard(effective);
+
+  if (effective.level !== 'NONE' || effective.rules?.length || effective.confirm) {
+    getLogger().info(
+      {level: effective.level, confirm: effective.confirm, ruleCount: effective.rules?.length ?? 0},
+      'B2C DX: Safety mode active',
+    );
+  }
+}
+
+/**
+ * Register a single middleware provider that delegates to the current SafetyGuard.
+ *
+ * The registration happens once; `currentGuard` is swapped out on config resets
+ * so existing and future SDK clients both pick up the new policy.
+ */
+export function registerSafety(context: vscode.ExtensionContext, configProvider: B2CExtensionConfig): void {
+  rebuildGuard(configProvider);
+
+  globalMiddlewareRegistry.register({
+    name: PROVIDER_NAME,
+    getMiddleware: () => {
+      if (currentGuard.config.level === 'NONE' && !currentGuard.config.rules?.length) {
+        return undefined;
+      }
+      return createSafetyMiddleware(currentGuard);
+    },
+  });
+
+  context.subscriptions.push(
+    configProvider.onDidReset(() => rebuildGuard(configProvider)),
+    {dispose: () => globalMiddlewareRegistry.unregister(PROVIDER_NAME)},
+  );
+}
+
+/**
+ * Run a destructive SDK operation with VS Code-idiomatic safety confirmation.
+ *
+ * If the configured safety policy requires confirmation, a modal warning dialog
+ * is shown. On `Proceed`, the operation is retried with a scoped exemption. On
+ * cancel, the SDK throws a `SafetyBlockedError` — callers should let it surface
+ * to their existing error handling.
+ *
+ * @example
+ * ```ts
+ * const result = await runWithSafety(
+ *   () => odsClient.DELETE('/sandboxes/{sandboxId}', {params: {path: {sandboxId}}}),
+ *   `Delete sandbox "${sandboxId}"?`,
+ * );
+ * ```
+ */
+export function runWithSafety<T>(operation: () => Promise<T>, detail?: string): Promise<T> {
+  return withSafetyConfirmation(currentGuard, operation, async (evaluation) => {
+    const message = detail ? `${detail}\n\n${evaluation.reason}` : evaluation.reason;
+    const choice = await vscode.window.showWarningMessage(message, {modal: true}, 'Proceed');
+    return choice === 'Proceed';
+  });
+}
+
+/**
+ * Register a VS Code command with automatic safety evaluation.
+ *
+ * Before the handler runs, the command ID is evaluated against the SafetyGuard:
+ * - `allow` (or no matching rule): the handler runs as normal.
+ * - `block`: the handler is skipped and an error toast is shown.
+ * - `confirm`: a modal warning dialog is shown; on `Proceed` the handler runs
+ *   with a scoped exemption so downstream HTTP middleware won't re-prompt for
+ *   the same command operation.
+ *
+ * This mirrors how `BaseCommand.evaluateCommandSafety()` runs on every oclif
+ * command. Use this anywhere you'd otherwise call `vscode.commands.registerCommand`.
+ */
+// Matches vscode.commands.registerCommand's own signature, which uses any[] for context-menu args.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function registerSafeCommand(commandId: string, handler: (...args: any[]) => any): vscode.Disposable {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return vscode.commands.registerCommand(commandId, async (...args: any[]) => {
+    try {
+      currentGuard.assert({type: 'command', commandId});
+    } catch (err) {
+      if (err instanceof SafetyBlockedError) {
+        await vscode.window.showErrorMessage(`B2C DX: Blocked by safety policy — ${err.message}`);
+        return undefined;
+      }
+      if (err instanceof SafetyConfirmationRequired) {
+        const choice = await vscode.window.showWarningMessage(
+          `B2C DX: ${err.evaluation.reason}. Proceed?`,
+          {modal: true},
+          'Proceed',
+        );
+        if (choice !== 'Proceed') return undefined;
+        const release = currentGuard.temporarilyAllow(err.evaluation.operation);
+        try {
+          return await handler(...args);
+        } finally {
+          release();
+        }
+      }
+      throw err;
+    }
+    return handler(...args);
+  });
+}

--- a/packages/b2c-vs-extension/src/sandbox-tree/sandbox-commands.ts
+++ b/packages/b2c-vs-extension/src/sandbox-tree/sandbox-commands.ts
@@ -6,6 +6,7 @@
 import {getApiErrorMessage} from '@salesforce/b2c-tooling-sdk';
 import {createOdsClient} from '@salesforce/b2c-tooling-sdk/clients';
 import * as vscode from 'vscode';
+import {registerSafeCommand, runWithSafety} from '../safety.js';
 import type {SandboxConfigProvider} from './sandbox-config.js';
 import type {RealmTreeItem, SandboxTreeDataProvider, SandboxTreeItem} from './sandbox-tree-provider.js';
 
@@ -47,11 +48,11 @@ export function registerSandboxCommands(
     SANDBOX_DETAIL_SCHEME,
     detailProvider,
   );
-  const refresh = vscode.commands.registerCommand('b2c-dx.sandbox.refresh', () => {
+  const refresh = registerSafeCommand('b2c-dx.sandbox.refresh', () => {
     treeProvider.refresh();
   });
 
-  const addRealm = vscode.commands.registerCommand('b2c-dx.sandbox.addRealm', async () => {
+  const addRealm = registerSafeCommand('b2c-dx.sandbox.addRealm', async () => {
     const defaultRealm = configProvider.getDefaultRealm();
     const realm = await vscode.window.showInputBox({
       title: 'Add Realm',
@@ -65,13 +66,13 @@ export function registerSandboxCommands(
     treeProvider.refresh();
   });
 
-  const removeRealm = vscode.commands.registerCommand('b2c-dx.sandbox.removeRealm', (node: RealmTreeItem) => {
+  const removeRealm = registerSafeCommand('b2c-dx.sandbox.removeRealm', (node: RealmTreeItem) => {
     if (!node || node.nodeType !== 'realm') return;
     configProvider.removeRealm(node.realm);
     treeProvider.refresh();
   });
 
-  const create = vscode.commands.registerCommand('b2c-dx.sandbox.create', async (node?: RealmTreeItem) => {
+  const create = registerSafeCommand('b2c-dx.sandbox.create', async (node?: RealmTreeItem) => {
     // Use the realm directly when invoked from a realm context menu, otherwise prompt
     let realm: string | undefined;
     if (node?.nodeType === 'realm') {
@@ -126,7 +127,7 @@ export function registerSandboxCommands(
     );
   });
 
-  const deleteSandbox = vscode.commands.registerCommand('b2c-dx.sandbox.delete', async (node: SandboxTreeItem) => {
+  const deleteSandbox = registerSafeCommand('b2c-dx.sandbox.delete', async (node: SandboxTreeItem) => {
     if (!node) return;
     const choice = await vscode.window.showWarningMessage(
       `Delete sandbox "${node.sandbox.id}"? This cannot be undone.`,
@@ -141,9 +142,10 @@ export function registerSandboxCommands(
       async () => {
         try {
           const odsClient = await getOdsClientFromConfig(configProvider);
-          const result = await odsClient.DELETE('/sandboxes/{sandboxId}', {
-            params: {path: {sandboxId: node.sandbox.id}},
-          });
+          const result = await runWithSafety(
+            () => odsClient.DELETE('/sandboxes/{sandboxId}', {params: {path: {sandboxId: node.sandbox.id}}}),
+            `Delete sandbox "${node.sandbox.id}"?`,
+          );
           if (result.error) {
             vscode.window.showErrorMessage(
               `Sandbox delete failed: ${getApiErrorMessage(result.error, result.response)}`,
@@ -182,10 +184,14 @@ export function registerSandboxCommands(
       async () => {
         try {
           const odsClient = await getOdsClientFromConfig(configProvider);
-          const result = await odsClient.POST('/sandboxes/{sandboxId}/operations', {
-            params: {path: {sandboxId: node.sandbox.id}},
-            body: {operation: operationType},
-          });
+          const result = await runWithSafety(
+            () =>
+              odsClient.POST('/sandboxes/{sandboxId}/operations', {
+                params: {path: {sandboxId: node.sandbox.id}},
+                body: {operation: operationType},
+              }),
+            `${operationType.charAt(0).toUpperCase() + operationType.slice(1)} sandbox "${node.sandbox.id}"?`,
+          );
           if (result.error) {
             vscode.window.showErrorMessage(
               `Sandbox ${operationType} failed: ${getApiErrorMessage(result.error, result.response)}`,
@@ -203,11 +209,11 @@ export function registerSandboxCommands(
     );
   };
 
-  const start = vscode.commands.registerCommand('b2c-dx.sandbox.start', sandboxOperation('start'));
-  const stop = vscode.commands.registerCommand('b2c-dx.sandbox.stop', sandboxOperation('stop'));
-  const restart = vscode.commands.registerCommand('b2c-dx.sandbox.restart', sandboxOperation('restart'));
+  const start = registerSafeCommand('b2c-dx.sandbox.start', sandboxOperation('start'));
+  const stop = registerSafeCommand('b2c-dx.sandbox.stop', sandboxOperation('stop'));
+  const restart = registerSafeCommand('b2c-dx.sandbox.restart', sandboxOperation('restart'));
 
-  const viewDetails = vscode.commands.registerCommand('b2c-dx.sandbox.viewDetails', async (node: SandboxTreeItem) => {
+  const viewDetails = registerSafeCommand('b2c-dx.sandbox.viewDetails', async (node: SandboxTreeItem) => {
     if (!node) return;
     await vscode.window.withProgress(
       {location: vscode.ProgressLocation.Notification, title: 'Fetching sandbox details...'},
@@ -232,7 +238,7 @@ export function registerSandboxCommands(
     );
   });
 
-  const openBM = vscode.commands.registerCommand('b2c-dx.sandbox.openBM', async (node: SandboxTreeItem) => {
+  const openBM = registerSafeCommand('b2c-dx.sandbox.openBM', async (node: SandboxTreeItem) => {
     if (!node?.sandbox.hostName) {
       vscode.window.showWarningMessage('No hostname available for this sandbox.');
       return;
@@ -240,54 +246,51 @@ export function registerSandboxCommands(
     await vscode.env.openExternal(vscode.Uri.parse(`https://${node.sandbox.hostName}/on/demandware.store/Sites-Site`));
   });
 
-  const extendExpiration = vscode.commands.registerCommand(
-    'b2c-dx.sandbox.extendExpiration',
-    async (node: SandboxTreeItem) => {
-      if (!node) return;
+  const extendExpiration = registerSafeCommand('b2c-dx.sandbox.extendExpiration', async (node: SandboxTreeItem) => {
+    if (!node) return;
 
-      const ttlStr = await vscode.window.showInputBox({
-        title: `Extend Expiration — ${node.label ?? node.sandbox.id}`,
-        prompt: 'Hours to add to sandbox lifetime (0 = infinite)',
-        value: '24',
-        validateInput: (v) => {
-          const n = Number(v);
-          if (Number.isNaN(n) || n < 0) return 'Enter a non-negative number';
-          return null;
-        },
-      });
-      if (ttlStr === undefined) return;
-      const ttl = Number(ttlStr);
+    const ttlStr = await vscode.window.showInputBox({
+      title: `Extend Expiration — ${node.label ?? node.sandbox.id}`,
+      prompt: 'Hours to add to sandbox lifetime (0 = infinite)',
+      value: '24',
+      validateInput: (v) => {
+        const n = Number(v);
+        if (Number.isNaN(n) || n < 0) return 'Enter a non-negative number';
+        return null;
+      },
+    });
+    if (ttlStr === undefined) return;
+    const ttl = Number(ttlStr);
 
-      await vscode.window.withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          title: `Extending expiration for sandbox ${node.sandbox.id}...`,
-        },
-        async () => {
-          try {
-            const odsClient = await getOdsClientFromConfig(configProvider);
-            const result = await odsClient.PATCH('/sandboxes/{sandboxId}', {
-              params: {path: {sandboxId: node.sandbox.id}},
-              body: {ttl},
-            });
-            if (result.error) {
-              vscode.window.showErrorMessage(
-                `Failed to extend expiration: ${getApiErrorMessage(result.error, result.response)}`,
-              );
-              return;
-            }
-            const message =
-              ttl === 0 ? 'Sandbox expiration removed (infinite).' : `Sandbox expiration extended by ${ttl} hours.`;
-            vscode.window.showInformationMessage(message);
-            treeProvider.refreshRealm(node.realm);
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            vscode.window.showErrorMessage(`Failed to extend expiration: ${message}`);
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `Extending expiration for sandbox ${node.sandbox.id}...`,
+      },
+      async () => {
+        try {
+          const odsClient = await getOdsClientFromConfig(configProvider);
+          const result = await odsClient.PATCH('/sandboxes/{sandboxId}', {
+            params: {path: {sandboxId: node.sandbox.id}},
+            body: {ttl},
+          });
+          if (result.error) {
+            vscode.window.showErrorMessage(
+              `Failed to extend expiration: ${getApiErrorMessage(result.error, result.response)}`,
+            );
+            return;
           }
-        },
-      );
-    },
-  );
+          const message =
+            ttl === 0 ? 'Sandbox expiration removed (infinite).' : `Sandbox expiration extended by ${ttl} hours.`;
+          vscode.window.showInformationMessage(message);
+          treeProvider.refreshRealm(node.realm);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          vscode.window.showErrorMessage(`Failed to extend expiration: ${message}`);
+        }
+      },
+    );
+  });
 
   return [
     detailRegistration,

--- a/packages/b2c-vs-extension/src/scaffold/scaffold-commands.ts
+++ b/packages/b2c-vs-extension/src/scaffold/scaffold-commands.ts
@@ -23,6 +23,7 @@ import {
 } from '@salesforce/b2c-tooling-sdk/scaffold';
 import {findCartridges} from '@salesforce/b2c-tooling-sdk/operations/code';
 import type {B2CExtensionConfig} from '../config-provider.js';
+import {registerSafeCommand} from '../safety.js';
 
 interface ScaffoldQuickPickItem extends vscode.QuickPickItem {
   scaffold: Scaffold;
@@ -41,7 +42,7 @@ export function registerScaffoldCommands(
   log: vscode.OutputChannel,
   builtInScaffoldsDir: string,
 ): vscode.Disposable[] {
-  const generate = vscode.commands.registerCommand('b2c-dx.scaffold.generate', async (uri?: vscode.Uri) => {
+  const generate = registerSafeCommand('b2c-dx.scaffold.generate', async (uri?: vscode.Uri) => {
     try {
       await runScaffoldWizard(uri, configProvider, log, builtInScaffoldsDir);
     } catch (err) {

--- a/packages/b2c-vs-extension/src/webdav-tree/webdav-commands.ts
+++ b/packages/b2c-vs-extension/src/webdav-tree/webdav-commands.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import type {B2CExtensionConfig} from '../config-provider.js';
+import {registerSafeCommand} from '../safety.js';
 import {type WebDavFileSystemProvider, webdavPathToUri} from './webdav-fs-provider.js';
 import type {WebDavMappingsProvider} from './webdav-mappings.js';
 import type {WebDavTreeDataProvider, WebDavTreeItem} from './webdav-tree-provider.js';
@@ -19,11 +20,11 @@ export function registerWebDavCommands(
   fsProvider: WebDavFileSystemProvider,
   mappingsProvider: WebDavMappingsProvider,
 ): vscode.Disposable[] {
-  const refresh = vscode.commands.registerCommand('b2c-dx.webdav.refresh', () => {
+  const refresh = registerSafeCommand('b2c-dx.webdav.refresh', () => {
     configProvider.reset();
   });
 
-  const newFolder = vscode.commands.registerCommand('b2c-dx.webdav.newFolder', async (node: WebDavTreeItem) => {
+  const newFolder = registerSafeCommand('b2c-dx.webdav.newFolder', async (node: WebDavTreeItem) => {
     if (!node) return;
 
     const name = await vscode.window.showInputBox({
@@ -53,7 +54,7 @@ export function registerWebDavCommands(
     );
   });
 
-  const uploadFile = vscode.commands.registerCommand('b2c-dx.webdav.uploadFile', async (node: WebDavTreeItem) => {
+  const uploadFile = registerSafeCommand('b2c-dx.webdav.uploadFile', async (node: WebDavTreeItem) => {
     if (!node) return;
 
     const uris = await vscode.window.showOpenDialog({
@@ -85,7 +86,7 @@ export function registerWebDavCommands(
     );
   });
 
-  const deleteItem = vscode.commands.registerCommand('b2c-dx.webdav.delete', async (node: WebDavTreeItem) => {
+  const deleteItem = registerSafeCommand('b2c-dx.webdav.delete', async (node: WebDavTreeItem) => {
     if (!node) return;
 
     const detail = node.isCollection
@@ -112,7 +113,7 @@ export function registerWebDavCommands(
     );
   });
 
-  const download = vscode.commands.registerCommand('b2c-dx.webdav.download', async (node: WebDavTreeItem) => {
+  const download = registerSafeCommand('b2c-dx.webdav.download', async (node: WebDavTreeItem) => {
     if (!node) return;
 
     const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri
@@ -139,13 +140,13 @@ export function registerWebDavCommands(
     );
   });
 
-  const openFile = vscode.commands.registerCommand('b2c-dx.webdav.openFile', async (node: WebDavTreeItem) => {
+  const openFile = registerSafeCommand('b2c-dx.webdav.openFile', async (node: WebDavTreeItem) => {
     if (!node) return;
     const uri = webdavPathToUri(node.webdavPath);
     await vscode.commands.executeCommand('vscode.open', uri);
   });
 
-  const newFile = vscode.commands.registerCommand('b2c-dx.webdav.newFile', async (node: WebDavTreeItem) => {
+  const newFile = registerSafeCommand('b2c-dx.webdav.newFile', async (node: WebDavTreeItem) => {
     if (!node) return;
 
     const name = await vscode.window.showInputBox({
@@ -177,7 +178,7 @@ export function registerWebDavCommands(
     );
   });
 
-  const mountWorkspace = vscode.commands.registerCommand('b2c-dx.webdav.mountWorkspace', (node: WebDavTreeItem) => {
+  const mountWorkspace = registerSafeCommand('b2c-dx.webdav.mountWorkspace', (node: WebDavTreeItem) => {
     if (!node) return;
     const uri = webdavPathToUri(node.webdavPath);
     vscode.workspace.updateWorkspaceFolders(vscode.workspace.workspaceFolders?.length ?? 0, 0, {
@@ -186,7 +187,7 @@ export function registerWebDavCommands(
     });
   });
 
-  const addCatalog = vscode.commands.registerCommand('b2c-dx.webdav.addCatalog', async () => {
+  const addCatalog = registerSafeCommand('b2c-dx.webdav.addCatalog', async () => {
     const instance = configProvider.getInstance();
 
     // Try OCAPI discovery first
@@ -232,12 +233,12 @@ export function registerWebDavCommands(
     }
   });
 
-  const removeCatalog = vscode.commands.registerCommand('b2c-dx.webdav.removeCatalog', (node: WebDavTreeItem) => {
+  const removeCatalog = registerSafeCommand('b2c-dx.webdav.removeCatalog', (node: WebDavTreeItem) => {
     if (!node || node.nodeType !== 'catalog-mapping') return;
     mappingsProvider.removeCatalog(node.fileName);
   });
 
-  const addLibrary = vscode.commands.registerCommand('b2c-dx.webdav.addLibrary', async () => {
+  const addLibrary = registerSafeCommand('b2c-dx.webdav.addLibrary', async () => {
     const id = await vscode.window.showInputBox({
       title: 'Add Library',
       prompt: 'Enter the library ID',
@@ -252,12 +253,12 @@ export function registerWebDavCommands(
     mappingsProvider.addLibrary(id.trim());
   });
 
-  const removeLibrary = vscode.commands.registerCommand('b2c-dx.webdav.removeLibrary', (node: WebDavTreeItem) => {
+  const removeLibrary = registerSafeCommand('b2c-dx.webdav.removeLibrary', (node: WebDavTreeItem) => {
     if (!node || node.nodeType !== 'library-mapping') return;
     mappingsProvider.removeLibrary(node.fileName);
   });
 
-  const revealLibrary = vscode.commands.registerCommand('b2c-dx.webdav.revealLibrary', async (libraryId: string) => {
+  const revealLibrary = registerSafeCommand('b2c-dx.webdav.revealLibrary', async (libraryId: string) => {
     if (!libraryId) return;
 
     // Ensure library is in mappings
@@ -277,7 +278,7 @@ export function registerWebDavCommands(
     }
   });
 
-  const revealPath = vscode.commands.registerCommand('b2c-dx.webdav.revealPath', async (webdavPath: string) => {
+  const revealPath = registerSafeCommand('b2c-dx.webdav.revealPath', async (webdavPath: string) => {
     if (!webdavPath) return;
 
     // Ensure the parent library is in mappings if this is a Libraries path


### PR DESCRIPTION
## Summary

- **Enforce Safety Mode in the VS Code extension.** Register the SDK safety middleware on the global middleware registry from the extension so destructive HTTP calls honor `SFCC_SAFETY_LEVEL`, `SFCC_SAFETY_CONFIRM`, `SFCC_SAFETY_CONFIG`, and per-instance `safety` blocks in `dw.json`. Add `registerSafeCommand()` which evaluates every VS Code command against the guard (command rules like `{ "command": "b2c-dx.sandbox.delete", "action": "block" }`), mirroring `BaseCommand.evaluateCommandSafety()`. Sandbox destructive ops additionally flow through `runWithSafety()` for a native VS Code confirm modal.
- **Fix Content Libraries tree stale on instance switch.** `ContentConfigProvider` now also clears browsed libraries (not just the cache) on `onDidReset`, so the tree re-seeds from the new instance's `contentLibrary`.
- **Support `assetQuery` as a first-class config field.** Settable in `dw.json`, `package.json` `b2c` block, or `SFCC_ASSET_QUERY`. VS Code tree + `b2c content export` both honor it; `--asset-query` flag still wins when provided.

## Notes

- CLI and extension command IDs differ (oclif `sandbox:delete` vs VS Code `b2c-dx.sandbox.delete`) — rules are not portable verbatim between them. Worth calling out in the Safety docs as a follow-up.
- `setup inspect` doesn't render the `safety` section (pre-existing display gap noticed during this work). Not fixed here; small follow-up.

## Test plan

- [ ] VS Code — set `SFCC_SAFETY_LEVEL=NO_DELETE` in the host shell; right-click → Delete a sandbox → confirm it blocks with an error toast.
- [ ] VS Code — add `"safety": { "level": "NONE", "rules": [{ "command": "b2c-dx.sandbox.extendExpiration", "action": "confirm" }] }` to a `dw.json` config → Extend Expiration shows a native modal before prompting for TTL.
- [ ] VS Code — switch between two instances with different `contentLibrary` values; Content Libraries tree reloads with the new library and drops the old one.
- [ ] CLI — `b2c content export PAGE_ID -l LIB_ID` uses `assetQuery` from `dw.json` when `--asset-query` is not passed; `--asset-query` still overrides.
- [ ] `pnpm --filter @salesforce/b2c-tooling-sdk run test:agent` and `pnpm --filter @salesforce/b2c-cli run test:agent` both green.