### PR TITLE
Optimize unit-test runtime (~89% reduction)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "pnpm --filter @salesforce/b2c-cli run dev",
     "test": "pnpm -r test",
     "test:unit": "pnpm -r run test:unit",
-    "test:agent": "pnpm -r run test:agent",
+    "test:agent": "pnpm -r --parallel run test:agent",
     "coverage": "pnpm -r run coverage",
     "format": "pnpm -r run format",
     "lint": "pnpm -r run lint",

--- a/packages/b2c-cli/package.json
+++ b/packages/b2c-cli/package.json
@@ -337,7 +337,7 @@
     "test:ci": "c8 env OCLIF_TEST_ROOT=. mocha --forbid-only --exclude \"test/functional/e2e/**\" --reporter json --reporter-option output=test-results.json \"test/**/*.test.ts\"",
     "test:ci:win": "c8 --check-coverage=false env OCLIF_TEST_ROOT=. mocha --forbid-only --exclude \"test/functional/e2e/**\" --reporter json --reporter-option output=test-results.json \"test/**/*.test.ts\"",
     "test:unit": "env OCLIF_TEST_ROOT=. mocha --forbid-only --exclude \"test/functional/e2e/**\" \"test/**/*.test.ts\"",
-    "test:agent": "env OCLIF_TEST_ROOT=. mocha --forbid-only --reporter min --exclude \"test/functional/e2e/**\" \"test/**/*.test.ts\"",
+    "test:agent": "env OCLIF_TEST_ROOT=. mocha --forbid-only --parallel --jobs 4 --reporter min --exclude \"test/functional/e2e/**\" \"test/**/*.test.ts\"",
     "test:e2e": "env TEST_USE_SHARED_SANDBOX=true OCLIF_TEST_ROOT=. mocha --forbid-only --require test/functional/e2e/hooks.ts --node-option import=tsx --timeout 30000 --retries 2 --reporter spec \"test/functional/e2e/**/*.test.ts\"",
     "test:e2e:ci": "env TEST_USE_SHARED_SANDBOX=true OCLIF_TEST_ROOT=. mocha --forbid-only --require test/functional/e2e/hooks.ts --node-option import=tsx --timeout 30000 --retries 2 --reporter json --reporter-option output=test-results.json \"test/functional/e2e/**/*.test.ts\"",
     "test:e2e:auth": "env OCLIF_TEST_ROOT=. mocha --forbid-only \"test/functional/e2e/auth-token.test.ts\"",

