### PR TITLE
fix(sdk): isolate developer environment in SDK test setup

### DIFF
--- a/packages/b2c-tooling-sdk/test/setup.ts
+++ b/packages/b2c-tooling-sdk/test/setup.ts
@@ -7,6 +7,8 @@
 /**
  * Global test setup for SDK tests.
  *
+ * - Strips the developer's SFCC_ and MRT_ environment so tests never inherit
+ *   real config (e.g. SFCC_CONFIG pointing at a personal dw.json)
  * - Sets log level to silent to reduce test output noise
  * - Skips plugin hook collection so real plugins don't pollute the test environment
  * - Clears all global registries before each test to prevent state leakage
@@ -14,6 +16,22 @@
 import {globalMiddlewareRegistry} from '../src/clients/middleware-registry.js';
 import {globalAuthMiddlewareRegistry} from '../src/auth/middleware.js';
 import {globalConfigSourceRegistry} from '../src/config/config-source-registry.js';
+
+// Establish a clean baseline environment for the entire test run so no test
+// inherits the developer's config. Individual tests may still layer their own
+// isolateConfig()/restoreConfig() on top of this. This is intentionally not the
+// stateful isolateConfig() helper — that one save/restores within a single test,
+// whereas this is a permanent, non-restoring baseline for the whole process.
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith('SFCC_') || key.startsWith('MRT_')) {
+    delete process.env[key];
+  }
+}
+
+// Point config/credential lookups at /dev/null so file-based sources resolve to
+// nothing even if a default dw.json/~/.mobify exists on the machine.
+process.env.SFCC_CONFIG = '/dev/null';
+process.env.MRT_CREDENTIALS_FILE = '/dev/null';
 
 // Set silent log level by default for all tests
 process.env.SFCC_LOG_LEVEL = 'silent';


### PR DESCRIPTION
## Summary

`instance-command.integration.test.ts` failed for developers who had `SFCC_*`/`MRT_*` variables set in their shell. The global SDK test setup did not strip them, so a personal `SFCC_CONFIG` (pointing at a real `dw.json`) leaked into config resolution, supplied a hostname, and broke the assertion expecting no server config.

## Change

`test/setup.ts` now establishes a clean baseline environment for the whole test run:
- Deletes every `SFCC_*` and `MRT_*` variable at startup
- Points `SFCC_CONFIG` and `MRT_CREDENTIALS_FILE` at `/dev/null` so file-based config sources resolve to nothing even when a default `dw.json`/`~/.mobify` exists on the machine

This is a process-wide, non-restoring baseline; the existing per-test `isolateConfig()`/`restoreConfig()` helpers continue to layer on top of it.

No shipped code changed — this is test infrastructure only.