### PR TITLE
Audit cleanup: concurrency, error handling, DRY pass

### DIFF
--- a/.changeset/audit-cleanup-cli.md
+++ b/.changeset/audit-cleanup-cli.md
@@ -1,0 +1,11 @@
+---
+'@salesforce/b2c-cli': patch
+---
+
+CLI cleanup and correctness fixes:
+
+- `b2c cip query`, `cip describe`, `cip tables`, and `cip report *` now stream output through oclif's `ux.stdout` instead of writing directly to `process.stdout`. This restores the `--json` flag and makes output capturable by tests and CI.
+- Long-running commands (`code:watch`, `logs:tail`, `mrt:tail-logs`) now deregister their SIGINT/SIGTERM handlers when finished, so re-invocations no longer stack handlers on the same process.
+- Hook and signal-handler errors that were previously swallowed (`job:run` afterOperation hooks, `logs:tail` stop, `setup:ide:prophet` console fallbacks) now log at debug instead of disappearing.
+- AM list commands (`am clients|roles|users list`) share a single `amPageSizeFlag` definition.
+- Removed deprecated `LocalSourceResult` re-export.

--- a/.changeset/audit-cleanup-mcp.md
+++ b/.changeset/audit-cleanup-mcp.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/b2c-dx-mcp': patch
+---
+
+- Telemetry send failures are no longer silently swallowed; they now log at debug level so deployment-monitoring drift is visible behind the `--debug` flag.
+- `registerToolsets()` throws a clear error if invoked more than once for the same server instance (instead of producing a cryptic duplicate-tool error from the SDK).

--- a/.changeset/audit-cleanup-mrt.md
+++ b/.changeset/audit-cleanup-mrt.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/mrt-utilities': patch
+---
+
+- The Lambda response adapter's `pipeToDestination` now destroys the destination stream when the underlying pipeline rejects, so consumers fail fast instead of hanging.
+- `pipedDestinations` cleanup is unified between the success and error paths.

--- a/.changeset/audit-cleanup-sdk.md
+++ b/.changeset/audit-cleanup-sdk.md
@@ -1,0 +1,13 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+Hardened auth and long-running operation paths:
+
+- Token store now writes atomically (temp file + rename) so concurrent CLI invocations cannot corrupt `auth-session.json`.
+- `OAuthStrategy.getAccessToken()` coalesces concurrent refreshes onto a single in-flight request, preventing token-endpoint stampedes.
+- Debug session cleans up its keepalive/poll timers if `connect()` fails after starting them.
+- `downloadCartridges` and `deployCartridges` use try/finally around progress timers so an aborted or failing request can no longer leak intervals.
+- New `@salesforce/b2c-tooling-sdk/ux` export surfaces the canonical `confirm()` prompt; CLI re-exports from here.
+- New `auth/jwt-utils` consolidates JWT `exp`/`scope` decoding previously duplicated across three auth strategies.
+- Better error message when the implicit-OAuth port is already in use (suggests `SFCC_OAUTH_LOCAL_PORT`).

--- a/.changeset/audit-cleanup-vsx.md
+++ b/.changeset/audit-cleanup-vsx.md
@@ -1,0 +1,9 @@
+---
+'b2c-vs-extension': patch
+---
+
+VS Code extension reliability fixes:
+
+- Swagger API Browser webview no longer attempts `postMessage` after the panel has been disposed (previously could throw on token refresh or proxy responses arriving after close).
+- Sandbox tree polling no longer stacks "stop-check" timers when the configured polling interval is shorter than the 3-second stabilization window.
+- Code Sync now drains pending uploads/deletes before tearing down its file watchers, so saves immediately preceding a stop are no longer dropped.

--- a/packages/b2c-cli/src/commands/am/clients/list.ts
+++ b/packages/b2c-cli/src/commands/am/clients/list.ts
@@ -7,6 +7,7 @@ import {Flags, Errors} from '@oclif/core';
 import {AmCommand, TableRenderer, type ColumnDef} from '@salesforce/b2c-tooling-sdk/cli';
 import type {AccountManagerApiClient, APIClientCollection} from '@salesforce/b2c-tooling-sdk';
 import {t} from '../../../i18n/index.js';
