### PR TITLE
fix(vs-extension): declare .ts content type in VSIX [Content_Types].xml

### DIFF
--- a/.changeset/vsix-content-types-ts.md
+++ b/.changeset/vsix-content-types-ts.md
@@ -1,0 +1,5 @@
+---
+'b2c-vs-extension': patch
+---
+
+Make the published VSIX OPC-compliant by declaring a content type for `.ts` files (introduced by the bundled Script API types). The packaging step now patches `[Content_Types].xml` after injection so every file extension in the archive has a registered content type. Strict OPC consumers — observed on some Windows installs — may otherwise reject the package.

--- a/packages/b2c-vs-extension/scripts/inject-script-types.mjs
+++ b/packages/b2c-vs-extension/scripts/inject-script-types.mjs
@@ -11,6 +11,11 @@
  * back. VS Code's TypeScript Server plugin loader requires the plugin to live
  * at <extension-root>/node_modules/<name>, so we add it to the zip ourselves
  * after vsce produces the VSIX.
+ *
+ * Because the injected tree introduces file extensions (notably .ts/.d.ts)
+ * that vsce did not see, [Content_Types].xml is patched in-place to register
+ * a Default content type for any new extension. Without this, strict OPC
+ * consumers — observed on some Windows installs — reject the VSIX.
  */
 import {execFileSync} from 'node:child_process';
 import fs from 'node:fs';
@@ -59,6 +64,48 @@ try {
     stdio: 'inherit',
   });
   console.log('[inject] added script-types plugin to', path.relative(pkgRoot, vsixPath));
+
+  patchContentTypes(vsixPath, stagingDir, target);
 } finally {
   fs.rmSync(stagingDir, {recursive: true, force: true});
+}
+
+function collectExtensions(dir, acc = new Set()) {
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) collectExtensions(p, acc);
+    else {
+      const ext = path.extname(entry.name).toLowerCase();
+      if (ext) acc.add(ext);
+    }
+  }
+  return acc;
+}
+
+function patchContentTypes(vsixPath, stagingDir, injectedRoot) {
+  const injected = collectExtensions(injectedRoot);
+  // unzip treats `[` as a glob char-class; backslash-escape to match it literally.
+  const existing = execFileSync('unzip', ['-p', vsixPath, '\\[Content_Types\\].xml'], {encoding: 'utf8'});
+  const declared = new Set();
+  for (const m of existing.matchAll(/Extension="(\.[^"]+)"/g)) {
+    declared.add(m[1].toLowerCase());
+  }
+
+  const missing = [...injected].filter((e) => !declared.has(e));
+  if (missing.length === 0) {
+    return;
+  }
+
+  const inserts = missing.map((e) => `<Default Extension="${e}" ContentType="application/octet-stream"/>`).join('');
+  const updated = existing.replace('</Types>', `${inserts}</Types>`);
+
+  // zip's CLI treats `[` as a glob char-class, so write the file then feed its
+  // name through stdin via -@ to avoid wildcard expansion.
+  fs.writeFileSync(path.join(stagingDir, '[Content_Types].xml'), updated);
+  execFileSync('zip', ['-q', vsixPath, '-@'], {
+    cwd: stagingDir,
+    input: '[Content_Types].xml\n',
+    stdio: ['pipe', 'inherit', 'inherit'],
+  });
+  console.log('[inject] patched [Content_Types].xml with extensions:', missing.join(', '));
 }


### PR DESCRIPTION
## Summary

- The VSIX packaging step injects `@salesforce/b2c-script-types` into the archive **after** `vsce package` runs (because `vsce --no-dependencies` hard-ignores `node_modules/**`). That injection adds `.ts` files (Script API `d.ts` types) that `vsce` never saw, so the generated `[Content_Types].xml` does not declare a content type for `.ts`.
- A VSIX is an OPC package; every file extension must have a registered content type. The Mac VS Code installer is lenient about this; some Windows-side installers / OPC consumers / corporate AV gateways are stricter and may reject the archive.
- This change patches `[Content_Types].xml` after injection: it scans the injected tree for file extensions and adds a `<Default Extension="…" ContentType="application/octet-stream"/>` entry for any extension `vsce` did not already declare. On the current build this adds `.ts`.

## Context

Triggered by user reports that some Windows users could not install the 0.8.1 VSIX (`Unexpected non-whitespace character after JSON at position 240 (line 8 column 1)`). I could not reproduce the JSON-parse error from this OPC issue alone, and a byte-by-byte comparison between the GitHub release artifact and the locally-built VSIX showed no CI corruption — the published VSIX is exactly what we built. The user's specific failure is most likely environmental (AV/EDR rewriting the file, corporate proxy, etc.). However, the OPC noncompliance is a real spec violation and worth fixing on its own merits.

## Test plan

- [x] \`pnpm --filter b2c-vs-extension run package\` succeeds locally
- [x] Resulting VSIX has \`.ts\` declared in \`[Content_Types].xml\`
- [x] \`unzip -t\` clean, no duplicate entries
- [x] \`extension.vsixmanifest\` still parses
- [x] \`pnpm --filter b2c-vs-extension run lint:agent\` clean
- [ ] Install resulting VSIX in VS Code on macOS (smoke)
- [ ] Install resulting VSIX in VS Code on Windows (smoke)