### PR TITLE
fix(cap): remove root directory naming convention validation warning

### DIFF
--- a/.changeset/remove-cap-root-dir-convention-warning.md
+++ b/.changeset/remove-cap-root-dir-convention-warning.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+Remove the CAP validation warning that flagged a root directory not matching the `{id}-v{version}` naming convention. This convention is no longer required, so the check has been dropped from `b2c cap validate` (and `b2c cap install`).

--- a/packages/b2c-tooling-sdk/src/operations/cap/validate.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cap/validate.ts
@@ -116,14 +116,6 @@ export async function validateCap(target: string): Promise<CapValidationResult> 
         if (errors.filter((e) => e.startsWith('commerce-app.json:')).length === 0) {
           manifest = raw as unknown as CommerceAppManifest;
         }
-        // Check root dir naming convention
-        const dirName = path.basename(capDir);
-        if (manifest && dirName !== '.' && dirName !== tempDir) {
-          const expectedName = `${manifest.id}-v${manifest.version}`;
-          if (dirName !== expectedName) {
-            warnings.push(`Root directory "${dirName}" does not match expected convention "${expectedName}"`);
-          }
-        }
       } catch {
         errors.push('commerce-app.json: file exists but is not valid JSON');
       }


### PR DESCRIPTION
## Summary
Removes the CAP validation warning that flagged a root directory not matching the `{id}-v{version}` naming convention (e.g. `Root directory "commerce-noibu-app-v1.0.0" does not match expected convention "noibu-v1.0.0"`).

This convention is no longer a valid check, so the warning has been dropped from `b2c cap validate` (and by extension `b2c cap install`).

## Changes
- Remove the root-directory naming-convention check in `packages/b2c-tooling-sdk/src/operations/cap/validate.ts`.
- Add changeset.

## Testing
- `pnpm --filter @salesforce/b2c-tooling-sdk run typecheck:agent` — passes
- `pnpm run lint:agent` — passes
- cap validate test suite — all 13 passing

(Note: a pre-existing, unrelated `InstanceCommand integration` test failure exists on the base branch and is not affected by this change.)