### PR TITLE
ci: SHA-pin pnpm/action-setup in deploy-docs and preview-release

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 22.x
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
## Summary

Extends the existing SHA-pinning policy (already applied to `pnpm/action-setup` in `publish.yml` and `changesets.yml`) to the two other workflows that hold release-grade credentials:

- `.github/workflows/deploy-docs.yml` — has `pages: write` + `id-token: write`, deploys to GitHub Pages.
- `.github/workflows/preview-release.yml` — runs the npm publish flow for preview tags.

Both pinned to commit `fc06bc1257f339d1d5d8b3a19a8cae5388b55320` (current `pnpm/action-setup@v5`), matching the SHA already in use in `publish.yml`/`changesets.yml`.

## Why

A static-analysis pass with [zizmor](https://github.com/zizmorcore/zizmor) flagged 58 `unpinned-uses` findings across the workflow suite. After triaging against the project's trust model (only collaborators can push/merge), the only category representing a realistic external-attacker risk is **third-party action references in workflows that hold publish credentials**. A force-push of the `v5` tag on `pnpm/action-setup` would otherwise run with whatever secrets the workflow has in scope.

GitHub-owned actions (`actions/checkout`, `actions/setup-node`, `actions/cache`, etc.) and CI-only workflows that carry no secrets are intentionally left on tag refs to avoid the Renovate churn — the supply-chain risk there is low and the upgrade tax is non-trivial.

## Test plan

- [ ] CI passes (the change is a no-op functionally — same commit, same action behavior).
- [ ] Confirm the SHA matches the existing pins by `git grep 'pnpm/action-setup' .github/workflows/`.