--- a/packages/b2c-cli/test/commands/scapi/replications/wait.test.ts
+++ b/packages/b2c-cli/test/commands/scapi/replications/wait.test.ts
@@ -30,7 +30,7 @@ describe('scapi replications wait', () => {
 
     it('waits for process to complete', async () => {
       const command: any = new ReplicationsWait([], config);
-      stubParse(command, {'tenant-id': 'zzxy_prd', timeout: 10, interval: 1}, {'process-id': 'proc-123'});
+      stubParse(command, {'tenant-id': 'zzxy_prd', timeout: 10, interval: 0}, {'process-id': 'proc-123'});
       await command.init();
 
       sinon.stub(command, 'requireOAuthCredentials').returns(void 0);
@@ -74,7 +74,7 @@ describe('scapi replications wait', () => {
 
     it('returns failed status', async () => {
       const command: any = new ReplicationsWait([], config);
-      stubParse(command, {'tenant-id': 'zzxy_prd', timeout: 10, interval: 1}, {'process-id': 'proc-456'});
+      stubParse(command, {'tenant-id': 'zzxy_prd', timeout: 10, interval: 0}, {'process-id': 'proc-456'});
       await command.init();
 
       sinon.stub(command, 'requireOAuthCredentials').returns(void 0);
@@ -102,7 +102,7 @@ describe('scapi replications wait', () => {
 
     it('logs status updates in non-JSON mode', async () => {
       const command: any = new ReplicationsWait([], config);
-      stubParse(command, {'tenant-id': 'zzxy_prd', timeout: 10, interval: 1}, {'process-id': 'proc-789'});
+      stubParse(command, {'tenant-id': 'zzxy_prd', timeout: 10, interval: 0}, {'process-id': 'proc-789'});
       await command.init();
 
       sinon.stub(command, 'requireOAuthCredentials').returns(void 0);
@@ -164,7 +164,7 @@ describe('scapi replications wait', () => {
 
     it('handles API errors during polling', async () => {
       const command: any = new ReplicationsWait([], config);
-      stubParse(command, {'tenant-id': 'zzxy_prd', timeout: 10, interval: 1}, {'process-id': 'proc-error'});
+      stubParse(command, {'tenant-id': 'zzxy_prd', timeout: 10, interval: 0}, {'process-id': 'proc-error'});
       await command.init();
 
       sinon.stub(command, 'requireOAuthCredentials').returns(void 0);

--- a/packages/b2c-cli/test/setup.ts
+++ b/packages/b2c-cli/test/setup.ts
@@ -12,16 +12,35 @@
  * - Clears all SDK global registries before each test to prevent state leakage
  */
 import {globalMiddlewareRegistry} from '@salesforce/b2c-tooling-sdk/clients';
-import {globalAuthMiddlewareRegistry} from '@salesforce/b2c-tooling-sdk/auth';
+import {
+  globalAuthMiddlewareRegistry,
+  initializeStatefulStore,
+  clearStoredSession,
+} from '@salesforce/b2c-tooling-sdk/auth';
 import {globalConfigSourceRegistry} from '@salesforce/b2c-tooling-sdk/config';
+import {mkdtempSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 
 // Prevent BaseCommand from running plugin hooks during tests
 process.env.B2C_SKIP_PLUGIN_HOOKS = '1';
+
+// Isolate the stateful auth session store to a unique per-process temp dir.
+// Both the test setup and BaseCommand.init() will use this path, so tests
+// (or parallel mocha workers) don't race on the developer's real auth file at
+// ~/Library/Application Support/@salesforce/b2c-cli/auth-session.json.
+const testDataDir = mkdtempSync(join(tmpdir(), 'b2c-cli-test-'));
+process.env.B2C_TEST_DATA_DIR = testDataDir;
+initializeStatefulStore(testDataDir);
 
 export const mochaHooks = {
   beforeEach() {
     globalMiddlewareRegistry.clear();
     globalAuthMiddlewareRegistry.clear();
     globalConfigSourceRegistry.clear();
+    // Re-isolate stateful store path before every test in case a prior test
+    // called resetStatefulStoreForTesting(), and clear any leftover session.
+    initializeStatefulStore(testDataDir);
+    clearStoredSession();
   },
 };

--- a/packages/b2c-tooling-sdk/package.json
+++ b/packages/b2c-tooling-sdk/package.json
@@ -411,7 +411,7 @@
     "test": "c8 mocha --forbid-only \"test/**/*.test.ts\"",
     "test:ci": "c8 mocha --forbid-only --reporter json --reporter-option output=test-results.json \"test/**/*.test.ts\"",
     "test:unit": "mocha --forbid-only \"test/**/*.test.ts\"",
-    "test:agent": "mocha --forbid-only --reporter min \"test/**/*.test.ts\"",
+    "test:agent": "mocha --forbid-only --parallel --jobs 4 --reporter min \"test/**/*.test.ts\"",
     "test:watch": "mocha --watch \"test/**/*.test.ts\"",
     "coverage": "c8 report",
     "posttest": "pnpm run lint",

--- a/packages/b2c-tooling-sdk/src/cli/base-command.ts
+++ b/packages/b2c-tooling-sdk/src/cli/base-command.ts
@@ -166,8 +166,10 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     this.configureLogging();
 
     // Initialize stateful auth store with oclif's data directory so session
-    // files are stored alongside other CLI data (e.g. ~/Library/Application Support/@salesforce/b2c-cli)
-    initializeStatefulStore(this.config.dataDir);
+    // files are stored alongside other CLI data (e.g. ~/Library/Application Support/@salesforce/b2c-cli).
+    // Tests may override the path via B2C_TEST_DATA_DIR to isolate the auth-session.json
+    // file (e.g. per mocha worker) so they don't race on the developer's real session file.
+    initializeStatefulStore(process.env.B2C_TEST_DATA_DIR ?? this.config.dataDir);
 
     // Set CLI User-Agent (CLI name/version only, without @salesforce/ prefix)
     // This must happen before any API clients are created

--- a/packages/b2c-tooling-sdk/src/operations/mrt/env.ts
+++ b/packages/b2c-tooling-sdk/src/operations/mrt/env.ts
@@ -390,6 +390,11 @@ export interface WaitForEnvOptions extends GetEnvOptions {
    * Custom sleep function for testing.
    */
   sleep?: (ms: number) => Promise<void>;
+
+  /**
+   * Custom clock for testing. Defaults to Date.now.
+   */
+  now?: () => number;
 }
 
 async function defaultSleep(ms: number): Promise<void> {
@@ -441,7 +446,8 @@ export async function waitForEnv(options: WaitForEnvOptions, auth: AuthStrategy)
   const {projectSlug, slug, pollIntervalSeconds = 10, timeoutSeconds = 2700, onPoll, origin} = options;
 
   const sleepFn = options.sleep ?? defaultSleep;
-  const startTime = Date.now();
+  const nowFn = options.now ?? Date.now;
+  const startTime = nowFn();
   const pollIntervalMs = pollIntervalSeconds * 1000;
   const timeoutMs = timeoutSeconds * 1000;
 
@@ -450,9 +456,9 @@ export async function waitForEnv(options: WaitForEnvOptions, auth: AuthStrategy)
   await sleepFn(pollIntervalMs);
 
   while (true) {
-    const elapsedSeconds = Math.round((Date.now() - startTime) / 1000);
+    const elapsedSeconds = Math.round((nowFn() - startTime) / 1000);
 
-    if (timeoutSeconds > 0 && Date.now() - startTime > timeoutMs) {
+    if (timeoutSeconds > 0 && nowFn() - startTime > timeoutMs) {
       throw new Error(`Timeout waiting for environment "${slug}" after ${timeoutSeconds}s`);
     }
 

--- a/packages/b2c-tooling-sdk/test/operations/mrt/env.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/mrt/env.test.ts
@@ -312,6 +312,13 @@ describe('operations/mrt/env', () => {
 
       const auth = new MockAuthStrategy();
 
+      // Virtual clock that advances by 1s on every call to simulate timeout without real waiting.
+      let virtualNow = 0;
+      const fakeNow = () => {
+        virtualNow += 1000;
+        return virtualNow;
+      };
+
       try {
         await waitForEnv(
           {
@@ -320,6 +327,7 @@ describe('operations/mrt/env', () => {
             pollIntervalSeconds: 1,
             timeoutSeconds: 1,
             sleep: instantSleep,
+            now: fakeNow,
           },
           auth,
         );

--- a/packages/b2c-tooling-sdk/test/operations/sites/cartridges.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/sites/cartridges.test.ts
@@ -20,6 +20,8 @@ import {
 } from '../../../src/operations/sites/cartridges.js';
 
 const TEST_HOST = 'test.demandware.net';
+// Skip the 3s job-poll interval in tests; the mocked job completes immediately.
+const FAST_POLL = {waitOptions: {pollIntervalSeconds: 0}};
 const BASE_URL = `https://${TEST_HOST}/s/-/dw/data/v25_6`;
 const WEBDAV_BASE = `https://${TEST_HOST}/on/demandware.servlet/webdav/Sites`;
 
@@ -167,7 +169,7 @@ describe('operations/sites/cartridges', () => {
         }),
       );
 
-      const result = await addCartridge(mockInstance, 'Sites-Site', {name: 'new_cart', position: 'first'});
+      const result = await addCartridge(mockInstance, 'Sites-Site', {name: 'new_cart', position: 'first'}, FAST_POLL);
 
       expect(result.cartridges).to.equal('new_cart:existing_cart');
       expect(importedBuffer).to.exist;
@@ -195,7 +197,7 @@ describe('operations/sites/cartridges', () => {
         ...createImportHandlers(),
       );
 
-      const result = await addCartridge(mockInstance, 'RefArch', {name: 'cart_c', position: 'last'});
+      const result = await addCartridge(mockInstance, 'RefArch', {name: 'cart_c', position: 'last'}, FAST_POLL);
 
       expect(result.cartridges).to.equal('cart_a:cart_b:cart_c');
     });
@@ -222,7 +224,7 @@ describe('operations/sites/cartridges', () => {
         ...createImportHandlers(),
       );
 
-      const result = await removeCartridge(mockInstance, 'Sites-Site', 'cart_a');
+      const result = await removeCartridge(mockInstance, 'Sites-Site', 'cart_a', FAST_POLL);
 
       expect(result.cartridges).to.equal('cart_b');
     });
@@ -269,7 +271,7 @@ describe('operations/sites/cartridges', () => {
         }),
       );
 
-      const result = await setCartridgePath(mockInstance, 'Sites-Site', 'bm_cart1:bm_cart2');
+      const result = await setCartridgePath(mockInstance, 'Sites-Site', 'bm_cart1:bm_cart2', FAST_POLL);
 
       expect(result.cartridges).to.equal('bm_cart1:bm_cart2');
 
@@ -293,7 +295,7 @@ describe('operations/sites/cartridges', () => {
         }),
       );
 
-      await setCartridgePath(mockInstance, 'RefArch', 'cart1:cart2');
+      await setCartridgePath(mockInstance, 'RefArch', 'cart1:cart2', FAST_POLL);
 
       const zip = await JSZip.loadAsync(importedBuffer!);
       const files = Object.keys(zip.files);
@@ -317,30 +319,32 @@ describe('operations/sites/cartridges', () => {
     });
 
     it('should add at first position', async () => {
-      const result = await addCartridge(mockInstance, 'Sites-Site', {name: 'new', position: 'first'});
+      const result = await addCartridge(mockInstance, 'Sites-Site', {name: 'new', position: 'first'}, FAST_POLL);
       expect(result.cartridgeList).to.deep.equal(['new', 'cart_a', 'cart_b', 'cart_c']);
     });
 
     it('should add at last position', async () => {
-      const result = await addCartridge(mockInstance, 'Sites-Site', {name: 'new', position: 'last'});
+      const result = await addCartridge(mockInstance, 'Sites-Site', {name: 'new', position: 'last'}, FAST_POLL);
       expect(result.cartridgeList).to.deep.equal(['cart_a', 'cart_b', 'cart_c', 'new']);
     });
 
     it('should add before target', async () => {
-      const result = await addCartridge(mockInstance, 'Sites-Site', {
-        name: 'new',
-        position: 'before',
-        target: 'cart_b',
-      });
+      const result = await addCartridge(
+        mockInstance,
+        'Sites-Site',
+        {name: 'new', position: 'before', target: 'cart_b'},
+        FAST_POLL,
+      );
       expect(result.cartridgeList).to.deep.equal(['cart_a', 'new', 'cart_b', 'cart_c']);
     });
 
     it('should add after target', async () => {
-      const result = await addCartridge(mockInstance, 'Sites-Site', {
-        name: 'new',
-        position: 'after',
-        target: 'cart_b',
-      });
+      const result = await addCartridge(
+        mockInstance,
+        'Sites-Site',
+        {name: 'new', position: 'after', target: 'cart_b'},
+        FAST_POLL,
+      );
       expect(result.cartridgeList).to.deep.equal(['cart_a', 'cart_b', 'new', 'cart_c']);
     });
 


### PR DESCRIPTION
# Optimize unit-test runtime (~89% reduction)

## Summary

Cuts `pnpm run test:agent` from **40.2s → ~4.5s** on a 16-core dev machine (~89%) using only idiomatic, ergonomic changes — no skipped tests, no weakened assertions, no esoteric workarounds. All **4075 tests still pass**, 0 failing, 6 pending unchanged.

## Why each commit

| # | Commit | Idea | Wall-clock |
|---|--------|------|---|
| 1 | `test(sdk): pass pollIntervalSeconds:0 in cartridge import tests` | Nine BM-import tests in `cartridges.test.ts` triggered `waitForJob`'s default 3s poll while the MSW handler resolved instantly. Pass `{waitOptions: {pollIntervalSeconds: 0}}` via the existing public `CartridgeUpdateOptions` API. | 40.2s → 14.4s |
| 2 | `chore: run package test suites concurrently with pnpm -r --parallel` | `pnpm -r run` walks the workspace in topological order (sdk/mrt → cli/mcp). Tests use the `development` workspace condition to import source TS, so packages don't actually need each other's build artifacts. Run them all at once. | 14.4s → 8.8s |
| 3 | `test(cli): pass interval:0 in scapi replications wait tests` | Four tests passed `interval: 1` (one real second per poll) against a stub `fetch`. Use `interval: 0` — the integer flag already accepts it. | (cli pkg: 4s → 3s) |
| 4 | `feat(sdk): inject now() clock into waitForEnv` | The "should timeout after specified duration" test waited 1s of wall time because `waitForEnv` read `Date.now()` directly even though `instantSleep` was injected. Add an optional `now?: () => number` option mirroring the existing `sleep` injection so tests can use a virtual clock. | (sdk pkg: 4s → 3s) |
| 5 | `test(sdk): run mocha --parallel --jobs 4` | SDK has 114 unit-test files and is the wall-clock bottleneck. `mocha --parallel --jobs 4` shards them across worker processes; jobs=4 is the empirical sweet spot under root `pnpm -r --parallel` (jobs=8 oversubscribes the 16-CPU machine and degrades wall time when CLI is also running parallel workers). | 8.9s → 5.2s |
| 6 | `test(cli): run mocha --parallel with per-worker auth-store isolation` | The CLI's stateful auth store is a JSON file in the oclif data dir (`~/Library/Application Support/@salesforce/b2c-cli/auth-session.json`); concurrent `setStoredSession`/`clearStoredSession` calls from parallel mocha workers race on it. Adds an optional `B2C_TEST_DATA_DIR` env override in `BaseCommand.init()`; CLI test setup creates a unique `mkdtemp` directory per worker process and re-asserts the path each `beforeEach` (handles tests that call `resetStatefulStoreForTesting`). Then enables `mocha --parallel --jobs 4` for CLI. | 5.2s → 4.5s |

## Files touched

```
package.json                                                                       |  2 +-
packages/b2c-cli/package.json                                                      |  2 +-
packages/b2c-cli/test/commands/scapi/replications/wait.test.ts                     |  8 ++---
packages/b2c-cli/test/setup.ts                                                     | 17 +++++++++-
packages/b2c-tooling-sdk/package.json                                              |  2 +-
packages/b2c-tooling-sdk/src/cli/base-command.ts                                   |  6 ++--
packages/b2c-tooling-sdk/src/operations/mrt/env.ts                                 | 12 +++++--
packages/b2c-tooling-sdk/test/operations/mrt/env.test.ts                           |  8 +++++
packages/b2c-tooling-sdk/test/operations/sites/cartridges.test.ts                  | 38 +++++++++++++---------
9 files changed, 65 insertions(+), 30 deletions(-)
```

The only production-code changes are:
- `b2c-tooling-sdk/src/cli/base-command.ts`: 1-line env-var override (`B2C_TEST_DATA_DIR`) for the test data dir; production behavior unchanged when the env var is absent.
- `b2c-tooling-sdk/src/operations/mrt/env.ts`: optional `now?: () => number` option on `WaitForEnvOptions`, defaulting to `Date.now`.

Both are additive and back-compat.

## Things tried and rolled back (in case anyone wonders)

- Reducing the 50ms post-flush sleeps in mrt streaming compression tests: 5ms-20ms variants pass locally but mrt isn't on the critical path under `pnpm -r --parallel` and the tighter waits are CI-flake risks.
- `mocha --parallel` for `mrt-utilities` (only 9 test files): worker spawn overhead ≥ savings under root parallel.
- Replacing the 50ms chokidar `setTimeout` waits in `watch.test.ts` with `'ready'`-event sync: introduced 30-50% flake under parallel CPU pressure.

## Review notes

- Each commit is independent in spirit and was developed on its own branch (`autoresearch/test-runtime/01-…` through `06-…`); cherry-picked here in logical order for a single PR.
- No changesets needed — all changes are test-/build-only except the two additive SDK options noted above. Happy to add changesets if the team prefers to surface the new `B2C_TEST_DATA_DIR` env override and `WaitForEnvOptions.now` in release notes.

Draft for now — please flag any concerns about the `B2C_TEST_DATA_DIR` env hook landing in the SDK's public `BaseCommand` surface; happy to rename/scope it differently.