+import {amPageSizeFlag} from '../../../utils/am/flags.js';
 
 /** Format date as MM/DD/YYYY HH:MM:SS with zero-padding for equal column width. */
 function formatDateEqualLength(value: Date | number | string): string {
@@ -75,10 +76,7 @@ export default class ClientList extends AmCommand<typeof ClientList> {
   ];
 
   static flags = {
-    size: Flags.integer({
-      char: 's',
-      description: 'Page size (default: 20, min: 1, max: 4000)',
-    }),
+    size: amPageSizeFlag,
     page: Flags.integer({
       description: 'Page number (zero-based index, default: 0, min: 0)',
     }),

--- a/packages/b2c-cli/src/commands/am/roles/list.ts
+++ b/packages/b2c-cli/src/commands/am/roles/list.ts
@@ -7,6 +7,7 @@ import {Flags, Errors} from '@oclif/core';
 import {AmCommand, TableRenderer, type ColumnDef} from '@salesforce/b2c-tooling-sdk/cli';
 import type {AccountManagerRole, RoleCollection} from '@salesforce/b2c-tooling-sdk';
 import {t} from '../../../i18n/index.js';
+import {amPageSizeFlag} from '../../../utils/am/flags.js';
 
 const COLUMNS: Record<string, ColumnDef<AccountManagerRole>> = {
   id: {
@@ -64,10 +65,7 @@ export default class RoleList extends AmCommand<typeof RoleList> {
   ];
 
   static flags = {
-    size: Flags.integer({
-      char: 's',
-      description: 'Page size (default: 20, min: 1, max: 4000)',
-    }),
+    size: amPageSizeFlag,
     page: Flags.integer({
       description: 'Page number (zero-based index, default: 0, min: 0)',
     }),

--- a/packages/b2c-cli/src/commands/am/users/list.ts
+++ b/packages/b2c-cli/src/commands/am/users/list.ts
@@ -7,6 +7,7 @@ import {Flags, Errors} from '@oclif/core';
 import {AmCommand, TableRenderer, type ColumnDef} from '@salesforce/b2c-tooling-sdk/cli';
 import type {AccountManagerUser, UserCollection} from '@salesforce/b2c-tooling-sdk';
 import {t} from '../../../i18n/index.js';
+import {amPageSizeFlag} from '../../../utils/am/flags.js';
 
 const COLUMNS: Record<string, ColumnDef<AccountManagerUser>> = {
   mail: {
@@ -89,10 +90,7 @@ export default class UserList extends AmCommand<typeof UserList> {
   ];
 
   static flags = {
-    size: Flags.integer({
-      char: 's',
-      description: 'Page size (default: 20, min: 1, max: 4000)',
-    }),
+    size: amPageSizeFlag,
     page: Flags.integer({
       description: 'Page number (zero-based index, default: 0, min: 0)',
     }),

--- a/packages/b2c-cli/src/commands/cip/describe.ts
+++ b/packages/b2c-cli/src/commands/cip/describe.ts
@@ -8,7 +8,7 @@ import {Args, Flags} from '@oclif/core';
 import {describeCipTable} from '@salesforce/b2c-tooling-sdk';
 import {withDocs} from '../../i18n/index.js';
 import {CipCommand} from '../../utils/cip/command.js';
-import {renderTable, toCsv, type CipOutputFormat} from '../../utils/cip/format.js';
+import {renderTable, writeCsv, writeJson, type CipOutputFormat} from '../../utils/cip/format.js';
 
 const {from: _unusedFrom, to: _unusedTo, ...cipMetadataFlags} = CipCommand.baseFlags;
 
@@ -77,7 +77,7 @@ export default class CipDescribe extends CipCommand<typeof CipDescribe> {
     }
 
     if (this.flags.format === 'json') {
-      process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+      writeJson(output);
       return output;
     }
 
@@ -88,7 +88,7 @@ export default class CipDescribe extends CipCommand<typeof CipDescribe> {
   private renderRows(rows: CipDescribeCommandResult['columns'], format: CipOutputFormat): void {
     const columns = ['column', 'dataType', 'isNullable'];
     if (format === 'csv') {
-      process.stdout.write(`${toCsv(columns, rows)}\n`);
+      writeCsv(columns, rows);
       return;
     }
 

--- a/packages/b2c-cli/src/commands/cip/query.ts
+++ b/packages/b2c-cli/src/commands/cip/query.ts
@@ -8,7 +8,7 @@ import fs from 'node:fs';
 import {Args, Flags} from '@oclif/core';
 import {withDocs} from '../../i18n/index.js';
 import {CipCommand} from '../../utils/cip/command.js';
-import {renderTable, toCsv, type CipOutputFormat} from '../../utils/cip/format.js';
+import {renderTable, writeCsv, writeJson, type CipOutputFormat} from '../../utils/cip/format.js';
 
 interface CipQueryCommandResult {
   columns: string[];
@@ -56,7 +56,7 @@ export default class CipQuery extends CipCommand<typeof CipQuery> {
     }
 
     if (this.flags.format === 'json') {
-      process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+      writeJson(output);
       return output;
     }
 
@@ -66,7 +66,7 @@ export default class CipQuery extends CipCommand<typeof CipQuery> {
 
   private renderRows(columns: string[], rows: Array<Record<string, unknown>>, format: CipOutputFormat): void {
     if (format === 'csv') {
-      process.stdout.write(`${toCsv(columns, rows)}\n`);
+      writeCsv(columns, rows);
       return;
     }
 

--- a/packages/b2c-cli/src/commands/cip/tables.ts
+++ b/packages/b2c-cli/src/commands/cip/tables.ts
@@ -8,7 +8,7 @@ import {Flags} from '@oclif/core';
 import {listCipTables} from '@salesforce/b2c-tooling-sdk';
 import {withDocs} from '../../i18n/index.js';
 import {CipCommand} from '../../utils/cip/command.js';
-import {renderTable, toCsv, type CipOutputFormat} from '../../utils/cip/format.js';
+import {renderTable, writeCsv, writeJson, type CipOutputFormat} from '../../utils/cip/format.js';
 
 const {from: _unusedFrom, to: _unusedTo, ...cipMetadataFlags} = CipCommand.baseFlags;
 
@@ -73,7 +73,7 @@ export default class CipTables extends CipCommand<typeof CipTables> {
     }
 
     if (this.flags.format === 'json') {
-      process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+      writeJson(output);
       return output;
     }
 
@@ -84,7 +84,7 @@ export default class CipTables extends CipCommand<typeof CipTables> {
   private renderRows(rows: CipTablesCommandResult['tables'], format: CipOutputFormat): void {
     const columns = ['table', 'type'];
     if (format === 'csv') {
-      process.stdout.write(`${toCsv(columns, rows)}\n`);
+      writeCsv(columns, rows);
       return;
     }
 

--- a/packages/b2c-cli/src/commands/code/watch.ts
+++ b/packages/b2c-cli/src/commands/code/watch.ts
@@ -83,18 +83,32 @@ export default class CodeWatch extends CartridgeCommand<typeof CodeWatch> {
       );
       this.log(t('commands.code.watch.pressCtrlC', 'Press Ctrl+C to stop'));
 
-      // Keep the process running until interrupted
+      // Keep the process running until interrupted. Capture handler ref so we
+      // can deregister on resolve — otherwise repeated invocations stack handlers.
+      let cleanupRef: (() => void) | undefined;
       await new Promise<void>((resolve) => {
-        const cleanup = () => {
+        let stopping = false;
+        const cleanup = (): void => {
+          if (stopping) return;
+          stopping = true;
           this.log(t('commands.code.watch.stopping', '\nStopping watcher...'));
-          result.stop().then(() => {
-            resolve();
-          });
+          result.stop().then(
+            () => resolve(),
+            (error: unknown) => {
+              this.logger.debug({err: error}, '[code:watch] stop() failed during signal handling');
+              resolve();
+            },
+          );
         };
+        cleanupRef = cleanup;
 
         process.on('SIGINT', cleanup);
         process.on('SIGTERM', cleanup);
       });
+      if (cleanupRef) {
+        process.removeListener('SIGINT', cleanupRef);
+        process.removeListener('SIGTERM', cleanupRef);
+      }
     } catch (error) {
       if (error instanceof Error) {
         this.error(t('commands.code.watch.failed', 'Watch failed: {{message}}', {message: error.message}));

--- a/packages/b2c-cli/src/commands/job/run.ts
+++ b/packages/b2c-cli/src/commands/job/run.ts
@@ -178,12 +178,16 @@ export default class JobRun extends JobCommand<typeof JobRun> {
   }
 
   private handleExecutionError(error: unknown, context: B2COperationContext): never {
-    // Run afterOperation hooks with failure (fire-and-forget, errors ignored)
+    // Fire-and-forget: we're already on the error path and rethrow below; surface
+    // hook failures in the debug log so they aren't completely invisible, but
+    // don't shadow the original error.
     this.runAfterHooks(context, {
       success: false,
       error: error instanceof Error ? error : new Error(String(error)),
       duration: Date.now() - context.startTime,
-    }).catch(() => {});
+    }).catch((error_: unknown) => {
+      this.logger.debug({err: error_}, '[job:run] afterOperation hook failed');
+    });
 
     if (error instanceof Error) {
       this.error(t('commands.job.run.executionFailed', 'Failed to execute job: {{message}}', {message: error.message}));

--- a/packages/b2c-cli/src/commands/logs/tail.ts
+++ b/packages/b2c-cli/src/commands/logs/tail.ts
@@ -140,21 +140,28 @@ export default class LogsTail extends InstanceCommand<typeof LogsTail> {
       },
     });
 
-    // Handle SIGINT (Ctrl+C) for graceful shutdown
-    const handleSignal = async (): Promise<void> => {
+    // Handle SIGINT (Ctrl+C) for graceful shutdown. Capture handler refs so we
+    // can deregister on exit — otherwise repeated invocations of this command
+    // (e.g. in tests) would stack handlers on the global process.
+    let stopping = false;
+    const handleSignal = (): void => {
+      if (stopping) return;
+      stopping = true;
       this.log(t('commands.logs.tail.stopping', '\nStopping log tail...'));
-      await stop();
+      stop().catch((error: unknown) => {
+        this.logger.debug({err: error}, '[logs:tail] stop() failed during signal handling');
+      });
     };
 
-    process.on('SIGINT', () => {
-      handleSignal().catch(() => {});
-    });
-    process.on('SIGTERM', () => {
-      handleSignal().catch(() => {});
-    });
+    process.on('SIGINT', handleSignal);
+    process.on('SIGTERM', handleSignal);
 
-    // Wait for tailing to complete
-    await done;
+    try {
+      await done;
+    } finally {
+      process.removeListener('SIGINT', handleSignal);
+      process.removeListener('SIGTERM', handleSignal);
+    }
 
     this.log(t('commands.logs.tail.stopped', 'Log tailing stopped.'));
   }

--- a/packages/b2c-cli/src/commands/mrt/save-credentials.ts
+++ b/packages/b2c-cli/src/commands/mrt/save-credentials.ts
@@ -12,6 +12,9 @@ import {DEFAULT_MRT_ORIGIN} from '@salesforce/b2c-tooling-sdk/clients';
 import {t, withDocs} from '../../i18n/index.js';
 import {confirm} from '../../prompts.js';
 
+/** Basename of the Mobify-format credentials file in the user's home directory. */
+const MOBIFY_FILE_BASENAME = '.mobify';
+
 interface MobifyConfigFile {
   username?: string;
   api_key?: string;
@@ -107,11 +110,11 @@ export default class MrtSaveCredentials extends BaseCommand<typeof MrtSaveCreden
     if (cloudOrigin) {
       try {
         const url = new URL(cloudOrigin);
-        return path.join(os.homedir(), `.mobify--${url.hostname}`);
+        return path.join(os.homedir(), `${MOBIFY_FILE_BASENAME}--${url.hostname}`);
       } catch {
-        return path.join(os.homedir(), `.mobify--${cloudOrigin}`);
+        return path.join(os.homedir(), `${MOBIFY_FILE_BASENAME}--${cloudOrigin}`);
       }
     }
-    return path.join(os.homedir(), '.mobify');
+    return path.join(os.homedir(), MOBIFY_FILE_BASENAME);
   }
 }

--- a/packages/b2c-cli/src/commands/mrt/tail-logs.ts
+++ b/packages/b2c-cli/src/commands/mrt/tail-logs.ts
@@ -60,10 +60,15 @@ export default class MrtTailLogs extends MrtCommand<typeof MrtTailLogs> {
     const levelFilter = this.flags.level;
     const searchFilter = this.flags.search;
 
-    // Compile search regex (case-insensitive, global for highlighting)
+    // Compile search regexes:
+    //  - `searchTestRegex` (no `g` flag) is used for `.test()` so we don't have
+    //    to manage `lastIndex` on a shared global regex.
+    //  - `searchRegex` (global) is passed to the highlighter to mark every match.
+    let searchTestRegex: RegExp | undefined;
     let searchRegex: RegExp | undefined;
     if (searchFilter) {
       try {
+        searchTestRegex = new RegExp(searchFilter, 'i');
         searchRegex = new RegExp(searchFilter, 'gi');
       } catch {
         this.error(`Invalid search pattern: "${searchFilter}". Must be a valid regular expression.`);
@@ -112,15 +117,10 @@ export default class MrtTailLogs extends MrtCommand<typeof MrtTailLogs> {
           if (upperLevels && (!entry.level || !upperLevels.has(entry.level.toUpperCase()))) return;
 
           // Apply search filter (regex match against message and raw)
-          if (searchRegex) {
-            // Reset lastIndex since we reuse the global regex
-            searchRegex.lastIndex = 0;
-            const matchesMessage = searchRegex.test(entry.message);
-            searchRegex.lastIndex = 0;
-            const matchesRaw = searchRegex.test(entry.raw);
+          if (searchTestRegex) {
+            const matchesMessage = searchTestRegex.test(entry.message);
+            const matchesRaw = searchTestRegex.test(entry.raw);
             if (!matchesMessage && !matchesRaw) return;
-            // Reset for highlighting pass
-            searchRegex.lastIndex = 0;
           }
 
           if (this.jsonEnabled()) {
@@ -147,14 +147,23 @@ export default class MrtTailLogs extends MrtCommand<typeof MrtTailLogs> {
       auth,
     );
 
-    // Graceful shutdown on signals
+    // Graceful shutdown on signals. Capture ref so we can deregister; otherwise
+    // repeated invocations of this command stack handlers on the global process.
+    let stopping = false;
     const handleSignal = (): void => {
+      if (stopping) return;
+      stopping = true;
       stop();
     };
 
     process.on('SIGINT', handleSignal);
     process.on('SIGTERM', handleSignal);
 
-    await done;
+    try {
+      await done;
+    } finally {
+      process.removeListener('SIGINT', handleSignal);
+      process.removeListener('SIGTERM', handleSignal);
+    }
   }
 }

--- a/packages/b2c-cli/src/commands/setup/ide/prophet.ts
+++ b/packages/b2c-cli/src/commands/setup/ide/prophet.ts
@@ -39,13 +39,20 @@ function logProphetDw(message, error) {
   var suffix = error && error.message ? ': ' + String(error.message) : '';
   var line = '[b2c setup ide prophet] ' + message + suffix;
 
+  // Best-effort logging: this script is loaded by external tools (Prophet) where
+  // console may be redirected or unavailable. A failure to log a log message is
+  // not actionable and must not interfere with returning the resolved config.
   try {
     console.error(line);
-  } catch (logError) {}
+  } catch (logError) {
+    /* ignore */
+  }
 
   try {
     console.log(line);
-  } catch (logError) {}
+  } catch (logError) {
+    /* ignore */
+  }
 }
 
 function loadDotEnv() {

--- a/packages/b2c-cli/src/lib/scaffold/source-resolver.ts
+++ b/packages/b2c-cli/src/lib/scaffold/source-resolver.ts
@@ -17,12 +17,6 @@ import {loadConfig} from '@salesforce/b2c-tooling-sdk/cli';
 export {isRemoteSource, validateAgainstSource, type SourceResult} from '@salesforce/b2c-tooling-sdk/scaffold';
 
 /**
- * @deprecated Use SourceResult from '@salesforce/b2c-tooling-sdk/scaffold' instead.
- * This type alias is kept for backwards compatibility.
- */
-export type LocalSourceResult = SourceResult;
-
-/**
  * Resolves a local (non-remote) parameter source.
  * Delegates to SDK function.
  *

--- a/packages/b2c-cli/src/prompts.ts
+++ b/packages/b2c-cli/src/prompts.ts
@@ -3,38 +3,8 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
-import * as readline from 'node:readline';
 
-export interface ConfirmOptions {
-  /** Default to yes when the user presses Enter without typing. Defaults to false (no). */
-  defaultYes?: boolean;
-}
-
-/**
- * Simple yes/no confirmation prompt.
- *
- * @param message - Prompt message (the hint is appended automatically, e.g., "(y/N)" or "(Y/n)")
- * @param options - Options to control default behavior
- * @returns true if user confirmed, false otherwise
- */
-export async function confirm(message: string, options?: ConfirmOptions): Promise<boolean> {
-  const defaultYes = options?.defaultYes ?? false;
-  const hint = defaultYes ? '(Y/n)' : '(y/N)';
-
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stderr,
-  });
-
-  return new Promise((resolve) => {
-    rl.question(`${message} ${hint} `, (answer) => {
-      rl.close();
-      const normalized = answer.trim().toLowerCase();
-      if (normalized === '') {
-        resolve(defaultYes);
-      } else {
-        resolve(normalized === 'y' || normalized === 'yes');
-      }
-    });
-  });
-}
+// Thin re-export to keep existing CLI imports working while consolidating the
+// canonical implementation into the SDK. New code should import directly from
+// `@salesforce/b2c-tooling-sdk/ux`.
+export {confirm, type ConfirmOptions} from '@salesforce/b2c-tooling-sdk/ux';

--- a/packages/b2c-cli/src/utils/am/flags.ts
+++ b/packages/b2c-cli/src/utils/am/flags.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import {Flags} from '@oclif/core';
+
+/**
+ * Page-size flag with the default AM API limits (20 default / 4000 max).
+ * Use this for endpoints that accept the standard "size" pagination param;
+ * orgs uses a slightly different range and defines its own.
+ */
+export const amPageSizeFlag = Flags.integer({
+  char: 's',
+  description: 'Page size (default: 20, min: 1, max: 4000)',
+});

--- a/packages/b2c-cli/src/utils/cip/format.ts
+++ b/packages/b2c-cli/src/utils/cip/format.ts
@@ -35,6 +35,20 @@ export function toCsv(columns: string[], rows: Array<Record<string, unknown>>): 
   return lines.join('\n');
 }
 
+/**
+ * Write CSV-formatted rows to stdout. Uses `ux.stdout` so that test helpers
+ * (`stubCommandConfigAndLogger`/`runSilent`) can capture or silence output —
+ * unlike a raw `process.stdout.write`, which bypasses oclif redirection.
+ */
+export function writeCsv(columns: string[], rows: Array<Record<string, unknown>>): void {
+  ux.stdout(toCsv(columns, rows));
+}
+
+/** Pretty-print a JSON output through `ux.stdout` for the same testability reasons as {@link writeCsv}. */
+export function writeJson(value: unknown): void {
+  ux.stdout(JSON.stringify(value, null, 2));
+}
+
 export function renderTable(columns: string[], rows: Array<Record<string, unknown>>): void {
   if (columns.length === 0) {
     ux.stdout('No columns returned.');

--- a/packages/b2c-cli/src/utils/cip/report-command.ts
+++ b/packages/b2c-cli/src/utils/cip/report-command.ts
@@ -13,7 +13,8 @@ import {
   type CipReportParamDefinition,
 } from '@salesforce/b2c-tooling-sdk';
 import {CipCommand} from './command.js';
-import {renderTable, toCsv, type CipOutputFormat} from './format.js';
+import {renderTable, writeCsv, writeJson, type CipOutputFormat} from './format.js';
+import {ux} from '@oclif/core';
 
 function camelToKebab(str: string): string {
   return str.replaceAll(/[A-Z]/gu, (match) => `-${match.toLowerCase()}`);
@@ -98,7 +99,7 @@ export abstract class CipReportCommand<T extends typeof Command> extends CipComm
 
     const sqlResult = buildCipReportSql(this.reportName, params);
     if (flags.sql === true) {
-      process.stdout.write(`${sqlResult.sql}\n`);
+      ux.stdout(sqlResult.sql);
       return {
         reportName: sqlResult.report.name,
         sql: sqlResult.sql,
@@ -125,7 +126,7 @@ export abstract class CipReportCommand<T extends typeof Command> extends CipComm
     }
 
     if (this.flags.format === 'json') {
-      process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+      writeJson(output);
       return output;
     }
 
@@ -175,7 +176,7 @@ export abstract class CipReportCommand<T extends typeof Command> extends CipComm
 
   private renderRows(columns: string[], rows: Array<Record<string, unknown>>, format: CipOutputFormat): void {
     if (format === 'csv') {
-      process.stdout.write(`${toCsv(columns, rows)}\n`);
+      writeCsv(columns, rows);
       return;
     }
 

--- a/packages/b2c-cli/src/utils/ecdn/base-command.ts
+++ b/packages/b2c-cli/src/utils/ecdn/base-command.ts
@@ -9,7 +9,8 @@ import {createCdnZonesClient, type CdnZonesClient} from '@salesforce/b2c-tooling
 import {t} from '../../i18n/index.js';
 
 /**
- * Format API error for display.
+ * Format API error for display. Used by ECDN call sites that capture the error
+ * but not the response (the SDK's getApiErrorMessage requires both).
  */
 export function formatApiError(error: unknown): string {
   return typeof error === 'object' ? JSON.stringify(error) : String(error);
@@ -28,27 +29,8 @@ export abstract class EcdnCommand<T extends typeof Command> extends OAuthCommand
    */
   protected getCdnZonesClient(): CdnZonesClient {
     if (!this._cdnZonesClient) {
-      const {shortCode, tenantId} = this.resolvedConfig.values;
-
-      if (!shortCode) {
-        this.error(
-          t(
-            'error.shortCodeRequired',
-            'SCAPI short code required. Provide --short-code, set SFCC_SHORTCODE, or configure short-code in dw.json.',
-          ),
-        );
-      }
-      if (!tenantId) {
-        this.error(
-          t(
-            'error.tenantIdRequired',
-            'tenant-id is required. Provide via --tenant-id flag, SFCC_TENANT_ID env var, or tenant-id in dw.json.',
-          ),
-        );
-      }
-
-      const oauthStrategy = this.getOAuthStrategy();
-      this._cdnZonesClient = createCdnZonesClient({shortCode, tenantId}, oauthStrategy);
+      const {shortCode, tenantId} = this.requireScapiCoordinates();
+      this._cdnZonesClient = createCdnZonesClient({shortCode, tenantId}, this.getOAuthStrategy());
     }
     return this._cdnZonesClient;
   }
@@ -58,28 +40,34 @@ export abstract class EcdnCommand<T extends typeof Command> extends OAuthCommand
    */
   protected getCdnZonesRwClient(): CdnZonesClient {
     if (!this._cdnZonesRwClient) {
-      const {shortCode, tenantId} = this.resolvedConfig.values;
-
-      if (!shortCode) {
-        this.error(
-          t(
-            'error.shortCodeRequired',
-            'SCAPI short code required. Provide --short-code, set SFCC_SHORTCODE, or configure short-code in dw.json.',
-          ),
-        );
-      }
-      if (!tenantId) {
-        this.error(
-          t(
-            'error.tenantIdRequired',
-            'tenant-id is required. Provide via --tenant-id flag, SFCC_TENANT_ID env var, or tenant-id in dw.json.',
-          ),
-        );
-      }
-
-      const oauthStrategy = this.getOAuthStrategy();
-      this._cdnZonesRwClient = createCdnZonesClient({shortCode, tenantId}, oauthStrategy, {readWrite: true});
+      const {shortCode, tenantId} = this.requireScapiCoordinates();
+      this._cdnZonesRwClient = createCdnZonesClient({shortCode, tenantId}, this.getOAuthStrategy(), {readWrite: true});
     }
     return this._cdnZonesRwClient;
+  }
+
+  /**
+   * Resolves the SCAPI shortCode + tenantId, raising a uniform user-facing error
+   * if either is missing. Centralized so both client variants stay consistent.
+   */
+  private requireScapiCoordinates(): {shortCode: string; tenantId: string} {
+    const {shortCode, tenantId} = this.resolvedConfig.values;
+    if (!shortCode) {
+      this.error(
+        t(
+          'error.shortCodeRequired',
+          'SCAPI short code required. Provide --short-code, set SFCC_SHORTCODE, or configure short-code in dw.json.',
+        ),
+      );
+    }
+    if (!tenantId) {
+      this.error(
+        t(
+          'error.tenantIdRequired',
+          'tenant-id is required. Provide via --tenant-id flag, SFCC_TENANT_ID env var, or tenant-id in dw.json.',
+        ),
+      );
+    }
+    return {shortCode, tenantId};
   }
 }

--- a/packages/b2c-cli/src/utils/scapi/schemas.ts
+++ b/packages/b2c-cli/src/utils/scapi/schemas.ts
@@ -5,19 +5,12 @@
  */
 import {Command} from '@oclif/core';
 import {OAuthCommand} from '@salesforce/b2c-tooling-sdk/cli';
-import {
-  createScapiSchemasClient,
-  getApiErrorMessage,
-  type ScapiSchemasClient,
-} from '@salesforce/b2c-tooling-sdk/clients';
+import {createScapiSchemasClient, type ScapiSchemasClient} from '@salesforce/b2c-tooling-sdk/clients';
 import {t} from '../../i18n/index.js';
 
-/**
- * Format API error for display.
- */
-export function formatApiError(error: unknown, response: Response): string {
-  return getApiErrorMessage(error, response);
-}
+// Backwards-compatible alias for SDK's getApiErrorMessage; existing call sites
+// use this name. New code should import getApiErrorMessage from the SDK directly.
+export {getApiErrorMessage as formatApiError} from '@salesforce/b2c-tooling-sdk/clients';
 
 /**
  * Base command for SCAPI Schemas operations.

--- a/packages/b2c-cli/src/utils/slas/client.ts
+++ b/packages/b2c-cli/src/utils/slas/client.ts
@@ -113,12 +113,9 @@ export function parseRedirectUris(redirectUri: string): string[] {
     .filter(Boolean);
 }
 
-/**
- * Format API error for display.
- */
-export function formatApiError(error: unknown, response: Response): string {
-  return getApiErrorMessage(error, response);
-}
+// Backwards-compatible alias for SDK's getApiErrorMessage; existing call sites
+// use this name. New code should import getApiErrorMessage from the SDK directly.
+export {getApiErrorMessage as formatApiError} from '@salesforce/b2c-tooling-sdk/clients';
 
 /**
  * Base command for SLAS client operations.
@@ -157,7 +154,7 @@ export abstract class SlasClientCommand<T extends typeof Command> extends OAuthC
 
     this.error(
       t('commands.slas.client.create.tenantError', 'Failed to check tenant: {{message}}', {
-        message: formatApiError(error, response),
+        message: getApiErrorMessage(error, response),
       }),
     );
   }
@@ -195,7 +192,7 @@ export abstract class SlasClientCommand<T extends typeof Command> extends OAuthC
     if (createError) {
       this.error(
         t('commands.slas.client.create.tenantCreateError', 'Failed to create tenant: {{message}}', {
-          message: formatApiError(createError, createResponse),
+          message: getApiErrorMessage(createError, createResponse),
         }),
       );
     }

--- a/packages/b2c-cli/test/commands/auth/token.test.ts
+++ b/packages/b2c-cli/test/commands/auth/token.test.ts
@@ -42,9 +42,12 @@ describe('auth token', () => {
 
     const result = await command.run();
 
-    expect(strategy.getTokenResponse.calledOnce).to.equal(true);
-    expect(result.accessToken).to.equal('token123');
-    expect(result.scopes).to.have.lengthOf(1);
+    expect(strategy.getTokenResponse.calledOnce).to.be.true;
+    expect(result).to.deep.equal({
+      accessToken: 'token123',
+      expires: new Date('2025-01-01T00:00:00.000Z').toISOString(),
+      scopes: ['scope1'],
+    });
   });
 
   it('prints raw token in non-JSON mode', async () => {
@@ -69,6 +72,6 @@ describe('auth token', () => {
 
     await command.run();
 
-    expect(stdoutStub.calledOnce).to.equal(true);
+    expect(stdoutStub.calledOnceWithExactly('token123')).to.be.true;
   });
 });

--- a/packages/b2c-cli/test/commands/cip/describe.test.ts
+++ b/packages/b2c-cli/test/commands/cip/describe.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import CipDescribe from '../../../src/commands/cip/describe.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../helpers/test-setup.js';
 
 describe('cip describe', () => {
   const hooks = createIsolatedConfigHooks();
@@ -101,7 +101,6 @@ describe('cip describe', () => {
 
     sinon.stub(command, 'requireCipCredentials').returns(void 0);
     sinon.stub(command, 'jsonEnabled').returns(false);
-    sinon.stub(process.stdout, 'write');
 
     const mockQueryResult = {
       rows: [
@@ -123,7 +122,7 @@ describe('cip describe', () => {
     };
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.tableName).to.equal('products');
   });
@@ -133,7 +132,6 @@ describe('cip describe', () => {
 
     sinon.stub(command, 'requireCipCredentials').returns(void 0);
     sinon.stub(command, 'jsonEnabled').returns(false);
-    sinon.stub(process.stdout, 'write');
 
     const mockQueryResult = {
       rows: [
@@ -155,7 +153,7 @@ describe('cip describe', () => {
     };
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.tableName).to.equal('customers');
   });

--- a/packages/b2c-cli/test/commands/cip/query.test.ts
+++ b/packages/b2c-cli/test/commands/cip/query.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import CipQuery from '../../../src/commands/cip/query.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../helpers/test-setup.js';
 
 describe('cip query', () => {
   const hooks = createIsolatedConfigHooks();
@@ -107,7 +107,6 @@ describe('cip query', () => {
 
     sinon.stub(command, 'requireCipCredentials').returns(void 0);
     sinon.stub(command, 'jsonEnabled').returns(false);
-    sinon.stub(process.stdout, 'write');
 
     const mockClient = {
       query: sinon.stub().resolves({
@@ -119,7 +118,7 @@ describe('cip query', () => {
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.sql).to.equal('SELECT 1');
   });
@@ -129,7 +128,6 @@ describe('cip query', () => {
 
     sinon.stub(command, 'requireCipCredentials').returns(void 0);
     sinon.stub(command, 'jsonEnabled').returns(false);
-    sinon.stub(process.stdout, 'write');
 
     const mockClient = {
       query: sinon.stub().resolves({
@@ -141,7 +139,7 @@ describe('cip query', () => {
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.sql).to.equal('SELECT 1');
   });

--- a/packages/b2c-cli/test/commands/cip/query.test.ts
+++ b/packages/b2c-cli/test/commands/cip/query.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import CipQuery from '../../../src/commands/cip/query.js';
-import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, expectError, runSilent} from '../../helpers/test-setup.js';
 
 describe('cip query', () => {
   const hooks = createIsolatedConfigHooks();
@@ -42,8 +42,13 @@ describe('cip query', () => {
 
     const result = await command.run();
 
+    // Verify the client received the resolved SQL — not just that the result
+    // echoes the input unchanged, which would pass even if the command dropped it.
+    expect(mockClient.query.calledOnce, 'CIP client should be invoked once').to.be.true;
+    expect(mockClient.query.firstCall.args[0]).to.equal('SELECT 1 as num');
     expect(result.sql).to.equal('SELECT 1 as num');
     expect(result.columns).to.deep.equal(['num']);
+    expect(result.rows).to.deep.equal([{num: 1}]);
     expect(result.rowCount).to.equal(1);
   });
 
@@ -52,13 +57,9 @@ describe('cip query', () => {
 
     const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
 
-    try {
-      await command.run();
-      expect.fail('Should have thrown');
-    } catch {
-      expect(errorStub.called).to.be.true;
-      expect(errorStub.firstCall.args[0]).to.include('No SQL provided');
-    }
+    await expectError(() => command.run());
+    expect(errorStub.called).to.be.true;
+    expect(errorStub.firstCall.args[0]).to.include('No SQL provided');
   });
 
   it('throws error when multiple SQL sources are provided', async () => {
@@ -66,13 +67,9 @@ describe('cip query', () => {
 
     const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
 
-    try {
-      await command.run();
-      expect.fail('Should have thrown');
-    } catch {
-      expect(errorStub.called).to.be.true;
-      expect(errorStub.firstCall.args[0]).to.include('exactly one source');
-    }
+    await expectError(() => command.run());
+    expect(errorStub.called).to.be.true;
+    expect(errorStub.firstCall.args[0]).to.include('exactly one source');
   });
 
   it('replaces FROM and TO placeholders in SQL', async () => {
@@ -120,7 +117,10 @@ describe('cip query', () => {
 
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.sql).to.equal('SELECT 1');
+    expect(mockClient.query.calledOnce).to.be.true;
+    expect(mockClient.query.firstCall.args[0]).to.equal('SELECT 1');
+    expect(result.rowCount).to.equal(1);
+    expect(result.columns).to.deep.equal(['num']);
   });
 
   it('outputs CSV format when format flag is csv', async () => {
@@ -141,6 +141,8 @@ describe('cip query', () => {
 
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.sql).to.equal('SELECT 1');
+    expect(mockClient.query.calledOnce).to.be.true;
+    expect(mockClient.query.firstCall.args[0]).to.equal('SELECT 1');
+    expect(result.rowCount).to.equal(1);
   });
 });

--- a/packages/b2c-cli/test/commands/cip/report/customer-registration-trends.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/customer-registration-trends.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import CustomerRegistrationTrends from '../../../../src/commands/cip/report/customer-registration-trends.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
 describe('cip report customer-registration-trends', () => {
   const hooks = createIsolatedConfigHooks();
@@ -33,9 +33,7 @@ describe('cip report customer-registration-trends', () => {
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-    sinon.stub(process.stdout, 'write');
-
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.reportName).to.equal('customer-registration-trends');
     expect(result.sql).to.be.a('string');

--- a/packages/b2c-cli/test/commands/cip/report/ocapi-requests.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/ocapi-requests.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import OcapiRequests from '../../../../src/commands/cip/report/ocapi-requests.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
 describe('cip report ocapi-requests', () => {
   const hooks = createIsolatedConfigHooks();
@@ -33,9 +33,7 @@ describe('cip report ocapi-requests', () => {
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-    sinon.stub(process.stdout, 'write');
-
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.reportName).to.equal('ocapi-requests');
     expect(result.sql).to.be.a('string');

--- a/packages/b2c-cli/test/commands/cip/report/payment-method-performance.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/payment-method-performance.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import PaymentMethodPerformance from '../../../../src/commands/cip/report/payment-method-performance.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
 describe('cip report payment-method-performance', () => {
   const hooks = createIsolatedConfigHooks();
@@ -33,9 +33,7 @@ describe('cip report payment-method-performance', () => {
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-    sinon.stub(process.stdout, 'write');
-
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.reportName).to.equal('payment-method-performance');
     expect(result.sql).to.be.a('string');

--- a/packages/b2c-cli/test/commands/cip/report/product-co-purchase-analysis.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/product-co-purchase-analysis.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import ProductCoPurchaseAnalysis from '../../../../src/commands/cip/report/product-co-purchase-analysis.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
 describe('cip report product-co-purchase-analysis', () => {
   const hooks = createIsolatedConfigHooks();
@@ -33,9 +33,7 @@ describe('cip report product-co-purchase-analysis', () => {
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-    sinon.stub(process.stdout, 'write');
-
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.reportName).to.equal('product-co-purchase-analysis');
     expect(result.sql).to.be.a('string');

--- a/packages/b2c-cli/test/commands/cip/report/promotion-discount-analysis.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/promotion-discount-analysis.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import PromotionDiscountAnalysis from '../../../../src/commands/cip/report/promotion-discount-analysis.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
 describe('cip report promotion-discount-analysis', () => {
   const hooks = createIsolatedConfigHooks();
@@ -32,9 +32,7 @@ describe('cip report promotion-discount-analysis', () => {
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-    sinon.stub(process.stdout, 'write');
-
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.reportName).to.equal('promotion-discount-analysis');
     expect(result.sql).to.be.a('string');

--- a/packages/b2c-cli/test/commands/cip/report/sales-summary.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/sales-summary.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import SalesSummary from '../../../../src/commands/cip/report/sales-summary.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
 describe('cip report sales-summary', () => {
   const hooks = createIsolatedConfigHooks();
@@ -32,9 +32,7 @@ describe('cip report sales-summary', () => {
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-    sinon.stub(process.stdout, 'write');
-
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.reportName).to.equal('sales-summary');
     expect(result.sql).to.be.a('string');

--- a/packages/b2c-cli/test/commands/cip/report/search-query-performance.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/search-query-performance.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
 describe('cip report search-query-performance', () => {
   const hooks = createIsolatedConfigHooks();
@@ -49,9 +49,7 @@ describe('cip report search-query-performance', () => {
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-    sinon.stub(process.stdout, 'write');
-
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.reportName).to.equal('search-query-performance');
     expect(result.sql).to.be.a('string');

--- a/packages/b2c-cli/test/commands/cip/report/top-referrers.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/top-referrers.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import TopReferrers from '../../../../src/commands/cip/report/top-referrers.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
 describe('cip report top-referrers', () => {
   const hooks = createIsolatedConfigHooks();
@@ -33,9 +33,7 @@ describe('cip report top-referrers', () => {
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-    sinon.stub(process.stdout, 'write');
-
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.reportName).to.equal('top-referrers');
     expect(result.sql).to.be.a('string');

--- a/packages/b2c-cli/test/commands/cip/report/top-selling-products.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/top-selling-products.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import TopSellingProducts from '../../../../src/commands/cip/report/top-selling-products.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
 describe('cip report top-selling-products', () => {
   const hooks = createIsolatedConfigHooks();
@@ -33,9 +33,8 @@ describe('cip report top-selling-products', () => {
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-    sinon.stub(process.stdout, 'write');
 
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.reportName).to.equal('top-selling-products');
     expect(result.sql).to.be.a('string');

--- a/packages/b2c-cli/test/commands/cip/tables.test.ts
+++ b/packages/b2c-cli/test/commands/cip/tables.test.ts
@@ -7,7 +7,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import CipTables from '../../../src/commands/cip/tables.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../helpers/test-setup.js';
 
 describe('cip tables', () => {
   const hooks = createIsolatedConfigHooks();
@@ -114,7 +114,6 @@ describe('cip tables', () => {
 
     sinon.stub(command, 'requireCipCredentials').returns(void 0);
     sinon.stub(command, 'jsonEnabled').returns(false);
-    sinon.stub(process.stdout, 'write');
 
     const mockQueryResult = {
       rows: [{tableSchem: 'warehouse', tableName: 'orders', tableType: 'TABLE'}],
@@ -128,7 +127,7 @@ describe('cip tables', () => {
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.tableCount).to.equal(1);
   });
@@ -138,7 +137,6 @@ describe('cip tables', () => {
 
     sinon.stub(command, 'requireCipCredentials').returns(void 0);
     sinon.stub(command, 'jsonEnabled').returns(false);
-    sinon.stub(process.stdout, 'write');
 
     const mockQueryResult = {
       rows: [{tableSchem: 'warehouse', tableName: 'orders', tableType: 'TABLE'}],
@@ -152,7 +150,7 @@ describe('cip tables', () => {
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
-    const result = await command.run();
+    const result = (await runSilent(() => command.run())) as any;
 
     expect(result.tableCount).to.equal(1);
   });

--- a/packages/b2c-cli/test/commands/code/activate.test.ts
+++ b/packages/b2c-cli/test/commands/code/activate.test.ts
@@ -8,7 +8,7 @@ import {expect} from 'chai';
 import {afterEach, beforeEach} from 'mocha';
 import sinon from 'sinon';
 import CodeActivate from '../../../src/commands/code/activate.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, expectError} from '../../helpers/test-setup.js';
 
 describe('code activate', () => {
   const hooks = createIsolatedConfigHooks();
@@ -39,8 +39,11 @@ describe('code activate', () => {
 
     await command.run();
 
-    expect(patchStub.calledOnce).to.equal(true);
-    expect(patchStub.getCall(0).args[0]).to.equal('/code_versions/{code_version_id}');
+    expect(patchStub.calledOnce).to.be.true;
+    const [path, options] = patchStub.firstCall.args;
+    expect(path).to.equal('/code_versions/{code_version_id}');
+    expect(options?.params?.path).to.deep.equal({code_version_id: 'v1'});
+    expect(options?.body).to.deep.equal({active: true});
   });
 
   it('errors when no code version is provided for activate mode', async () => {
@@ -51,14 +54,10 @@ describe('code activate', () => {
 
     const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
 
-    try {
-      await command.run();
-      expect.fail('Should have thrown');
-    } catch {
-      // expected
-    }
+    await expectError(() => command.run());
 
-    expect(errorStub.calledOnce).to.equal(true);
+    expect(errorStub.calledOnce).to.be.true;
+    expect(errorStub.firstCall.args[0]).to.match(/code version/i);
   });
 
   it('reloads the active code version when --reload is set and no arg is provided', async () => {
@@ -90,8 +89,11 @@ describe('code activate', () => {
 
     await command.run();
 
-    expect(getStub.calledOnce).to.equal(true);
+    expect(getStub.calledOnce).to.be.true;
     expect(patchStub.callCount).to.equal(2);
+    // Reload toggles to alternate then back to active.
+    const calledIds = patchStub.getCalls().map((c) => c.args[1]?.params?.path?.code_version_id);
+    expect(calledIds).to.deep.equal(['v2', 'v1']);
   });
 
   it('calls command.error when reload fails with an error message', async () => {
@@ -102,9 +104,13 @@ describe('code activate', () => {
 
     sinon.stub(command, 'resolvedConfig').get(() => ({values: {hostname: 'example.com', codeVersion: undefined}}));
 
+    // Reload toggles active → alternate → active, so we need at least two versions.
     const getStub = sinon.stub().resolves({
       data: {
-        data: [{id: 'v1', active: true}],
+        data: [
+          {id: 'v1', active: true},
+          {id: 'v2', active: false},
+        ],
       },
       error: undefined,
     });
@@ -120,13 +126,10 @@ describe('code activate', () => {
 
     const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
 
-    try {
-      await command.run();
-      expect.fail('Should have thrown');
-    } catch {
-      // expected
-    }
+    await expectError(() => command.run());
 
-    expect(errorStub.calledOnce).to.equal(true);
+    expect(errorStub.calledOnce).to.be.true;
+    expect(errorStub.firstCall.args[0]).to.include('Failed to reload code version');
+    expect(patchStub.called).to.be.true;
   });
 });

--- a/packages/b2c-cli/test/commands/code/deploy.test.ts
+++ b/packages/b2c-cli/test/commands/code/deploy.test.ts
@@ -8,7 +8,7 @@ import {expect} from 'chai';
 import {afterEach, beforeEach} from 'mocha';
 import sinon from 'sinon';
 import CodeDeploy from '../../../src/commands/code/deploy.js';
-import {createIsolatedConfigHooks, createTestCommand} from '../../helpers/test-setup.js';
+import {createIsolatedConfigHooks, createTestCommand, expectError} from '../../helpers/test-setup.js';
 
 describe('code deploy', () => {
   const hooks = createIsolatedConfigHooks();
@@ -54,14 +54,10 @@ describe('code deploy', () => {
 
     const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
 
-    try {
-      await command.run();
-      expect.fail('Should have thrown');
-    } catch {
-      // expected
-    }
+    await expectError(() => command.run());
 
-    expect(errorStub.calledOnce).to.equal(true);
+    expect(errorStub.calledOnce).to.be.true;
+    expect(errorStub.firstCall.args[0]).to.include('No cartridges found');
   });
 
   it('calls delete + upload and reload when flags are set', async () => {
@@ -86,14 +82,15 @@ describe('code deploy', () => {
 
     const result = await command.run();
 
-    expect(deleteStub.calledOnceWithExactly(instance, cartridges)).to.equal(true);
-    expect(uploadStub.calledOnce).to.equal(true);
+    expect(deleteStub.calledOnceWithExactly(instance, cartridges)).to.be.true;
+    expect(uploadStub.calledOnce).to.be.true;
     expect(uploadStub.firstCall.args[0]).to.equal(instance);
     expect(uploadStub.firstCall.args[1]).to.equal(cartridges);
-    expect(reloadStub.calledOnceWithExactly(instance, 'v1')).to.equal(true);
+    expect(reloadStub.calledOnceWithExactly(instance, 'v1')).to.be.true;
 
     expect(result).to.deep.include({codeVersion: 'v1', activated: true, reloaded: true});
-    expect(afterHooksStub.calledOnce).to.equal(true);
+    expect(afterHooksStub.calledOnce).to.be.true;
+    expect(afterHooksStub.firstCall.args[1]).to.deep.include({success: true});
   });
 
   it('calls activate after deploy when --activate is set', async () => {
@@ -112,7 +109,10 @@ describe('code deploy', () => {
 
     const result = await command.run();
 
-    expect(activateStub.calledOnceWithExactly(instance, 'v1')).to.equal(true);
+    expect(activateStub.calledOnceWithExactly(instance, 'v1')).to.be.true;
+    expect(uploadStub.calledOnce).to.be.true;
+    expect(uploadStub.firstCall.args[0]).to.equal(instance);
+    expect(uploadStub.firstCall.args[1]).to.equal(cartridges);
     expect(result).to.deep.include({codeVersion: 'v1', activated: true, reloaded: false});
   });
 
@@ -132,14 +132,9 @@ describe('code deploy', () => {
 
     const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
 
-    try {
-      await command.run();
-      expect.fail('Should have thrown');
-    } catch {
-      // expected
-    }
+    await expectError(() => command.run());
 
-    expect(errorStub.called).to.equal(true);
+    expect(errorStub.called).to.be.true;
     const errorMessage = errorStub.firstCall.args[0];
     expect(errorMessage).to.include('activate failed');
     expect(errorMessage).to.include('OCAPI');
@@ -161,14 +156,9 @@ describe('code deploy', () => {
 
     const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
 
-    try {
-      await command.run();
-      expect.fail('Should have thrown');
-    } catch {
-      // expected
-    }
+    await expectError(() => command.run());
 
-    expect(errorStub.called).to.equal(true);
+    expect(errorStub.called).to.be.true;
     const errorMessage = errorStub.firstCall.args[0];
     expect(errorMessage).to.include('reload failed');
     expect(errorMessage).to.include('OCAPI');
@@ -185,14 +175,9 @@ describe('code deploy', () => {
 
     const errorStub = sinon.stub(command, 'error').throws(new Error('OAuth required'));
 
-    try {
-      await command.run();
-      expect.fail('Should have thrown');
-    } catch {
-      // expected
-    }
+    await expectError(() => command.run());
 
-    expect(errorStub.calledOnce).to.equal(true);
+    expect(errorStub.calledOnce).to.be.true;
     const errorMessage = errorStub.firstCall.args[0];
     expect(errorMessage).to.include('auto-discover');
   });
@@ -208,14 +193,9 @@ describe('code deploy', () => {
 
     const errorStub = sinon.stub(command, 'error').throws(new Error('OAuth required'));
 
-    try {
-      await command.run();
-      expect.fail('Should have thrown');
-    } catch {
-      // expected
-    }
+    await expectError(() => command.run());
 
-    expect(errorStub.calledOnce).to.equal(true);
+    expect(errorStub.calledOnce).to.be.true;
     const errorMessage = errorStub.firstCall.args[0];
     expect(errorMessage).to.include('activate');
   });
@@ -231,14 +211,9 @@ describe('code deploy', () => {
 
     const errorStub = sinon.stub(command, 'error').throws(new Error('OAuth required'));
 
-    try {
-      await command.run();
-      expect.fail('Should have thrown');
-    } catch {
-      // expected
-    }
+    await expectError(() => command.run());
 
-    expect(errorStub.calledOnce).to.equal(true);
+    expect(errorStub.calledOnce).to.be.true;
     const errorMessage = errorStub.firstCall.args[0];
     expect(errorMessage).to.include('activate');
   });

--- a/packages/b2c-cli/test/commands/mrt/env/var/push.test.ts
+++ b/packages/b2c-cli/test/commands/mrt/env/var/push.test.ts
@@ -125,6 +125,7 @@ describe('mrt env var push', () => {
 
     await command.run();
 
+    expect(listStub.calledOnce, 'remote env vars must be fetched to compute diff').to.be.true;
     expect(setBatchStub.called).to.be.false;
     expect(setStub.called).to.be.false;
   });

--- a/packages/b2c-cli/test/commands/sandbox/create.test.ts
+++ b/packages/b2c-cli/test/commands/sandbox/create.test.ts
@@ -8,7 +8,7 @@ import {expect} from 'chai';
 import sinon from 'sinon';
 import SandboxCreate from '../../../src/commands/sandbox/create.js';
 import {isolateConfig, restoreConfig} from '@salesforce/b2c-tooling-sdk/test-utils';
-import {runSilent} from '../../helpers/test-setup.js';
+import {makeCommandThrowOnError, runSilent, stubOdsClient} from '../../helpers/test-setup.js';
 
 function stubCommandConfigAndLogger(command: any, sandboxApiHost = 'admin.dx.test.com'): void {
   Object.defineProperty(command, 'config', {
@@ -26,24 +26,11 @@ function stubCommandConfigAndLogger(command: any, sandboxApiHost = 'admin.dx.tes
   });
 }
 
-function stubOdsClient(command: any, client: Partial<{GET: any; POST: any; PUT: any; DELETE: any}>): void {
-  Object.defineProperty(command, 'odsClient', {
-    value: client,
-    configurable: true,
-  });
-}
-
 function stubResolvedConfig(command: any, resolvedConfig: Record<string, unknown>): void {
   Object.defineProperty(command, 'resolvedConfig', {
     get: () => ({values: resolvedConfig}),
     configurable: true,
   });
-}
-
-function makeCommandThrowOnError(command: any): void {
-  command.error = (msg: string) => {
-    throw new Error(msg);
-  };
 }
 
 /**

--- a/packages/b2c-cli/test/commands/sandbox/delete.test.ts
+++ b/packages/b2c-cli/test/commands/sandbox/delete.test.ts
@@ -9,6 +9,7 @@ import sinon from 'sinon';
 
 import SandboxDelete from '../../../src/commands/sandbox/delete.js';
 import {isolateConfig, restoreConfig} from '@salesforce/b2c-tooling-sdk/test-utils';
+import {makeCommandThrowOnError, stubOdsClient} from '../../helpers/test-setup.js';
 
 function stubCommandConfigAndLogger(command: any, sandboxApiHost = 'admin.dx.test.com'): void {
   Object.defineProperty(command, 'config', {
@@ -28,19 +29,6 @@ function stubCommandConfigAndLogger(command: any, sandboxApiHost = 'admin.dx.tes
 
 function stubJsonEnabled(command: any, enabled: boolean): void {
   command.jsonEnabled = () => enabled;
-}
-
-function stubOdsClient(command: any, client: Partial<{GET: any; POST: any; PUT: any; DELETE: any}>): void {
-  Object.defineProperty(command, 'odsClient', {
-    value: client,
-    configurable: true,
-  });
-}
-
-function makeCommandThrowOnError(command: any): void {
-  command.error = (msg: string) => {
-    throw new Error(msg);
-  };
 }
 
 /**

--- a/packages/b2c-cli/test/commands/sandbox/get.test.ts
+++ b/packages/b2c-cli/test/commands/sandbox/get.test.ts
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 import SandboxGet from '../../../src/commands/sandbox/get.js';
 import {isolateConfig, restoreConfig} from '@salesforce/b2c-tooling-sdk/test-utils';
-import {runSilent} from '../../helpers/test-setup.js';
+import {makeCommandThrowOnError, runSilent, stubOdsClient} from '../../helpers/test-setup.js';
 
 function stubCommandConfigAndLogger(command: any, sandboxApiHost = 'admin.dx.test.com'): void {
   Object.defineProperty(command, 'config', {
@@ -29,19 +29,6 @@ function stubCommandConfigAndLogger(command: any, sandboxApiHost = 'admin.dx.tes
 
 function stubJsonEnabled(command: any, enabled: boolean): void {
   command.jsonEnabled = () => enabled;
-}
-
-function stubOdsClient(command: any, client: Partial<{GET: any; POST: any; PUT: any; DELETE: any}>): void {
-  Object.defineProperty(command, 'odsClient', {
-    value: client,
-    configurable: true,
-  });
-}
-
-function makeCommandThrowOnError(command: any): void {
-  command.error = (msg: string) => {
-    throw new Error(msg);
-  };
 }
 
 /**

--- a/packages/b2c-cli/test/commands/sandbox/info.test.ts
+++ b/packages/b2c-cli/test/commands/sandbox/info.test.ts
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 import SandboxInfo from '../../../src/commands/sandbox/info.js';
 import {isolateConfig, restoreConfig} from '@salesforce/b2c-tooling-sdk/test-utils';
-import {runSilent} from '../../helpers/test-setup.js';
+import {makeCommandThrowOnError, runSilent} from '../../helpers/test-setup.js';
 
 function stubCommandConfigAndLogger(command: any, sandboxApiHost = 'admin.dx.test.com'): void {
   Object.defineProperty(command, 'config', {
@@ -38,12 +38,6 @@ function stubOdsClientGet(command: any, handler: (path: string) => Promise<any>)
     },
     configurable: true,
   });
-}
-
-function makeCommandThrowOnError(command: any): void {
-  command.error = (msg: string) => {
-    throw new Error(msg);
-  };
 }
 
 /**

--- a/packages/b2c-cli/test/commands/sandbox/ips.test.ts
+++ b/packages/b2c-cli/test/commands/sandbox/ips.test.ts
@@ -12,14 +12,8 @@ import {
   createTestCommand,
   makeCommandThrowOnError,
   runSilent,
+  stubOdsClient,
 } from '../../helpers/test-setup.js';
-
-function stubOdsClient(command: any, client: Partial<{GET: any}>): void {
-  Object.defineProperty(command, 'odsClient', {
-    value: client,
-    configurable: true,
-  });
-}
 
 function stubOdsHost(command: any, host = 'admin.dx.test.com'): void {
   Object.defineProperty(command, 'odsHost', {

--- a/packages/b2c-cli/test/commands/sandbox/list.test.ts
+++ b/packages/b2c-cli/test/commands/sandbox/list.test.ts
@@ -8,7 +8,7 @@ import {expect} from 'chai';
 import sinon from 'sinon';
 import SandboxList, {COLUMNS} from '../../../src/commands/sandbox/list.js';
 import {isolateConfig, restoreConfig} from '@salesforce/b2c-tooling-sdk/test-utils';
-import {runSilent} from '../../helpers/test-setup.js';
+import {makeCommandThrowOnError, runSilent, stubOdsClient} from '../../helpers/test-setup.js';
 
 function stubCommandConfigAndLogger(command: any, sandboxApiHost = 'admin.dx.test.com'): void {
   Object.defineProperty(command, 'config', {
@@ -28,19 +28,6 @@ function stubCommandConfigAndLogger(command: any, sandboxApiHost = 'admin.dx.tes
 
 function stubJsonEnabled(command: any, enabled: boolean): void {
   command.jsonEnabled = () => enabled;
-}
-
-function stubOdsClient(command: any, client: Partial<{GET: any; POST: any; PUT: any; DELETE: any}>): void {
-  Object.defineProperty(command, 'odsClient', {
-    value: client,
-    configurable: true,
-  });
-}
-
-function makeCommandThrowOnError(command: any): void {
-  command.error = (msg: string) => {
-    throw new Error(msg);
-  };
 }
 
 /**

--- a/packages/b2c-cli/test/commands/sandbox/operations.test.ts
+++ b/packages/b2c-cli/test/commands/sandbox/operations.test.ts
@@ -12,6 +12,7 @@ import SandboxStart from '../../../src/commands/sandbox/start.js';
 import SandboxStop from '../../../src/commands/sandbox/stop.js';
 
 import SandboxRestart from '../../../src/commands/sandbox/restart.js';
+import {makeCommandThrowOnError, stubOdsClient} from '../../helpers/test-setup.js';
 
 function stubCommandConfigAndLogger(command: any, sandboxApiHost = 'admin.dx.test.com'): void {
   Object.defineProperty(command, 'config', {
@@ -31,19 +32,6 @@ function stubCommandConfigAndLogger(command: any, sandboxApiHost = 'admin.dx.tes
 
 function stubJsonEnabled(command: any, enabled: boolean): void {
   command.jsonEnabled = () => enabled;
-}
-
-function stubOdsClient(command: any, client: Partial<{GET: any; POST: any; PUT: any; DELETE: any}>): void {
-  Object.defineProperty(command, 'odsClient', {
-    value: client,
-    configurable: true,
-  });
-}
-
-function makeCommandThrowOnError(command: any): void {
-  command.error = (msg: string) => {
-    throw new Error(msg);
-  };
 }
 
 /**

--- a/packages/b2c-cli/test/commands/sandbox/reset.test.ts
+++ b/packages/b2c-cli/test/commands/sandbox/reset.test.ts
@@ -12,14 +12,8 @@ import {
   createTestCommand,
   makeCommandThrowOnError,
   runSilent,
+  stubOdsClient,
 } from '../../helpers/test-setup.js';
-
-function stubOdsClient(command: any, client: Partial<{GET: any; POST: any}>): void {
-  Object.defineProperty(command, 'odsClient', {
-    value: client,
-    configurable: true,
-  });
-}
 
 function stubOdsHost(command: any, host = 'admin.dx.test.com'): void {
   Object.defineProperty(command, 'odsHost', {

--- a/packages/b2c-cli/test/commands/sandbox/settings.test.ts
+++ b/packages/b2c-cli/test/commands/sandbox/settings.test.ts
@@ -12,14 +12,8 @@ import {
   createTestCommand,
   makeCommandThrowOnError,
   runSilent,
+  stubOdsClient,
 } from '../../helpers/test-setup.js';
-
-function stubOdsClient(command: any, client: Partial<{GET: any}>): void {
-  Object.defineProperty(command, 'odsClient', {
-    value: client,
-    configurable: true,
-  });
-}
 
 describe('sandbox settings', () => {
   const hooks = createIsolatedConfigHooks();

--- a/packages/b2c-cli/test/commands/sandbox/storage.test.ts
+++ b/packages/b2c-cli/test/commands/sandbox/storage.test.ts
@@ -12,14 +12,8 @@ import {
   createTestCommand,
   makeCommandThrowOnError,
   runSilent,
+  stubOdsClient,
 } from '../../helpers/test-setup.js';
-
-function stubOdsClient(command: any, client: Partial<{GET: any}>): void {
-  Object.defineProperty(command, 'odsClient', {
-    value: client,
-    configurable: true,
-  });
-}
 
 describe('sandbox storage', () => {
   const hooks = createIsolatedConfigHooks();

--- a/packages/b2c-cli/test/commands/sandbox/update.test.ts
+++ b/packages/b2c-cli/test/commands/sandbox/update.test.ts
@@ -13,14 +13,8 @@ import {
   makeCommandThrowOnError,
   runSilent,
   stubJsonEnabled,
+  stubOdsClient,
 } from '../../helpers/test-setup.js';
-
-function stubOdsClient(command: any, client: Partial<{PATCH: any}>): void {
-  Object.defineProperty(command, 'odsClient', {
-    value: client,
-    configurable: true,
-  });
-}
 
 function stubOdsHost(command: any, host = 'admin.dx.test.com'): void {
   Object.defineProperty(command, 'odsHost', {

--- a/packages/b2c-cli/test/commands/sandbox/usage.test.ts
+++ b/packages/b2c-cli/test/commands/sandbox/usage.test.ts
@@ -12,14 +12,8 @@ import {
   createTestCommand,
   makeCommandThrowOnError,
   runSilent,
+  stubOdsClient,
 } from '../../helpers/test-setup.js';
-
-function stubOdsClient(command: any, client: Partial<{GET: any}>): void {
-  Object.defineProperty(command, 'odsClient', {
-    value: client,
-    configurable: true,
-  });
-}
 
 function stubOdsHost(command: any, host = 'admin.dx.test.com'): void {
   Object.defineProperty(command, 'odsHost', {

--- a/packages/b2c-cli/test/helpers/test-setup.ts
+++ b/packages/b2c-cli/test/helpers/test-setup.ts
@@ -160,6 +160,21 @@ export function makeCommandThrowOnError(command: any): void {
 }
 
 /**
+ * Stub the lazily-loaded `odsClient` on a sandbox command. Many tests previously
+ * re-implemented this locally — promoted here so all sandbox tests share one
+ * canonical helper.
+ */
+export function stubOdsClient(
+  command: any,
+  client: Partial<{GET: any; POST: any; PUT: any; DELETE: any; PATCH: any}>,
+): void {
+  Object.defineProperty(command, 'odsClient', {
+    value: client,
+    configurable: true,
+  });
+}
+
+/**
  * Mocks getOAuthStrategy to return ImplicitOAuthStrategy with mocked implicitFlowLogin.
  * This follows the pattern from oauth-implicit.test.ts to avoid browser-based OAuth flow.
  * Use this for AM command tests that need to test implicit flow behavior without triggering

--- a/packages/b2c-cli/test/helpers/test-setup.ts
+++ b/packages/b2c-cli/test/helpers/test-setup.ts
@@ -35,6 +35,41 @@ export async function runSilent<T>(fn: () => Promise<T>): Promise<T> {
   return result as T;
 }
 
+/**
+ * Assert that the given async operation rejects, optionally with an error
+ * message that matches a substring or regex. Replaces the verbose
+ * `try { await x; expect.fail(...) } catch { expect(...).to.include(...) }`
+ * pattern, which can silently absorb the wrong error type.
+ *
+ * @example
+ *   await expectError(() => command.run(), /No SQL provided/);
+ *   await expectError(() => command.run(), 'No SQL provided');
+ *
+ * Returns the caught error so callers can make additional assertions on it.
+ */
+export async function expectError(fn: () => Promise<unknown>, match?: RegExp | string): Promise<Error> {
+  let caught: unknown;
+  try {
+    await fn();
+  } catch (error) {
+    caught = error;
+  }
+  if (caught === undefined) {
+    throw new Error('Expected the async operation to reject, but it resolved.');
+  }
+  const err = caught instanceof Error ? caught : new Error(String(caught));
+  if (match !== undefined) {
+    if (typeof match === 'string') {
+      if (!err.message.includes(match)) {
+        throw new Error(`Expected error message to include "${match}" but got: ${err.message}`);
+      }
+    } else if (!match.test(err.message)) {
+      throw new Error(`Expected error message to match ${match} but got: ${err.message}`);
+    }
+  }
+  return err;
+}
+
 export function createIsolatedEnvHooks(): {
   beforeEach: () => void;
   afterEach: () => void;

--- a/packages/b2c-dx-mcp/src/registry.ts
+++ b/packages/b2c-dx-mcp/src/registry.ts
@@ -169,11 +169,20 @@ async function performAutoDiscovery(flags: StartupFlags, reason: string): Promis
  * @param server - B2CDxMcpServer instance
  * @param loadServices - Function that loads configuration and returns Services instance
  */
+// Guards against accidental double-registration. The MCP SDK throws on duplicate
+// `addTool` names, but tracking servers we've already populated lets callers fail
+// fast with an explicit message instead of a cryptic SDK error.
+const REGISTERED_SERVERS = new WeakSet<B2CDxMcpServer>();
+
 export async function registerToolsets(
   flags: StartupFlags,
   server: B2CDxMcpServer,
   loadServices: () => Promise<Services> | Services,
 ): Promise<void> {
+  if (REGISTERED_SERVERS.has(server)) {
+    throw new Error('registerToolsets() was called more than once for the same server instance');
+  }
+  REGISTERED_SERVERS.add(server);
   const toolsets = flags.toolsets ?? [];
   const individualTools = flags.tools ?? [];
   const allowNonGaTools = flags.allowNonGaTools ?? false;

--- a/packages/b2c-dx-mcp/src/server.ts
+++ b/packages/b2c-dx-mcp/src/server.ts
@@ -16,6 +16,7 @@ import type {RequestHandlerExtra} from '@modelcontextprotocol/sdk/shared/protoco
 import type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
 import type {ZodRawShape} from 'zod';
 import type {Telemetry} from '@salesforce/b2c-tooling-sdk/telemetry';
+import {getLogger} from '@salesforce/b2c-tooling-sdk/logging';
 
 /**
  * Extended server options.
@@ -89,7 +90,9 @@ export class B2CDxMcpServer extends McpServer {
             runTimeMs,
             isError: result.isError ?? false,
           })
-          .catch(() => {});
+          .catch((error_: unknown) => {
+            getLogger().debug({err: error_, toolName: name}, '[mcp] telemetry sendEventAndFlush failed');
+          });
 
         return result;
       } catch (error) {
@@ -101,7 +104,9 @@ export class B2CDxMcpServer extends McpServer {
             runTimeMs,
             isError: true,
           })
-          .catch(() => {});
+          .catch((error_: unknown) => {
+            getLogger().debug({err: error_, toolName: name}, '[mcp] telemetry sendEventAndFlush failed');
+          });
 
         throw error;
       }

--- a/packages/b2c-dx-mcp/test/registry.test.ts
+++ b/packages/b2c-dx-mcp/test/registry.test.ts
@@ -124,6 +124,23 @@ describe('registry', () => {
         expect(tool.toolsets).to.include('STOREFRONTNEXT');
       }
     });
+
+    it('registered tool handlers are invokable end-to-end', async () => {
+      // Smoke test that verifies tools aren't just registered by name — the
+      // handler can actually be invoked and produce a tool-call response.
+      // Uses sfnext_get_guidelines (pure, no network/services needed).
+      const loadServices = createMockLoadServicesWrapper();
+      const registry = createToolRegistry(loadServices);
+      const tool = registry.STOREFRONTNEXT.find((t) => t.name === 'sfnext_get_guidelines');
+      expect(tool, 'sfnext_get_guidelines must be registered in STOREFRONTNEXT').to.not.be.undefined;
+
+      const result = await tool!.handler({sections: ['quick-reference']});
+      expect(result).to.have.property('content');
+      expect(result.content).to.be.an('array').and.to.have.lengthOf.greaterThan(0);
+      expect(result.content[0]).to.have.property('type', 'text');
+      expect(result.content[0]).to.have.property('text').that.is.a('string').and.to.have.lengthOf.greaterThan(0);
+      expect(result.isError, 'guidelines tool should not error on a valid section').to.not.equal(true);
+    });
   });
 
   describe('registerToolsets', () => {

--- a/packages/b2c-dx-mcp/test/tools/storefrontnext/figma/generate-component/index.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/storefrontnext/figma/generate-component/index.test.ts
@@ -40,7 +40,7 @@ describe('generate-component', () => {
 
       const result = generateComponentRecommendation(mockInput);
 
-      expect(result).to.be.ok;
+      expect(result).to.be.a('string').and.to.have.lengthOf.greaterThan(0);
       expect(result).to.include('CREATE');
     });
   });
@@ -140,8 +140,9 @@ describe('generate-component', () => {
         '{}',
       );
 
-      expect(differences.styling.some((d) => d.description.includes('inline styles'))).to.equal(true);
-      expect(differences.styling.some((d) => d.severity === 'moderate')).to.equal(true);
+      const inlineStylesDiff = differences.styling.find((d) => d.description.includes('inline styles'));
+      expect(inlineStylesDiff, 'expected an "inline styles" styling difference').to.not.be.undefined;
+      expect(inlineStylesDiff!.severity).to.equal('moderate');
     });
 
     it('detects different root element as structural difference', () => {
@@ -154,8 +155,9 @@ describe('generate-component', () => {
         '{}',
       );
 
-      expect(differences.structural.some((d) => d.description.includes('Different root element'))).to.equal(true);
-      expect(differences.structural.some((d) => !d.isBackwardCompatible)).to.equal(true);
+      const rootDiff = differences.structural.find((d) => d.description.includes('Different root element'));
+      expect(rootDiff, 'expected a "Different root element" structural difference').to.not.be.undefined;
+      expect(rootDiff!.isBackwardCompatible).to.be.false;
     });
 
     it('detects client directive change as behavioral difference', () => {
@@ -168,8 +170,9 @@ describe('generate-component', () => {
         '{}',
       );
 
-      expect(differences.behavioral.some((d) => d.description.includes('client-side rendering'))).to.equal(true);
-      expect(differences.behavioral.some((d) => d.severity === 'major')).to.equal(true);
+      const clientDiff = differences.behavioral.find((d) => d.description.includes('client-side rendering'));
+      expect(clientDiff, 'expected a "client-side rendering" behavioral difference').to.not.be.undefined;
+      expect(clientDiff!.severity).to.equal('major');
     });
 
     it('detects new React hooks as behavioral difference', () => {
@@ -182,7 +185,8 @@ describe('generate-component', () => {
         '{}',
       );
 
-      expect(differences.behavioral.some((d) => d.description.includes('useState'))).to.equal(true);
+      const useStateDiff = differences.behavioral.find((d) => d.description.includes('useState'));
+      expect(useStateDiff, 'expected a "useState" behavioral difference').to.not.be.undefined;
     });
 
     it('detects when existing component is client-side but Figma design could be RSC', () => {
@@ -195,8 +199,9 @@ describe('generate-component', () => {
         '{}',
       );
 
-      expect(differences.behavioral.some((d) => d.description.includes('could be RSC'))).to.equal(true);
-      expect(differences.behavioral.some((d) => d.severity === 'major')).to.equal(true);
+      const rscDiff = differences.behavioral.find((d) => d.description.includes('could be RSC'));
+      expect(rscDiff, 'expected a "could be RSC" behavioral difference').to.not.be.undefined;
+      expect(rscDiff!.severity).to.equal('major');
     });
 
     it('detects new event handlers as behavioral difference', () => {
@@ -209,8 +214,9 @@ describe('generate-component', () => {
         '{}',
       );
 
-      expect(differences.behavioral.some((d) => d.description.includes('event handlers'))).to.equal(true);
-      expect(differences.behavioral.some((d) => d.severity === 'moderate')).to.equal(true);
+      const eventDiff = differences.behavioral.find((d) => d.description.includes('event handlers'));
+      expect(eventDiff, 'expected an "event handlers" behavioral difference').to.not.be.undefined;
+      expect(eventDiff!.severity).to.equal('moderate');
     });
 
     it('detects when Figma design requires additional prop interfaces', () => {
@@ -223,8 +229,9 @@ describe('generate-component', () => {
         '{}',
       );
 
-      expect(differences.props.some((d) => d.description.includes('additional props'))).to.equal(true);
-      expect(differences.props.some((d) => d.isBackwardCompatible)).to.equal(true);
+      const additionalPropsDiff = differences.props.find((d) => d.description.includes('additional props'));
+      expect(additionalPropsDiff, 'expected an "additional props" props difference').to.not.be.undefined;
+      expect(additionalPropsDiff!.isBackwardCompatible).to.be.true;
     });
   });
 

--- a/packages/b2c-dx-mcp/test/tools/storefrontnext/site-theming/theming-store.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/storefrontnext/site-theming/theming-store.test.ts
@@ -67,7 +67,7 @@ What are the exact hex color values?`,
 
       expect(siteThemingStore.has('custom-theming')).to.be.true;
       const guidance = siteThemingStore.get('custom-theming');
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       expect(guidance!.metadata.fileName).to.equal('custom-theming.md');
       expect(guidance!.guidelines.length).to.be.greaterThan(0);
       expect(guidance!.rules.length).to.be.greaterThan(0);
@@ -103,7 +103,7 @@ Test.
 
     it('should return guidance for existing key', () => {
       const guidance = siteThemingStore.get('theming-questions');
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       expect(guidance!.questions).to.be.an('array');
       expect(guidance!.guidelines).to.be.an('array');
       expect(guidance!.rules).to.be.an('array');
@@ -143,7 +143,7 @@ Test.
       siteThemingStore.loadFile('workflow-test', filePath);
       const guidance = siteThemingStore.get('workflow-test');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       expect(guidance!.metadata.fileName).to.equal('workflow-test.md');
       // Workflow is parsed when steps, extraction, or checklist exist
       if (guidance!.workflow) {
@@ -177,7 +177,7 @@ No validation sub-sections here.
       siteThemingStore.loadFile('validation-empty', filePath);
       const guidance = siteThemingStore.get('validation-empty');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       expect(guidance!.validation).to.be.undefined;
     });
 
@@ -194,7 +194,7 @@ Only plain text, no A. Color, B. Font, C. General, or IMPORTANT.`,
       siteThemingStore.loadFile('validation-no-subsections', filePath);
       const guidance = siteThemingStore.get('validation-no-subsections');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       expect(guidance!.validation).to.be.undefined;
     });
 
@@ -216,9 +216,9 @@ Ask for clarification on color type mapping. Use exact hex. Primary vs secondary
       siteThemingStore.loadFile('color-mapping-q', filePath);
       const guidance = siteThemingStore.get('color-mapping-q');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       const mappingQ = guidance!.questions.find((q) => q.question.includes('primary vs secondary'));
-      expect(mappingQ).to.exist;
+      expect(mappingQ, 'mappingQ must be defined').to.not.be.undefined;
     });
 
     it('should parse validation section from markdown', () => {
@@ -245,7 +245,7 @@ Ask for clarification on color type mapping. Use exact hex. Primary vs secondary
       siteThemingStore.loadFile('validation-test', filePath);
       const guidance = siteThemingStore.get('validation-test');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       expect(guidance!.metadata.fileName).to.equal('validation-test.md');
       // Validation is parsed when color, font, general, or requirements exist
       if (guidance!.validation) {
@@ -288,7 +288,7 @@ Some critical content.
       siteThemingStore.loadFile('minimal', filePath);
       const guidance = siteThemingStore.get('minimal');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       expect(guidance!.guidelines).to.have.lengthOf.at.least(1);
       expect(guidance!.rules).to.have.lengthOf.at.least(1);
     });
@@ -311,10 +311,10 @@ Use exact hex values.
       siteThemingStore.loadFile('color-only', filePath);
       const guidance = siteThemingStore.get('color-only');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       expect(guidance!.questions.length).to.be.greaterThan(0);
       const colorQ = guidance!.questions.find((q) => q.category === 'colors');
-      expect(colorQ).to.exist;
+      expect(colorQ, 'colorQ must be defined').to.not.be.undefined;
     });
 
     it('should generate font fallback question when content has font', () => {
@@ -333,9 +333,9 @@ Typography and font styling. No workflow.
       siteThemingStore.loadFile('font-only', filePath);
       const guidance = siteThemingStore.get('font-only');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       const fontQ = guidance!.questions.find((q) => q.category === 'typography');
-      expect(fontQ).to.exist;
+      expect(fontQ, 'fontQ must be defined').to.not.be.undefined;
     });
 
     it('should handle THEMING_FILES with non-existent path', () => {
@@ -399,7 +399,7 @@ Use exact hex code values.
       siteThemingStore.loadFile('questions-extracted', filePath);
       const guidance = siteThemingStore.get('questions-extracted');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       expect(guidance!.questions.length).to.be.greaterThan(0);
       const hasColorQ = guidance!.questions.some((q) => q.question.includes('brand colors'));
       const hasFontQ = guidance!.questions.some((q) => q.question.includes('font family'));
@@ -436,9 +436,9 @@ When layout modifications are needed, they should be explicitly requested by the
       siteThemingStore.loadFile('layout-changes', filePath);
       const guidance = siteThemingStore.get('layout-changes');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       const layoutQ = guidance!.questions.find((q) => q.category === 'general' && q.question.includes('layout'));
-      expect(layoutQ).to.exist;
+      expect(layoutQ, 'layoutQ must be defined').to.not.be.undefined;
     });
 
     it('should generate font question for headings and body when content has font usage', () => {
@@ -459,11 +459,11 @@ Use exact font name. Font apply to headings and body.
       siteThemingStore.loadFile('font-usage', filePath);
       const guidance = siteThemingStore.get('font-usage');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       const fontQ = guidance!.questions.find(
         (q) => q.category === 'typography' && q.question.includes('headings and body'),
       );
-      expect(fontQ).to.exist;
+      expect(fontQ, 'fontQ must be defined').to.not.be.undefined;
     });
 
     it('should generate color questions for color combinations and dark/light when content has both', () => {
@@ -484,7 +484,7 @@ Propose color combinations. Use exact hex. Dark and light themes.
       siteThemingStore.loadFile('color-combos', filePath);
       const guidance = siteThemingStore.get('color-combos');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       const primaryQ = guidance!.questions.find((q) => q.question.includes('primary actions'));
       const hoverQ = guidance!.questions.find((q) => q.question.includes('hover state'));
       const darkLightQ = guidance!.questions.find((q) => q.question.includes('light and dark'));
@@ -509,11 +509,11 @@ Propose color combinations for buttons and links.
       siteThemingStore.loadFile('color-combos-only', filePath);
       const guidance = siteThemingStore.get('color-combos-only');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       const primaryQ = guidance!.questions.find((q) => q.question.includes('primary actions'));
       const hoverQ = guidance!.questions.find((q) => q.question.includes('hover state'));
-      expect(primaryQ).to.exist;
-      expect(hoverQ).to.exist;
+      expect(primaryQ, 'primaryQ must be defined').to.not.be.undefined;
+      expect(hoverQ, 'hoverQ must be defined').to.not.be.undefined;
     });
 
     it('should generate font question for Google Fonts when content has font availability', () => {
@@ -533,9 +533,9 @@ Use exact font name. Check font availability and Google Fonts.
       siteThemingStore.loadFile('font-availability', filePath);
       const guidance = siteThemingStore.get('font-availability');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       const fontQ = guidance!.questions.find((q) => q.question.includes('Google Fonts'));
-      expect(fontQ).to.exist;
+      expect(fontQ, 'fontQ must be defined').to.not.be.undefined;
     });
 
     it('should assign required to first extracted color/font question when no generated questions', () => {
@@ -558,7 +558,7 @@ Follow user specs exactly.
       siteThemingStore.loadFile('extracted-only', filePath);
       const guidance = siteThemingStore.get('extracted-only');
 
-      expect(guidance).to.exist;
+      expect(guidance, 'guidance must be defined').to.not.be.undefined;
       const colorQ = guidance!.questions.find((q) => q.question.includes('brand colors'));
       const fontQ = guidance!.questions.find((q) => q.question.includes('font family'));
       expect(colorQ?.required).to.be.true;

--- a/packages/b2c-tooling-sdk/package.json
+++ b/packages/b2c-tooling-sdk/package.json
@@ -386,6 +386,17 @@
         "types": "./dist/cjs/operations/debug/index.d.ts",
         "default": "./dist/cjs/operations/debug/index.js"
       }
+    },
+    "./ux": {
+      "development": "./src/ux/index.ts",
+      "import": {
+        "types": "./dist/esm/ux/index.d.ts",
+        "default": "./dist/esm/ux/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/ux/index.d.ts",
+        "default": "./dist/cjs/ux/index.js"
+      }
     }
   },
   "main": "./dist/cjs/index.js",

--- a/packages/b2c-tooling-sdk/src/auth/jwt-utils.ts
+++ b/packages/b2c-tooling-sdk/src/auth/jwt-utils.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+/**
+ * Shared helpers for working with decoded JWT access tokens. Centralizes the
+ * `exp` / `scope` extraction patterns that previously lived in multiple auth
+ * strategy files.
+ *
+ * @module auth/jwt-utils
+ */
+import {decodeJWT} from './oauth.js';
+
+/** Default buffer (seconds) before token `exp` to consider the token expired. */
+export const DEFAULT_EXPIRY_BUFFER_SEC = 60;
+
+/**
+ * Extract `scope` from a decoded JWT payload. Tolerates both the (legacy)
+ * space-delimited string form and the array form.
+ */
+export function extractJwtScopes(payload: Record<string, unknown>): string[] {
+  const scope = payload.scope as string | string[] | undefined;
+  if (scope == null) return [];
+  return Array.isArray(scope) ? scope : scope.split(' ');
+}
+
+/**
+ * Decode a JWT and return its `expires` Date and `scopes` array. Errors from
+ * `decodeJWT` propagate to the caller — callers that want a soft-fail should
+ * wrap this in try/catch.
+ */
+export function decodeJwtTokenInfo(token: string): {expires: Date; scopes: string[]} {
+  const decoded = decodeJWT(token);
+  const exp = typeof decoded.payload.exp === 'number' ? decoded.payload.exp : 0;
+  return {
+    expires: new Date(exp * 1000),
+    scopes: extractJwtScopes(decoded.payload as Record<string, unknown>),
+  };
+}
+
+/**
+ * Returns `true` if the token is non-empty, decodes successfully, has not
+ * expired (with a small buffer), and includes all required scopes.
+ *
+ * @param token - The JWT access token
+ * @param requiredScopes - Scopes that must all be present in the token (default: none)
+ * @param expiryBufferSec - Treat token as expired this many seconds before its real `exp`
+ */
+export function isJwtTokenValid(
+  token: string,
+  requiredScopes: string[] = [],
+  expiryBufferSec: number = DEFAULT_EXPIRY_BUFFER_SEC,
+): boolean {
+  if (!token) return false;
+  let info: {expires: Date; scopes: string[]};
+  try {
+    info = decodeJwtTokenInfo(token);
+  } catch {
+    return false;
+  }
+  const nowSec = Math.floor(Date.now() / 1000);
+  const expSec = Math.floor(info.expires.getTime() / 1000);
+  if (expSec === 0 || nowSec >= expSec - expiryBufferSec) return false;
+  if (requiredScopes.length > 0 && !requiredScopes.every((s) => info.scopes.includes(s))) {
+    return false;
+  }
+  return true;
+}

--- a/packages/b2c-tooling-sdk/src/auth/oauth-implicit.ts
+++ b/packages/b2c-tooling-sdk/src/auth/oauth-implicit.ts
@@ -440,7 +440,11 @@ export class ImplicitOAuthStrategy implements AuthStrategy {
 
       server.on('error', (err) => {
         logger.error({error: err.message, port: this.localPort}, '[Auth] Failed to start OAuth redirect server');
-        reject(new Error(`Failed to start OAuth redirect server: ${err.message}`));
+        const hint =
+          'code' in err && (err as NodeJS.ErrnoException).code === 'EADDRINUSE'
+            ? ` Port ${this.localPort} is in use; set SFCC_OAUTH_LOCAL_PORT or pass localPort to use a different port.`
+            : '';
+        reject(new Error(`Failed to start OAuth redirect server: ${err.message}.${hint}`));
       });
     });
   }

--- a/packages/b2c-tooling-sdk/src/auth/oauth.ts
+++ b/packages/b2c-tooling-sdk/src/auth/oauth.ts
@@ -11,6 +11,10 @@ import {globalAuthMiddlewareRegistry, applyAuthRequestMiddleware, applyAuthRespo
 // Module-level token cache to support multiple instances with same clientId
 const ACCESS_TOKEN_CACHE: Map<string, AccessTokenResponse> = new Map();
 
+// In-flight token requests, keyed by cacheKey, so concurrent callers coalesce
+// onto a single token-endpoint round trip instead of stampeding the server.
+const PENDING_TOKEN_REQUESTS: Map<string, Promise<AccessTokenResponse>> = new Map();
+
 export interface OAuthConfig {
   clientId: string;
   clientSecret: string;
@@ -163,10 +167,7 @@ export class OAuthStrategy implements AuthStrategy {
       return cached;
     }
 
-    // Get new token via client credentials
-    const tokenResponse = await this.clientCredentialsGrant();
-    setCachedOAuthToken(this.cacheKey, tokenResponse);
-    return tokenResponse;
+    return this.refreshTokenSingleflight();
   }
 
   /**
@@ -203,11 +204,31 @@ export class OAuthStrategy implements AuthStrategy {
       return cached.accessToken;
     }
 
-    // Get new token via client credentials
-    logger.debug('[OAuthStrategy] Requesting new access token');
-    const tokenResponse = await this.clientCredentialsGrant();
-    setCachedOAuthToken(this.cacheKey, tokenResponse);
+    const tokenResponse = await this.refreshTokenSingleflight();
     return tokenResponse.accessToken;
+  }
+
+  /**
+   * Returns a fresh token, coalescing concurrent callers onto a single in-flight
+   * token request keyed by cacheKey. Prevents stampeding the AM token endpoint
+   * when many requests trigger refresh at once.
+   */
+  private refreshTokenSingleflight(): Promise<AccessTokenResponse> {
+    const existing = PENDING_TOKEN_REQUESTS.get(this.cacheKey);
+    if (existing) {
+      getLogger().debug('[OAuthStrategy] Joining in-flight token request');
+      return existing;
+    }
+    const pending = (async () => {
+      getLogger().debug('[OAuthStrategy] Requesting new access token');
+      const tokenResponse = await this.clientCredentialsGrant();
+      setCachedOAuthToken(this.cacheKey, tokenResponse);
+      return tokenResponse;
+    })().finally(() => {
+      PENDING_TOKEN_REQUESTS.delete(this.cacheKey);
+    });
+    PENDING_TOKEN_REQUESTS.set(this.cacheKey, pending);
+    return pending;
   }
 
   /**

--- a/packages/b2c-tooling-sdk/src/auth/stateful-oauth-strategy.ts
+++ b/packages/b2c-tooling-sdk/src/auth/stateful-oauth-strategy.ts
@@ -13,6 +13,7 @@
 import type {AuthStrategy, AccessTokenResponse, DecodedJWT, FetchInit} from './types.js';
 import {getLogger} from '../logging/logger.js';
 import {decodeJWT} from './oauth.js';
+import {decodeJwtTokenInfo} from './jwt-utils.js';
 import {DEFAULT_ACCOUNT_MANAGER_HOST} from '../defaults.js';
 import {getStoredSession, setStoredSession, clearStoredSession, type StatefulSession} from './stateful-store.js';
 import {globalAuthMiddlewareRegistry, applyAuthRequestMiddleware, applyAuthResponseMiddleware} from './middleware.js';
@@ -76,15 +77,8 @@ export class StatefulOAuthStrategy implements AuthStrategy {
    */
   async getTokenResponse(): Promise<AccessTokenResponse> {
     const token = await this.getAccessToken();
-    const decoded = decodeJWT(token);
-    const exp = (decoded.payload.exp as number) ?? 0;
-    const scope = decoded.payload.scope as string | string[] | undefined;
-    const scopes = scope == null ? [] : Array.isArray(scope) ? scope : scope.split(' ');
-    return {
-      accessToken: token,
-      expires: new Date(exp * 1000),
-      scopes,
-    };
+    const {expires, scopes} = decodeJwtTokenInfo(token);
+    return {accessToken: token, expires, scopes};
   }
 
   async getJWT(): Promise<DecodedJWT> {

--- a/packages/b2c-tooling-sdk/src/auth/stateful-store.ts
+++ b/packages/b2c-tooling-sdk/src/auth/stateful-store.ts
@@ -17,16 +17,13 @@
  *
  * @module auth/stateful-store
  */
-import {existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync} from 'node:fs';
 import {join} from 'node:path';
 import {homedir, platform} from 'node:os';
-import {decodeJWT} from './oauth.js';
+import {DEFAULT_EXPIRY_BUFFER_SEC, decodeJwtTokenInfo} from './jwt-utils.js';
 import {getLogger} from '../logging/logger.js';
 
 const STATEFUL_AUTH_SESSION_STORE = 'auth-session.json';
-
-/** Default buffer (seconds) before token exp to consider it expired */
-const EXPIRY_BUFFER_SEC = 60;
 
 let storePath: string | null = null;
 
@@ -114,7 +111,11 @@ export function setStoredSession(session: StatefulSession): void {
     renewBase: session.renewBase ?? null,
     user: session.user ?? null,
   };
-  writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf8');
+  // Atomic write: write to temp file then rename so a concurrent reader (or a
+  // crashed writer) never observes a partially written JSON document.
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf8');
+  renameSync(tmpPath, filePath);
 }
 
 /**
@@ -125,8 +126,8 @@ export function clearStoredSession(): void {
   if (existsSync(filePath)) {
     try {
       unlinkSync(filePath);
-    } catch {
-      // ignore — file may have already been removed
+    } catch (err) {
+      getLogger().debug({err, filePath}, '[StatefulAuth] Failed to remove session file');
     }
   }
 }
@@ -146,40 +147,36 @@ export function clearStoredSession(): void {
 export function isStatefulTokenValid(
   session: StatefulSession,
   requiredScopes: string[] = [],
-  expiryBufferSec: number = EXPIRY_BUFFER_SEC,
+  expiryBufferSec: number = DEFAULT_EXPIRY_BUFFER_SEC,
   requiredClientId?: string,
 ): boolean {
   const logger = getLogger();
-  try {
-    if (requiredClientId && session.clientId !== requiredClientId) {
-      logger.debug({storedClientId: session.clientId, requiredClientId}, '[StatefulAuth] Token client ID mismatch');
-      return false;
-    }
-    const decoded = decodeJWT(session.accessToken);
-    const exp = decoded.payload.exp;
-    if (typeof exp !== 'number') {
-      logger.debug('[StatefulAuth] Token has no exp claim; treating as invalid');
-      return false;
-    }
-    const nowSec = Math.floor(Date.now() / 1000);
-    if (nowSec >= exp - expiryBufferSec) {
-      logger.debug('[StatefulAuth] Token missing or expired');
-      return false;
-    }
-    if (requiredScopes.length > 0) {
-      const tokenScopes = (decoded.payload.scope as string | string[] | undefined) ?? [];
-      const scopeList = Array.isArray(tokenScopes) ? tokenScopes : tokenScopes.split(' ');
-      const hasAll = requiredScopes.every((s) => scopeList.includes(s));
-      if (!hasAll) {
-        logger.debug({requiredScopes, tokenScopes: scopeList}, '[StatefulAuth] Token missing required scopes');
-        return false;
-      }
-    }
-    return true;
-  } catch (e) {
-    logger.debug({err: e}, '[StatefulAuth] Token invalid (e.g. not a JWT)');
+  if (requiredClientId && session.clientId !== requiredClientId) {
+    logger.debug({storedClientId: session.clientId, requiredClientId}, '[StatefulAuth] Token client ID mismatch');
     return false;
   }
+  let info: {expires: Date; scopes: string[]};
+  try {
+    info = decodeJwtTokenInfo(session.accessToken);
+  } catch (error) {
+    logger.debug({err: error}, '[StatefulAuth] Token invalid (e.g. not a JWT)');
+    return false;
+  }
+  if (info.expires.getTime() === 0) {
+    logger.debug('[StatefulAuth] Token has no exp claim; treating as invalid');
+    return false;
+  }
+  const nowSec = Math.floor(Date.now() / 1000);
+  const expSec = Math.floor(info.expires.getTime() / 1000);
+  if (nowSec >= expSec - expiryBufferSec) {
+    logger.debug('[StatefulAuth] Token missing or expired');
+    return false;
+  }
+  if (requiredScopes.length > 0 && !requiredScopes.every((s) => info.scopes.includes(s))) {
+    logger.debug({requiredScopes, tokenScopes: info.scopes}, '[StatefulAuth] Token missing required scopes');
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/packages/b2c-tooling-sdk/src/clients/webdav.ts
+++ b/packages/b2c-tooling-sdk/src/clients/webdav.ts
@@ -137,8 +137,11 @@ export class WebDavClient {
 
     for (const m of middleware) {
       if (m.onRequest) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = await m.onRequest(middlewareParams as any);
+        // openapi-fetch's MiddlewareCallbackParams has many internal fields we
+        // don't reproduce here; the cast is intentional and tightening the type
+        // would require pulling those into our own contract.
+        // @ts-expect-error — see comment above
+        const result = await m.onRequest(middlewareParams);
         if (result instanceof Request) {
           request = result;
           middlewareParams.request = request;
@@ -181,8 +184,9 @@ export class WebDavClient {
     };
     for (const m of middleware) {
       if (m.onResponse) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = await m.onResponse(responseParams as any);
+        // See note on the onRequest cast above; same rationale applies.
+        // @ts-expect-error — partial reimplementation of openapi-fetch's MiddlewareCallbackParams
+        const result = await m.onResponse(responseParams);
         if (result instanceof Response) {
           response = result;
           responseParams.response = response;

--- a/packages/b2c-tooling-sdk/src/operations/code/deploy.ts
+++ b/packages/b2c-tooling-sdk/src/operations/code/deploy.ts
@@ -195,21 +195,28 @@ export async function uploadCartridges(
   // Upload archive
   let stopProgress = startProgress('uploading');
   logger.debug({uploadPath}, 'Uploading archive...');
-  await webdav.put(uploadPath, buffer, 'application/zip');
-  stopProgress();
+  try {
+    await webdav.put(uploadPath, buffer, 'application/zip');
+  } finally {
+    stopProgress();
+  }
   logger.debug('Archive uploaded');
 
   // Unzip on server
   stopProgress = startProgress('unzipping');
   logger.debug('Unzipping archive on server...');
-  const response = await webdav.request(uploadPath, {
-    method: 'POST',
-    body: UNZIP_BODY,
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-  });
-  stopProgress();
+  let response: Response;
+  try {
+    response = await webdav.request(uploadPath, {
+      method: 'POST',
+      body: UNZIP_BODY,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
+  } finally {
+    stopProgress();
+  }
 
   if (!response.ok) {
     const text = await response.text();

--- a/packages/b2c-tooling-sdk/src/operations/code/download.ts
+++ b/packages/b2c-tooling-sdk/src/operations/code/download.ts
@@ -197,13 +197,17 @@ export async function downloadSingleCartridge(
 
   let stopProgress = startProgress('zipping', onProgress);
   logger.debug({cartridgeName, codeVersion}, 'Requesting server-side zip for single cartridge...');
-  const zipResponse = await webdav.request(cartridgePath, {
-    method: 'POST',
-    body: ZIP_BODY,
-    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-    signal: AbortSignal.timeout(LONG_OPERATION_TIMEOUT_MS),
-  });
-  stopProgress();
+  let zipResponse: Response;
+  try {
+    zipResponse = await webdav.request(cartridgePath, {
+      method: 'POST',
+      body: ZIP_BODY,
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      signal: AbortSignal.timeout(LONG_OPERATION_TIMEOUT_MS),
+    });
+  } finally {
+    stopProgress();
+  }
 
   if (!zipResponse.ok) {
     const text = await zipResponse.text();
@@ -211,16 +215,19 @@ export async function downloadSingleCartridge(
   }
 
   stopProgress = startProgress('downloading', onProgress);
-  const dlResponse = await webdav.request(zipPath, {
-    method: 'GET',
-    signal: AbortSignal.timeout(LONG_OPERATION_TIMEOUT_MS),
-  });
-  if (!dlResponse.ok) {
+  let buffer: ArrayBuffer;
+  try {
+    const dlResponse = await webdav.request(zipPath, {
+      method: 'GET',
+      signal: AbortSignal.timeout(LONG_OPERATION_TIMEOUT_MS),
+    });
+    if (!dlResponse.ok) {
+      throw new Error(`Failed to download zip: ${dlResponse.status} ${dlResponse.statusText}`);
+    }
+    buffer = await dlResponse.arrayBuffer();
+  } finally {
     stopProgress();
-    throw new Error(`Failed to download zip: ${dlResponse.status} ${dlResponse.statusText}`);
   }
-  const buffer = await dlResponse.arrayBuffer();
-  stopProgress();
   logger.debug({size: buffer.byteLength}, `Archive downloaded: ${buffer.byteLength} bytes`);
 
   // Cleanup server-side zip (best effort)
@@ -310,15 +317,19 @@ export async function downloadCartridges(
 
   let stopProgress = startProgress('zipping', onProgress);
   logger.debug({codeVersion}, 'Requesting server-side zip...');
-  const zipResponse = await webdav.request(`Cartridges/${codeVersion}`, {
-    method: 'POST',
-    body: ZIP_BODY,
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    signal: AbortSignal.timeout(LONG_OPERATION_TIMEOUT_MS),
-  });
-  stopProgress();
+  let zipResponse: Response;
+  try {
+    zipResponse = await webdav.request(`Cartridges/${codeVersion}`, {
+      method: 'POST',
+      body: ZIP_BODY,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      signal: AbortSignal.timeout(LONG_OPERATION_TIMEOUT_MS),
+    });
+  } finally {
+    stopProgress();
+  }
 
   if (!zipResponse.ok) {
     const text = await zipResponse.text();
@@ -328,18 +339,19 @@ export async function downloadCartridges(
 
   stopProgress = startProgress('downloading', onProgress);
   logger.debug({zipPath}, 'Downloading zip archive...');
-  const downloadResponse = await webdav.request(zipPath, {
-    method: 'GET',
-    signal: AbortSignal.timeout(LONG_OPERATION_TIMEOUT_MS),
-  });
-
-  if (!downloadResponse.ok) {
+  let buffer: ArrayBuffer;
+  try {
+    const downloadResponse = await webdav.request(zipPath, {
+      method: 'GET',
+      signal: AbortSignal.timeout(LONG_OPERATION_TIMEOUT_MS),
+    });
+    if (!downloadResponse.ok) {
+      throw new Error(`Failed to download zip: ${downloadResponse.status} ${downloadResponse.statusText}`);
+    }
+    buffer = await downloadResponse.arrayBuffer();
+  } finally {
     stopProgress();
-    throw new Error(`Failed to download zip: ${downloadResponse.status} ${downloadResponse.statusText}`);
   }
-
-  const buffer = await downloadResponse.arrayBuffer();
-  stopProgress();
   logger.debug({size: buffer.byteLength}, `Archive downloaded: ${buffer.byteLength} bytes`);
 
   // Cleanup server-side zip (best-effort)

--- a/packages/b2c-tooling-sdk/src/operations/debug/debug-session.ts
+++ b/packages/b2c-tooling-sdk/src/operations/debug/debug-session.ts
@@ -65,16 +65,29 @@ export class DebugSessionManager {
     await this.client.createClient();
     this.connected = true;
 
-    // Start keepalive timer
-    const keepaliveInterval = this.config.keepaliveInterval ?? DEFAULT_KEEPALIVE_INTERVAL;
-    this.keepaliveTimer = setInterval(() => void this.keepalive(), keepaliveInterval);
+    try {
+      // Start keepalive timer
+      const keepaliveInterval = this.config.keepaliveInterval ?? DEFAULT_KEEPALIVE_INTERVAL;
+      this.keepaliveTimer = setInterval(() => void this.keepalive(), keepaliveInterval);
 
-    // Start thread poller
-    const pollInterval = this.config.pollInterval ?? DEFAULT_POLL_INTERVAL;
-    this.pollTimer = setInterval(() => void this.pollThreads(), pollInterval);
+      // Start thread poller
+      const pollInterval = this.config.pollInterval ?? DEFAULT_POLL_INTERVAL;
+      this.pollTimer = setInterval(() => void this.pollThreads(), pollInterval);
 
-    this.logger.debug('Script debugger connected');
-    this.callbacks.onConnected?.(this.config.hostname);
+      this.logger.debug('Script debugger connected');
+      this.callbacks.onConnected?.(this.config.hostname);
+    } catch (err) {
+      // Ensure timers are cleared if anything (incl. onConnected callback) throws
+      // after we started them; otherwise we'd leak intervals.
+      this.stopTimers();
+      this.connected = false;
+      try {
+        await this.client.deleteClient();
+      } catch (deleteErr) {
+        this.logger.debug({err: deleteErr}, 'Failed to clean up debugger client after connect error');
+      }
+      throw err;
+    }
   }
 
   /**

--- a/packages/b2c-tooling-sdk/src/ux/index.ts
+++ b/packages/b2c-tooling-sdk/src/ux/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export {confirm, type ConfirmOptions} from './confirm.js';

--- a/packages/b2c-tooling-sdk/test/logging/logger.test.ts
+++ b/packages/b2c-tooling-sdk/test/logging/logger.test.ts
@@ -28,7 +28,6 @@ describe('logging/logger', () => {
   describe('createLogger', () => {
     it('creates logger with default options', () => {
       const logger = createLogger();
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
       expect(logger.debug).to.be.a('function');
       expect(logger.warn).to.be.a('function');
@@ -37,37 +36,31 @@ describe('logging/logger', () => {
 
     it('creates logger with custom level', () => {
       const logger = createLogger({level: 'debug'});
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
 
     it('creates logger with json output', () => {
       const logger = createLogger({json: true});
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
 
     it('creates logger with colorize disabled', () => {
       const logger = createLogger({colorize: false});
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
 
     it('creates logger with baseContext', () => {
       const logger = createLogger({baseContext: {app: 'test'}});
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
 
     it('creates logger with custom file descriptor', () => {
       const logger = createLogger({fd: 1}); // stdout
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
 
     it('creates logger with redaction disabled', () => {
       const logger = createLogger({redact: false});
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
 
@@ -80,7 +73,6 @@ describe('logging/logger', () => {
         redact: true,
         baseContext: {env: 'test'},
       });
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
   });
@@ -89,7 +81,6 @@ describe('logging/logger', () => {
     it('configures global logger options', () => {
       configureLogger({level: 'debug'});
       const logger = getLogger();
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
 
@@ -97,7 +88,6 @@ describe('logging/logger', () => {
       configureLogger({level: 'info'});
       configureLogger({json: true});
       const logger = getLogger();
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
 
@@ -106,8 +96,6 @@ describe('logging/logger', () => {
       const logger1 = getLogger();
       configureLogger({level: 'warn'});
       const logger2 = getLogger();
-      expect(logger1).to.exist;
-      expect(logger2).to.exist;
       expect(logger1.info).to.be.a('function');
       expect(logger2.info).to.be.a('function');
     });
@@ -117,7 +105,6 @@ describe('logging/logger', () => {
     it('returns logger with default options when not configured', () => {
       resetLogger();
       const logger = getLogger();
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
 
@@ -133,8 +120,6 @@ describe('logging/logger', () => {
       const logger1 = getLogger();
       resetLogger();
       const logger2 = getLogger();
-      expect(logger1).to.exist;
-      expect(logger2).to.exist;
       expect(logger1.info).to.be.a('function');
       expect(logger2.info).to.be.a('function');
     });
@@ -146,7 +131,6 @@ describe('logging/logger', () => {
       getLogger(); // Create logger
       resetLogger();
       const logger = getLogger();
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
 
@@ -154,7 +138,6 @@ describe('logging/logger', () => {
       configureLogger({level: 'debug', json: true});
       resetLogger();
       const logger = getLogger();
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
   });
@@ -162,7 +145,6 @@ describe('logging/logger', () => {
   describe('createSilentLogger', () => {
     it('creates logger with silent level', () => {
       const logger = createSilentLogger();
-      expect(logger).to.exist;
       expect(logger.info).to.be.a('function');
     });
 

--- a/packages/b2c-vs-extension/src/api-browser/swagger-webview.ts
+++ b/packages/b2c-vs-extension/src/api-browser/swagger-webview.ts
@@ -182,12 +182,30 @@ export class SwaggerWebviewManager implements vscode.Disposable {
   private readonly panels = new Map<string, vscode.WebviewPanel>();
   private readonly specCache = new Map<string, Record<string, unknown>>();
   private readonly disposables: vscode.Disposable[] = [];
+  /** Tracks panels that have been disposed so we don't `postMessage` to them. */
+  private readonly disposedPanels = new WeakSet<vscode.WebviewPanel>();
 
   constructor(
     private readonly context: vscode.ExtensionContext,
     private readonly configProvider: B2CExtensionConfig,
     private readonly log: vscode.OutputChannel,
   ) {}
+
+  /**
+   * Post a message to the panel, but only if it hasn't been disposed.
+   * VS Code's `postMessage` resolves to `false` after disposal, but some flows
+   * also throw — so we both guard and swallow defensively.
+   */
+  private safePostMessage(panel: vscode.WebviewPanel, message: unknown): void {
+    if (this.disposedPanels.has(panel)) return;
+    try {
+      void panel.webview.postMessage(message);
+    } catch (error) {
+      this.log.appendLine(
+        `[API Browser] postMessage failed (panel likely disposed): ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
 
   async openSwaggerPanel(schema: SchemaEntry): Promise<void> {
     const key = `${schema.apiFamily}/${schema.apiName}/${schema.apiVersion}`;
@@ -271,18 +289,25 @@ export class SwaggerWebviewManager implements vscode.Disposable {
     this.panels.set(key, panel);
 
     panel.onDidDispose(() => {
+      this.disposedPanels.add(panel);
       this.panels.delete(key);
     });
 
     panel.webview.html = this.getWebviewHtml(panel.webview, spec, apiType, initialToken);
 
     // Handle messages from webview (token refresh + API proxy)
-    panel.webview.onDidReceiveMessage(async (msg: {type: string; [k: string]: unknown}) => {
-      if (msg.type === 'refreshToken') {
-        await this.sendToken(panel, apiType, requiredScopes);
-      } else if (msg.type === 'proxyRequest') {
-        await this.handleProxyRequest(panel, msg);
-      }
+    panel.webview.onDidReceiveMessage((msg: {type: string; [k: string]: unknown}) => {
+      const handle = async (): Promise<void> => {
+        if (msg.type === 'refreshToken') {
+          await this.sendToken(panel, apiType, requiredScopes);
+        } else if (msg.type === 'proxyRequest') {
+          await this.handleProxyRequest(panel, msg);
+        }
+      };
+      handle().catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        this.log.appendLine(`[API Browser] webview message handler failed: ${message}`);
+      });
     });
   }
 
@@ -407,7 +432,7 @@ export class SwaggerWebviewManager implements vscode.Disposable {
         `[API Browser Proxy] ${requestId} → ${res.status} ${res.statusText} (${responseBody.length} bytes)`,
       );
 
-      panel.webview.postMessage({
+      this.safePostMessage(panel, {
         type: 'proxyResponse',
         requestId,
         status: res.status,
@@ -418,7 +443,7 @@ export class SwaggerWebviewManager implements vscode.Disposable {
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       this.log.appendLine(`[API Browser Proxy] ${requestId} → ERROR: ${errMsg}`);
-      panel.webview.postMessage({
+      this.safePostMessage(panel, {
         type: 'proxyResponse',
         requestId,
         error: errMsg,
@@ -430,19 +455,19 @@ export class SwaggerWebviewManager implements vscode.Disposable {
     try {
       const token = await this.getToken(apiType, scopes);
       if (token) {
-        panel.webview.postMessage({type: 'updateToken', token});
+        this.safePostMessage(panel, {type: 'updateToken', token});
       } else {
         const hint =
           apiType === 'Shopper'
             ? 'No public SLAS client found. Configure slasClientId and siteId in dw.json, or create a public SLAS client.'
             : 'Configure clientId and clientSecret in dw.json.';
         this.log.appendLine(`[API Browser] No ${apiType} token available — ${hint}`);
-        panel.webview.postMessage({type: 'tokenError', error: hint});
+        this.safePostMessage(panel, {type: 'tokenError', error: hint});
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.log.appendLine(`[API Browser] Token error (${apiType}): ${message}`);
-      panel.webview.postMessage({type: 'tokenError', error: message});
+      this.safePostMessage(panel, {type: 'tokenError', error: message});
     }
   }
 

--- a/packages/b2c-vs-extension/src/code-sync/code-sync-manager.ts
+++ b/packages/b2c-vs-extension/src/code-sync/code-sync-manager.ts
@@ -148,13 +148,23 @@ export class CodeSyncManager implements vscode.Disposable {
       this.debounceTimer = undefined;
     }
 
-    // Dispose all file watchers
+    // Dispose all file watchers first so no new changes accumulate while we drain.
     for (const w of this.fileWatchers) {
       w.dispose();
     }
     this.fileWatchers = [];
 
-    // Clear pending state
+    // Drain any pending uploads/deletes accumulated since the last debounce tick
+    // (or queued while a previous processChanges() loop was running). Without
+    // this drain, a save right before stop would be silently dropped.
+    if (this.pendingUploads.size > 0 || this.pendingDeletes.size > 0) {
+      try {
+        await this.processChanges();
+      } catch (error) {
+        this.log(`[Stop] Error draining pending changes: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+
     this.pendingUploads.clear();
     this.pendingDeletes.clear();
     this.isProcessing = false;
@@ -270,7 +280,11 @@ export class CodeSyncManager implements vscode.Disposable {
 
   dispose(): void {
     if (this.watching) {
-      this.stopWatch().catch(() => {});
+      this.stopWatch().catch((error: unknown) => {
+        // Best-effort: extension is unloading; log to the channel so failures
+        // are visible if the user has it open.
+        this.log(`[Dispose] stopWatch failed: ${error instanceof Error ? error.message : String(error)}`);
+      });
     }
     this.statusBar.dispose();
     this.outputChannel.dispose();

--- a/packages/b2c-vs-extension/src/sandbox-tree/sandbox-tree-provider.ts
+++ b/packages/b2c-vs-extension/src/sandbox-tree/sandbox-tree-provider.ts
@@ -104,6 +104,8 @@ export class SandboxTreeDataProvider implements vscode.TreeDataProvider<SandboxT
   private _onDidChangeTreeData = new vscode.EventEmitter<SandboxTreeNode | undefined | void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private pollingTimers = new Map<string, ReturnType<typeof setInterval>>();
+  /** Inner stop-check timers per realm, scheduled via setTimeout in each interval tick. */
+  private pollingStopChecks = new Map<string, ReturnType<typeof setTimeout>>();
   /** Sandbox IDs currently acting as a clone source (tracked client-side while Clone Sandbox is in flight). */
   private activeCloneSources = new Set<string>();
 
@@ -146,16 +148,25 @@ export class SandboxTreeDataProvider implements vscode.TreeDataProvider<SandboxT
 
     const startTime = Date.now();
     const pollIntervalMs = getPollIntervalMs();
-    const timer = setInterval(async () => {
+    const timer = setInterval(() => {
       if (Date.now() - startTime > MAX_POLL_DURATION_MS) {
         this.stopPollingRealm(realm);
         return;
       }
       this.refreshRealm(realm);
 
-      // Check if all sandboxes have reached stable states
-      // Give the tree a moment to fetch, then check cache
-      setTimeout(() => {
+      // Skip scheduling another stop-check if one is already pending for this
+      // realm — otherwise short poll intervals (< 3s) cause stop-checks to stack
+      // and concurrent `getCachedSandboxes`/`stopPollingRealm` calls to race.
+      if (this.pollingStopChecks.has(realm)) return;
+
+      // Check if all sandboxes have reached stable states. Give the tree a
+      // moment to fetch, then check cache.
+      const stopCheck = setTimeout(() => {
+        this.pollingStopChecks.delete(realm);
+        // The interval may have been cleared while we were sleeping.
+        if (!this.pollingTimers.has(realm)) return;
+
         const sandboxes = this.configProvider.getCachedSandboxes(realm);
         if (!sandboxes) return; // still loading
         const hasTransitional = sandboxes.some((s) => TRANSITIONAL_STATES.has((s.state ?? '').toLowerCase()));
@@ -170,6 +181,7 @@ export class SandboxTreeDataProvider implements vscode.TreeDataProvider<SandboxT
           this.stopPollingRealm(realm);
         }
       }, 3000);
+      this.pollingStopChecks.set(realm, stopCheck);
     }, pollIntervalMs);
 
     this.pollingTimers.set(realm, timer);
@@ -181,6 +193,11 @@ export class SandboxTreeDataProvider implements vscode.TreeDataProvider<SandboxT
       clearInterval(timer);
       this.pollingTimers.delete(realm);
     }
+    const stopCheck = this.pollingStopChecks.get(realm);
+    if (stopCheck) {
+      clearTimeout(stopCheck);
+      this.pollingStopChecks.delete(realm);
+    }
   }
 
   stopAllPolling(): void {
@@ -188,6 +205,10 @@ export class SandboxTreeDataProvider implements vscode.TreeDataProvider<SandboxT
       clearInterval(timer);
     }
     this.pollingTimers.clear();
+    for (const stopCheck of this.pollingStopChecks.values()) {
+      clearTimeout(stopCheck);
+    }
+    this.pollingStopChecks.clear();
   }
 
   getTreeItem(element: SandboxTreeNode): vscode.TreeItem {

--- a/packages/mrt-utilities/src/streaming/create-lambda-adapter.ts
+++ b/packages/mrt-utilities/src/streaming/create-lambda-adapter.ts
@@ -623,6 +623,14 @@ export function createExpressResponse(
       return true;
     } catch (error) {
       console.error('[pipeToDestination] Pipeline error:', error);
+      // Notify the destination so consumers (e.g. an HTTP response in another
+      // adapter) can fail fast instead of hanging waiting for data that will
+      // never arrive. Best-effort: ignore secondary errors from emit/destroy.
+      try {
+        destination.destroy(error instanceof Error ? error : new Error(String(error)));
+      } catch (destroyError) {
+        console.error('[pipeToDestination] Failed to destroy destination after pipeline error:', destroyError);
+      }
       return false;
     }
   };
@@ -923,15 +931,18 @@ export function createExpressResponse(
     // Track the destination for unpipe support
     pipedDestinations.add(destination);
 
-    // Use actual Node.js pipeline for pipe operations
-    pipeToDestination(destination)
-      .then(() => {
-        pipedDestinations.delete(destination);
-      })
-      .catch((error) => {
-        console.error('[res.pipe] Pipeline error:', error);
-        pipedDestinations.delete(destination);
-      });
+    // Use actual Node.js pipeline for pipe operations. Always remove the
+    // destination from the tracking set when the pipeline settles — using a
+    // single `finally`-style callback rather than mirroring the cleanup in both
+    // `then` and `catch`, so we can't accidentally leak entries if either
+    // branch throws.
+    const cleanup = (): void => {
+      pipedDestinations.delete(destination);
+    };
+    pipeToDestination(destination).then(cleanup, (error) => {
+      console.error('[res.pipe] Pipeline error:', error);
+      cleanup();
+    });
 
     return destination;
   };

--- a/packages/mrt-utilities/test/streaming/create-lambda-adapter-compression.test.ts
+++ b/packages/mrt-utilities/test/streaming/create-lambda-adapter-compression.test.ts
@@ -133,7 +133,6 @@ describe('Compression Streaming', () => {
 
       // Wait for stream to finish
       await stream.waitForEnd();
-      await new Promise((resolve) => setTimeout(resolve, 50));
 
       const compressedData = stream.getData();
       const metadata = stream.getMetadata();
@@ -156,7 +155,7 @@ describe('Compression Streaming', () => {
       const testData = JSON.stringify({message: 'test', data: Array(100).fill('x').join('')});
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const compressedData = stream.getData();
       const metadata = stream.getMetadata();
@@ -179,7 +178,7 @@ describe('Compression Streaming', () => {
       response.write('chunk3');
       response.end();
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const compressedData = stream.getData();
       const metadata = stream.getMetadata();
@@ -201,7 +200,7 @@ describe('Compression Streaming', () => {
       const testData = 'This is a test string. '.repeat(50);
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const compressedData = stream.getData();
       const metadata = stream.getMetadata();
@@ -224,7 +223,7 @@ describe('Compression Streaming', () => {
       const testData = 'This is a test string for brotli compression. '.repeat(100);
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const compressedData = stream.getData();
       const metadata = stream.getMetadata();
@@ -245,7 +244,7 @@ describe('Compression Streaming', () => {
       const testData = JSON.stringify({data: 'test'.repeat(100)});
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       // Negotiator prefers based on order in Accept-Encoding, but our code prefers br first
@@ -266,7 +265,7 @@ describe('Compression Streaming', () => {
       const testData = 'body { color: red; } '.repeat(50);
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.equal('gzip');
@@ -283,7 +282,7 @@ describe('Compression Streaming', () => {
       const testData = 'function test() { return true; } '.repeat(50);
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.equal('gzip');
@@ -300,7 +299,7 @@ describe('Compression Streaming', () => {
       const testData = '<root><item>test</item></root>'.repeat(50);
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.equal('gzip');
@@ -317,7 +316,7 @@ describe('Compression Streaming', () => {
       const testData = '<svg><circle r="10"/></svg>'.repeat(50);
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.equal('gzip');
@@ -336,7 +335,7 @@ describe('Compression Streaming', () => {
       const testData = Buffer.alloc(1000, 0xff); // Mock JPEG data
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.be.undefined;
@@ -355,7 +354,7 @@ describe('Compression Streaming', () => {
       const testData = Buffer.alloc(1000, 0x89); // Mock PNG data
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.be.undefined;
@@ -372,7 +371,7 @@ describe('Compression Streaming', () => {
       const testData = Buffer.alloc(1000);
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.be.undefined;
@@ -389,7 +388,7 @@ describe('Compression Streaming', () => {
       const testData = Buffer.alloc(1000, 0xff);
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       // Note: The compressible package considers application/octet-stream as compressible
@@ -412,7 +411,7 @@ describe('Compression Streaming', () => {
       const testData = 'This should not be compressed';
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.be.undefined;
@@ -434,7 +433,7 @@ describe('Compression Streaming', () => {
       const testData = 'test data';
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.equal('gzip');
@@ -460,7 +459,7 @@ describe('Compression Streaming', () => {
       }
       response.end();
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const compressedData = stream.getData();
       const metadata = stream.getMetadata();
@@ -481,7 +480,7 @@ describe('Compression Streaming', () => {
       response.setHeader('Content-Type', 'text/html');
       response.end('test data');
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       // Should prefer br due to higher quality value
@@ -498,7 +497,7 @@ describe('Compression Streaming', () => {
       response.setHeader('Content-Type', 'text/html');
       response.end('test data');
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       // Should use br as it's first in our preference list
@@ -524,7 +523,7 @@ describe('Compression Streaming', () => {
       // But we can verify the response still works
       response.end('more data');
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       // Response should still complete even if compression has issues
       const metadata = stream.getMetadata();
@@ -544,7 +543,7 @@ describe('Compression Streaming', () => {
       const testData = 'test data';
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.equal('gzip');
@@ -561,7 +560,7 @@ describe('Compression Streaming', () => {
       const testData = 'test data';
       response.end(testData);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       // multipart/form-data is NOT compressible according to the compressible package
@@ -581,7 +580,7 @@ describe('Compression Streaming', () => {
       response.setHeader('Content-Type', 'text/html');
       response.send('test data');
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.equal('gzip');
@@ -596,7 +595,7 @@ describe('Compression Streaming', () => {
 
       response.json({message: 'test', data: 'x'.repeat(100)});
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.equal('gzip');
@@ -612,7 +611,7 @@ describe('Compression Streaming', () => {
       response.writeHead(200, {'Content-Type': 'text/html'});
       response.end('test data');
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.equal('gzip');
@@ -629,7 +628,7 @@ describe('Compression Streaming', () => {
       response.flushHeaders();
       response.end('test data');
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await stream.waitForEnd();
 
       const metadata = stream.getMetadata();
       expect(metadata.headers['content-encoding']).to.equal('gzip');
@@ -652,7 +651,7 @@ describe('Compression Streaming', () => {
         response.setHeader('Content-Type', 'text/html');
         response.end('test data');
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         const metadata = stream.getMetadata();
         // Should use br from compressionConfig, not gzip from Accept-Encoding
@@ -673,7 +672,7 @@ describe('Compression Streaming', () => {
         response.setHeader('Content-Type', 'text/html');
         response.end('test data');
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         const metadata = stream.getMetadata();
         // Should use deflate from compressionConfig, not gzip from Accept-Encoding
@@ -695,7 +694,7 @@ describe('Compression Streaming', () => {
         response.setHeader('Content-Type', 'text/html');
         response.end('test data');
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         const metadata = stream.getMetadata();
         // Should use gzip from compressionConfig even without Accept-Encoding header
@@ -724,7 +723,7 @@ describe('Compression Streaming', () => {
         response.setHeader('Content-Type', 'text/html');
         response.end('test data');
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         // Verify createGzip was called with the options
         expect(createGzipStub.calledWith(compressionConfig.options)).to.be.true;
@@ -753,7 +752,7 @@ describe('Compression Streaming', () => {
         response.setHeader('Content-Type', 'text/html');
         response.end('test data');
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         // Verify createBrotliCompress was called with the options
         expect(createBrotliStub.calledWith(compressionConfig.options)).to.be.true;
@@ -780,7 +779,7 @@ describe('Compression Streaming', () => {
         response.setHeader('Content-Type', 'text/html');
         response.end('test data');
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         // Verify createDeflate was called with the options
         expect(createDeflateStub.calledWith(compressionConfig.options)).to.be.true;
@@ -806,7 +805,7 @@ describe('Compression Streaming', () => {
         response.setHeader('Content-Type', 'text/html');
         response.end('test data');
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         const metadata = stream.getMetadata();
         // Should still use gzip from Accept-Encoding
@@ -828,7 +827,7 @@ describe('Compression Streaming', () => {
         response.setHeader('Content-Type', 'text/html');
         response.end('test data');
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         const metadata = stream.getMetadata();
         // Should work normally without compressionConfig
@@ -846,7 +845,7 @@ describe('Compression Streaming', () => {
         response.setHeader('Content-Type', 'text/html');
         response.end('test data');
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         const metadata = stream.getMetadata();
         // Should work normally with empty compressionConfig
@@ -873,7 +872,7 @@ describe('Compression Streaming', () => {
         response.setHeader('Content-Type', 'text/html');
         response.end('test data');
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         const metadata = stream.getMetadata();
         // Should use br from Accept-Encoding
@@ -899,7 +898,7 @@ describe('Compression Streaming', () => {
         const testData = 'This is a test string that should NOT be compressed. '.repeat(100);
         response.end(testData);
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         const metadata = stream.getMetadata();
         // Should NOT have content-encoding header
@@ -924,7 +923,7 @@ describe('Compression Streaming', () => {
         response.setHeader('Content-Type', 'application/json');
         response.end(JSON.stringify({message: 'test', data: 'x'.repeat(1000)}));
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         const metadata = stream.getMetadata();
         // Should NOT have content-encoding header
@@ -945,7 +944,7 @@ describe('Compression Streaming', () => {
         response.setHeader('Content-Type', 'text/html');
         response.end('test data');
 
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await stream.waitForEnd();
 
         const metadata = stream.getMetadata();
         // Should NOT have content-encoding header


### PR DESCRIPTION
## Summary

Two-part audit cleanup on this branch:

### Part 1 — Source audit (commit `04fa47dc`)
Cross-package code review of `@salesforce/b2c-cli`, `@salesforce/b2c-tooling-sdk`, `@salesforce/b2c-dx-mcp`, `b2c-vs-extension`, and `@salesforce/mrt-utilities`. Addresses every High and Medium item that wasn't a false positive — 21 fixes total.

**Concurrency & correctness:**
- **SDK** — atomic write for the stateful auth-session file; single-flight refresh in `OAuthStrategy.getAccessToken` to coalesce concurrent token requests; cleanup of debug-session keepalive/poll timers when `connect()` fails after starting them; try/finally around progress timers in code `download`/`deploy`.
- **CLI** — long-running commands (`code:watch`, `logs:tail`, `mrt:tail-logs`) now deregister their SIGINT/SIGTERM handlers when finished.
- **VS Code extension** — guard webview `postMessage` against panel disposal in the Swagger API Browser; drain pending uploads before tearing down code-sync watchers; prevent sandbox-tree polling stop-checks from stacking.
- **mrt-utilities** — `pipeToDestination` destroys the destination on pipeline error so consumers fail fast instead of hanging.
- **MCP** — `registerToolsets()` throws clearly if invoked twice for the same server.

**Error handling:** replaced silent `catch {}` blocks in stateful-store, `job:run`, `logs:tail`, MCP telemetry, code-sync dispose. CIP commands stream output through `ux.stdout` instead of `process.stdout`, restoring `--json` and test capture.

**DRY / dead code:** new `@salesforce/b2c-tooling-sdk/ux` export hosts canonical `confirm()`; new `auth/jwt-utils` consolidates JWT decoding from three sites; AM list commands share `amPageSizeFlag`; ECDN gets a single `requireScapiCoordinates` helper; SLAS/SCAPI `formatApiError` aliases SDK's `getApiErrorMessage`; removed deprecated `LocalSourceResult`.

### Part 2 — Test audit (commit `03fbda6f`)
Companion sweep addressing every High and the highest-leverage Medium item from a parallel test-quality audit. Goal: make the test suite catch real regressions instead of just confirming functions ran.

**CLI tests:**
- New `expectError(fn, match?)` helper replaces the verbose `try { await x; expect.fail(...) } catch {}` pattern that could absorb the wrong error type.
- `code/deploy`, `code/activate`, `auth/token`, `mrt/env/var/push`, `cip/query` — tightened `.calledOnce`/`.called` assertions to verify call args (instance, cartridges, paths, payloads) instead of just invocation counts.
- Removed echo tautologies (`expect(result.sql).to.equal(input)`); assertions now confirm the *substituted* SQL was passed to the client.
- Promoted duplicated `stubOdsClient` and `makeCommandThrowOnError` out of 12 sandbox test files into the canonical helpers.

**SDK tests:** dropped 18 redundant `expect(logger).to.exist` lines in `logger.test.ts`.

**MCP tests:** added a smoke test that actually invokes a registered tool handler (previously only tool names were asserted); 25 weak `expect(x).to.exist` calls in `theming-store.test.ts` upgraded to named `.to.not.be.undefined`; replaced 7 `.some(d => …).to.equal(true)` chains in figma `generate-component` with `.find(...)` + concrete property assertions so failures show what actually went wrong.

**mrt-utilities tests:** replaced 39 fixed `setTimeout(50ms)` waits in `create-lambda-adapter-compression.test.ts` with the existing event-driven `stream.waitForEnd()`. Suite runtime drops from ~3s to ~1s.

### Verified false positives
**Source:** H3 (prophet `dw.json` fallback runs in user env, can't import SDK), H14 (Lambda response mock is fully populated synchronously), M2/M4/M5/M8/M9/M10/M11/M13/M15/M16/M17/M20/M21 (already-correct patterns or larger refactors).

**Tests:** the cross-cutting agent's "406 weak `expect.fail`" was overstated (verified: 167 typed catches + 200 with proper post-assertions + 0 truly empty); the SDK agent's "30+ middleware tests silently skip" claim was wrong (the `if (!x) throw` is TypeScript narrowing — `throw` in `it()` fails loud).

## Test plan
- [x] `pnpm run lint:agent` clean
- [x] `pnpm run typecheck:agent` clean
- [x] `pnpm run test:agent` — 4,076 tests passing (651 mcp + 1,705 sdk + 516 mrt + 1,204 cli)
- [ ] Manual smoke: `b2c cip query --json` and `--format json/csv` produce expected output
- [ ] Manual smoke: `b2c code watch` exits cleanly on Ctrl+C with no leaked listeners
- [ ] Manual smoke: VS Code Swagger API Browser doesn't error after closing during a request
- [ ] Manual smoke: parallel `b2c auth client` invocations don't corrupt `auth-session.json`