### PR TITLE
@W-22537129 e2e test fix

### DIFF
--- a/packages/b2c-cli/test/functional/e2e/hooks.ts
+++ b/packages/b2c-cli/test/functional/e2e/hooks.ts
@@ -44,27 +44,21 @@ export const mochaHooks = {
     const realm = process.env.TEST_REALM!;
     const shortCode = process.env.SFCC_SHORTCODE!;
     const clientId = process.env.SFCC_CLIENT_ID!;
-    const allMethods = ['get', 'post', 'patch', 'delete'];
-    // OCAPI permissions for the test sandbox: enumerate every top-level
-    // resource the suite touches, with attribute wildcards.
+    // OCAPI permissions for the test sandbox: enumerate every resource the
+    // e2e suite touches with only the HTTP methods each endpoint supports.
     const ocapiSettings = JSON.stringify([
       {
         client_id: clientId,
         resources: [
-          '/code_versions',
-          '/code_versions/*',
-          '/jobs/*/executions',
-          '/jobs/*/executions/*',
-          '/job_execution_search',
-          '/sites',
-          '/sites/*',
-          '/sites/*/cartridges',
-        ].map((resourceId) => ({
-          resource_id: resourceId,
-          methods: allMethods,
-          read_attributes: '(**)',
-          write_attributes: '(**)',
-        })),
+          {resource_id: '/code_versions', methods: ['get']},
+          {resource_id: '/code_versions/*', methods: ['get', 'patch', 'delete']},
+          {resource_id: '/jobs/*/executions', methods: ['post']},
+          {resource_id: '/jobs/*/executions/*', methods: ['get']},
+          {resource_id: '/job_execution_search', methods: ['post']},
+          {resource_id: '/sites', methods: ['get']},
+          {resource_id: '/sites/*', methods: ['get', 'patch']},
+          {resource_id: '/sites/*/cartridges', methods: ['get', 'post']},
+        ].map((r) => ({...r, read_attributes: '(**)', write_attributes: '(**)'})),
       },
     ]);
 

--- a/packages/b2c-cli/test/functional/e2e/hooks.ts
+++ b/packages/b2c-cli/test/functional/e2e/hooks.ts
@@ -44,20 +44,23 @@ export const mochaHooks = {
     const realm = process.env.TEST_REALM!;
     const shortCode = process.env.SFCC_SHORTCODE!;
     const clientId = process.env.SFCC_CLIENT_ID!;
-    // OCAPI permissions for the test sandbox: enumerate every resource the
-    // e2e suite touches with only the HTTP methods each endpoint supports.
+    // OCAPI permissions for the test sandbox.
+    // DBInit (26.6.0.220) validates that each method string is actually
+    // implemented for the given resource_id. Only list methods the OCAPI
+    // Data API exposes per resource — use the same methods proven in
+    // DEFAULT_OCAPI_RESOURCES (sandbox create command) plus extras for
+    // resources the e2e suite exercises.
     const ocapiSettings = JSON.stringify([
       {
         client_id: clientId,
         resources: [
           {resource_id: '/code_versions', methods: ['get']},
-          {resource_id: '/code_versions/*', methods: ['get', 'patch', 'delete']},
+          {resource_id: '/code_versions/*', methods: ['patch', 'delete']},
           {resource_id: '/jobs/*/executions', methods: ['post']},
           {resource_id: '/jobs/*/executions/*', methods: ['get']},
           {resource_id: '/job_execution_search', methods: ['post']},
           {resource_id: '/sites', methods: ['get']},
-          {resource_id: '/sites/*', methods: ['get', 'patch']},
-          {resource_id: '/sites/*/cartridges', methods: ['get', 'post']},
+          {resource_id: '/sites/*/cartridges', methods: ['post']},
         ].map((r) => ({...r, read_attributes: '(**)', write_attributes: '(**)'})),
       },
     ]);

--- a/packages/b2c-cli/test/functional/e2e/hooks.ts
+++ b/packages/b2c-cli/test/functional/e2e/hooks.ts
@@ -44,7 +44,7 @@ export const mochaHooks = {
     const realm = process.env.TEST_REALM!;
     const shortCode = process.env.SFCC_SHORTCODE!;
     const clientId = process.env.SFCC_CLIENT_ID!;
-    const allMethods = ['get', 'post', 'put', 'patch', 'delete'];
+    const allMethods = ['get', 'post', 'patch', 'delete'];
     // OCAPI permissions for the test sandbox: enumerate every top-level
     // resource the suite touches, with attribute wildcards.
     const ocapiSettings = JSON.stringify([


### PR DESCRIPTION
## Summary

Fix DBInit `UnknownHttpMethod` error during shared e2e sandbox creation. DBInit (v26.6.0.220) validates that each HTTP method listed in OCAPI settings is actually implemented by the specific resource endpoint. The previous configuration applied all methods (`get`, `post`, `put`, `patch`, `delete`) to every resource, but many resources only support a subset (e.g., `/code_versions` only supports `GET`, `/sites/*` does not support `PATCH`). Replaced with per-resource method lists matching what the OCAPI Data API actually exposes — aligned with the proven `DEFAULT_OCAPI_RESOURCES` in the `sandbox create` command.

## Testing

- Verified the OCAPI resource/method combinations match those already proven in `DEFAULT_OCAPI_RESOURCES` (used by `sandbox create --set-permissions` in production)
- Confirmed via CI logs that the updated settings JSON is being passed correctly to the CLI
- Lint passes (`pnpm run lint:agent`)

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
