### PR TITLE
docs: audit-driven repair of CLI reference, guides, and SDK JSDoc

### DIFF
--- a/.changeset/doc-audit-and-jsdoc-pass.md
+++ b/.changeset/doc-audit-and-jsdoc-pass.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/b2c-dx-docs': patch
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+Documentation audit and repair pass: corrected stale CLI flag and command references across the CLI reference and guides, fixed broken examples (e.g. eCDN mTLS, sandbox `--no-*` flags, WebDAV `get` arguments), aligned SDK JSDoc with current signatures, and added the missing `operations/cap` typedoc entry point so the Commerce App SDK module appears in the API reference. Filled in JSDoc for previously undocumented public exports across the SDK (auth, clients, instance, logging, ods, mrt, cap, cip, debug, scaffold, schemas, skills, etc.) so the generated API docs cover the full public surface.

--- a/docs/api-readme.md
+++ b/docs/api-readme.md
@@ -29,6 +29,7 @@ The SDK is organized into focused submodules that can be imported individually:
 ├── /operations/content  # Page Designer content export
 ├── /operations/cip      # Curated CIP analytics reports and SQL helpers
 ├── /operations/jobs     # Job execution, site archive import/export
+├── /operations/cap      # Custom API operations
 ├── /operations/logs     # Log tailing and retrieval
 ├── /operations/mrt      # Managed Runtime bundle operations
 ├── /operations/ods      # On-demand sandbox utilities
@@ -36,8 +37,13 @@ The SDK is organized into focused submodules that can be imported individually:
 ├── /operations/users    # Account Manager users
 ├── /operations/roles    # Account Manager roles
 ├── /operations/bm-roles # Business Manager roles
+├── /operations/bm-users # Business Manager users
 ├── /operations/orgs     # Account Manager organizations
 ├── /operations/sites    # Storefront site info and cartridge paths
+│
+├── /test-utils         # Testing utilities and helpers
+├── /telemetry          # Telemetry and analytics
+├── /ux                 # User experience utilities
 │
 ├── /slas                # SLAS helpers
 ├── /safety              # Safety-mode confirmation middleware
@@ -106,7 +112,8 @@ const {data} = await slasClient.GET('/tenants/{tenantId}/clients', {
 ### MRT Operations
 
 ```typescript
-import {pushBundle, ApiKeyStrategy} from '@salesforce/b2c-tooling-sdk';
+import {pushBundle} from '@salesforce/b2c-tooling-sdk/operations/mrt';
+import {ApiKeyStrategy} from '@salesforce/b2c-tooling-sdk/auth';
 
 const auth = new ApiKeyStrategy(process.env.MRT_API_KEY!);
 const result = await pushBundle(

--- a/docs/cli/account-manager.md
+++ b/docs/cli/account-manager.md
@@ -383,12 +383,11 @@ b2c am roles list [FLAGS]
 
 - ID
 - Description
-- Scope
-- Internal Role
+- Role Enum Name
 
 #### Extended Columns
 
-- Target Type
+- Permissions
 
 #### Examples
 
@@ -755,8 +754,7 @@ b2c am clients list [FLAGS]
 
 #### Extended Columns
 
-- Last Auth
-- Disabled
+None. All columns are available via the `--columns` flag.
 
 #### Examples
 

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -39,6 +39,13 @@ export SFCC_CLIENT_ID=your-client-id
 b2c auth login
 ```
 
+### Flags
+
+| Flag | Environment Variable | Description |
+|------|---------------------|-------------|
+| `--account-manager-host` | `SFCC_ACCOUNT_MANAGER_HOST` | Account Manager hostname (default: account.demandware.com) |
+| `--auth-scope` | `SFCC_OAUTH_SCOPES` | OAuth scopes to request (comma-separated or repeated flag) |
+
 After a successful login, subsequent commands use the stored token until it expires or you run `b2c auth logout`.
 
 ## b2c auth logout
@@ -118,6 +125,12 @@ Uses `refresh_token` grant when a refresh token is stored, otherwise falls back 
 b2c auth client renew
 ```
 
+### Flags
+
+| Flag | Environment Variable | Description |
+|------|---------------------|-------------|
+| `--account-manager-host` | `SFCC_ACCOUNT_MANAGER_HOST` | Account Manager hostname for OAuth (default: account.demandware.com) |
+
 ### Example
 
 ```bash
@@ -181,6 +194,13 @@ b2c auth token
 | `--client-secret` | `SFCC_CLIENT_SECRET` | Client Secret for OAuth |
 | `--auth-scope` | `SFCC_OAUTH_SCOPES` | OAuth scopes to request (can be repeated) |
 | `--account-manager-host` | `SFCC_ACCOUNT_MANAGER_HOST` | Account Manager hostname (default: account.demandware.com) |
+| `--short-code` | `SFCC_SHORTCODE` | SCAPI short code |
+| `--tenant-id` | `SFCC_TENANT_ID` | Organization/tenant ID |
+| `--auth-methods` | `SFCC_AUTH_METHODS` | Allowed auth methods in priority order (comma-separated): client-credentials, jwt, implicit, basic, api-key |
+| `--user-auth` | | Use browser-based user authentication (implicit OAuth flow) |
+| `--jwt-cert` | `SFCC_JWT_CERT` | Path to JWT certificate file (cert.pem) for JWT Bearer authentication |
+| `--jwt-key` | `SFCC_JWT_KEY` | Path to JWT private key file (key.pem) for JWT Bearer authentication |
+| `--jwt-passphrase` | `SFCC_JWT_PASSPHRASE` | Passphrase for encrypted JWT private key |
 
 ### Examples
 

--- a/docs/cli/bm.md
+++ b/docs/cli/bm.md
@@ -87,7 +87,7 @@ b2c bm roles list [--count <n>] [--start <n>] [--columns <cols>] [--extended]
 |------|-------------|
 | `--count`, `-n` | Number of roles to return (default 25) |
 | `--start` | Start index for pagination (default 0) |
-| `--columns`, `-c` | Comma-separated columns to display |
+| `--columns`, `-c` | Comma-separated columns to display. Available: `id`, `description`, `userCount`, `userManager` |
 | `--extended`, `-x` | Show all columns including extended fields |
 
 ```bash
@@ -275,7 +275,7 @@ b2c bm users list [--count <n>] [--start <n>] [--columns <cols>] [--extended]
 |------|-------------|
 | `--count`, `-n` | Number of users to return (default 25) |
 | `--start` | Start index for pagination (default 0) |
-| `--columns`, `-c` | Comma-separated columns to display |
+| `--columns`, `-c` | Comma-separated columns to display. Available: `login`, `email`, `name`, `disabled`, `locked`, `lastLogin`, `externalId` |
 | `--extended`, `-x` | Include extended columns (`lastLogin`, `externalId`) |
 
 ```bash
@@ -318,6 +318,10 @@ b2c bm users search [--search-phrase <text>] [--login <login>] [--email <email>]
 | `--sort-by` | Sort field (e.g. `last_login_date`) |
 | `--sort-order` | `asc` or `desc` |
 | `--query` | Raw OCAPI query JSON (overrides convenience flags) |
+| `--count`, `-n` | Number of users to return (default 25) |
+| `--start` | Start index for pagination (default 0) |
+| `--columns`, `-c` | Comma-separated columns to display. Available: `login`, `email`, `name`, `disabled`, `locked`, `lastLogin`, `externalId` |
+| `--extended`, `-x` | Include extended columns (`lastLogin`, `externalId`) |
 
 ```bash
 b2c bm users search --search-phrase smith

--- a/docs/cli/cap.md
+++ b/docs/cli/cap.md
@@ -230,6 +230,8 @@ b2c cap list [--site-id SITE_IDS]
 | `--site-id SITE_IDS` | `-s` | Site IDs to query (comma-separated). If omitted, queries all sites. |
 | `--timeout SECONDS` | `-t` | Timeout in seconds (default: no timeout) |
 | `--local` | `-l` | List locally detected Commerce App Packages (no instance required) |
+| `--columns COLS` | `-c` | Columns to display (comma-separated). Available columns: `path`, `id`, `name`, `version`, `domain`, `siteId`, `featureName`, `featureType`, `featureSource`, `installStatus`, `configStatus`, `installedAt` |
+| `--extended` | `-x` | Show all columns including extended fields |
 | `--json` | | Output result as JSON |
 
 ### Table Columns

--- a/docs/cli/cip.md
+++ b/docs/cli/cip.md
@@ -32,13 +32,13 @@ CIP commands use **OAuth client credentials only**.
 | --------------------- | ---------------------------------------------- |
 | Client ID             | `--client-id` or `SFCC_CLIENT_ID`              |
 | Client Secret         | `--client-secret` or `SFCC_CLIENT_SECRET`      |
-| Tenant (CIP instance) | `--tenant-id` / `--tenant` or `SFCC_TENANT_ID` |
+| Tenant (CIP instance) | `--tenant-id` or `SFCC_TENANT_ID`              |
 
 Your API client must include the **Salesforce Commerce API** role with a tenant filter that includes your target instance.
 
 ## Connection and Output Flags
 
-These flags are available on all CIP commands:
+These flags are available on `cip tables`, `cip describe`, `cip query`, and `cip report` subcommands:
 
 | Flag           | Description                           | Default                                       |
 | -------------- | ------------------------------------- | --------------------------------------------- |
@@ -46,6 +46,7 @@ These flags are available on all CIP commands:
 | `--fetch-size` | Frame fetch size for paging           | `1000`                                        |
 | `--cip-host`   | CIP host override                     | `jdbc.analytics.commercecloud.salesforce.com` |
 | `--staging`    | Use staging analytics host            | `false`                                       |
+| `--json`       | Output result as JSON                 | `false`                                       |
 
 ## Query and Report Date Flags
 
@@ -243,4 +244,4 @@ Both `cip query` and report commands support:
 - `--format table` (default)
 - `--format csv` (writes CSV to stdout)
 - `--format json` (writes JSON to stdout)
-- `--json` (global JSON mode)
+- `--json` (global JSON mode; available on all CIP commands)

--- a/docs/cli/code.md
+++ b/docs/cli/code.md
@@ -49,7 +49,12 @@ b2c code list
 
 ### Flags
 
-Uses [global instance and authentication flags](./index#global-flags).
+In addition to [global instance and authentication flags](./index#global-flags):
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--columns`, `-c` | Columns to display (comma-separated). Available: id, active, rollback, lastModified, cartridges | All columns |
+| `--extended`, `-x` | Show all columns including extended fields | `false` |
 
 ### Examples
 
@@ -116,8 +121,8 @@ In addition to [global flags](./index#global-flags):
 | `--activate`, `-a` | Activate code version after deploy | `false` |
 | `--reload`, `-r` | Reload (toggle activation to force reload) code version after deploy | `false` |
 | `--delete` | Delete existing cartridges before upload | `false` |
-| `--cartridge`, `-c` | Include specific cartridge(s) (can be repeated) | |
-| `--exclude-cartridge`, `-x` | Exclude specific cartridge(s) (can be repeated) | |
+| `--cartridge`, `-c` | Include specific cartridge(s) (comma-separated or repeated) | |
+| `--exclude-cartridge`, `-x` | Exclude specific cartridge(s) (comma-separated or repeated) | |
 
 ### Examples
 
@@ -183,8 +188,10 @@ In addition to [global flags](./index#global-flags):
 |------|-------------|---------|
 | `--output`, `-o` | Output directory for downloaded cartridges | `cartridges` |
 | `--mirror`, `-m` | Extract cartridges to their local project locations | `false` |
-| `--cartridge`, `-c` | Include specific cartridge(s) (can be repeated) | |
-| `--exclude-cartridge`, `-x` | Exclude specific cartridge(s) (can be repeated) | |
+| `--cartridge`, `-c` | Include specific cartridge(s) (comma-separated or repeated) | |
+| `--exclude-cartridge`, `-x` | Exclude specific cartridge(s) (comma-separated or repeated) | |
+
+**Note:** The `--mirror` and `--output` flags are mutually exclusive. You must use one or the other, not both. Use `--output` to extract all cartridges to a single directory, or use `--mirror` to extract each cartridge to its local project location.
 
 ### Examples
 
@@ -343,8 +350,8 @@ In addition to [global flags](./index#global-flags):
 
 | Flag | Description |
 |------|-------------|
-| `--cartridge`, `-c` | Include specific cartridge(s) (can be repeated) |
-| `--exclude-cartridge`, `-x` | Exclude specific cartridge(s) (can be repeated) |
+| `--cartridge`, `-c` | Include specific cartridge(s) (comma-separated or repeated) |
+| `--exclude-cartridge`, `-x` | Exclude specific cartridge(s) (comma-separated or repeated) |
 
 ### Examples
 

--- a/docs/cli/content.md
+++ b/docs/cli/content.md
@@ -179,6 +179,8 @@ In addition to [global flags](./index#global-flags):
 | `--components` | Include components in table output | `false` |
 | `--tree` | Show tree structure instead of table | `false` |
 | `--timeout` | Job timeout in seconds | |
+| `--columns`, `-c` | Columns to display (comma-separated). Available: id, type, typeId, children | All columns |
+| `--extended`, `-x` | Show all columns including extended fields | `false` |
 
 ### Examples
 
@@ -244,7 +246,7 @@ With `--json`, returns `{ data: [...] }` with each item containing `id`, `type`,
 
 ## b2c content validate
 
-Validate Page Designer metadefinition JSON files against bundled JSON schemas. This is a local-only command — no instance connection or authentication is required.
+Validate Page Designer metadefinition JSON files against schemas. This is a local-only command — no instance connection or authentication is required.
 
 The command auto-detects the schema type using file path conventions (`experience/pages/` → pagetype, `experience/components/` → componenttype) and falls back to inspecting the JSON properties. You can also specify the type explicitly with `--type`.
 

--- a/docs/cli/custom-apis.md
+++ b/docs/cli/custom-apis.md
@@ -14,6 +14,10 @@ These flags are available on all Custom APIs commands:
 |------|---------------------|-------------|
 | `--tenant-id` | `SFCC_TENANT_ID` | (Required) Organization/tenant ID |
 | `--short-code` | `SFCC_SHORTCODE` | SCAPI short code |
+| `--client-id` | `SFCC_CLIENT_ID` | Account Manager API Client ID |
+| `--client-secret` | `SFCC_CLIENT_SECRET` | Account Manager API Client secret |
+
+Additional authentication flags (`--auth-methods`, `--user-auth`, `--account-manager-host`, `--jwt-cert`, `--jwt-key`, `--jwt-passphrase`) and logging flags (`--log-level`, `--debug`, `--jsonl`) are also available. See the [Authentication Guide](/guide/authentication#scapi-authentication) for credential configuration, or run any command with `--help` for the complete flag list.
 
 ## Authentication
 

--- a/docs/cli/docs.md
+++ b/docs/cli/docs.md
@@ -45,10 +45,12 @@ b2c docs search [query]
 
 ### Flags
 
-| Flag            | Description                              | Default |
-| --------------- | ---------------------------------------- | ------- |
-| `--limit`, `-l` | Maximum number of results to display     | `20`    |
-| `--list`        | List all available documentation entries | `false` |
+| Flag               | Description                                                       | Default |
+| ------------------ | ----------------------------------------------------------------- | ------- |
+| `--limit`, `-l`    | Maximum number of results to display                              | `20`    |
+| `--list`           | List all available documentation entries                          | `false` |
+| `--columns`, `-c`  | Columns to display (comma-separated). Available: id, title, score | (none)  |
+| `--extended`, `-x` | Show all columns including extended fields                        | `false` |
 
 ### Examples
 

--- a/docs/cli/ecdn.md
+++ b/docs/cli/ecdn.md
@@ -128,8 +128,10 @@ b2c ecdn certificates add --zone my-zone --hostname www.example.com --certificat
 | Flag | Description | Required |
 |------|-------------|----------|
 | `--hostname` | Custom hostname | Yes |
-| `--certificate-file` | Path to certificate PEM file | Yes |
-| `--private-key-file` | Path to private key PEM file | Yes |
+| `--type` | Certificate type (`custom`, `automatic`; default `automatic`) | No |
+| `--certificate-file` | Path to certificate PEM file | Conditional (required for `custom`) |
+| `--private-key-file` | Path to private key PEM file | Conditional (required for `custom`) |
+| `--bundle-method` | Bundle method for custom certificate chain verification | No |
 
 ---
 
@@ -141,6 +143,17 @@ Update a certificate.
 b2c ecdn certificates update --zone my-zone --certificate-id abc123 --certificate-file ./new-cert.pem --private-key-file ./new-key.pem
 ```
 
+#### Flags
+
+| Flag | Description | Required |
+|------|-------------|----------|
+| `--certificate-id` | Certificate ID to update | Yes |
+| `--hostname`, `-h` | Hostname for the certificate | No |
+| `--type` | Certificate type (`custom`, `automatic`) | No |
+| `--certificate-file` | Path to certificate PEM file | No |
+| `--private-key-file` | Path to private key PEM file | No |
+| `--bundle-method` | Bundle method for custom certificate chain verification | No |
+
 ---
 
 ### b2c ecdn certificates delete
@@ -151,6 +164,12 @@ Delete a certificate.
 b2c ecdn certificates delete --zone my-zone --certificate-id abc123
 ```
 
+#### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--force`, `-f` | Skip confirmation prompt |
+
 ---
 
 ### b2c ecdn certificates validate
@@ -158,7 +177,7 @@ b2c ecdn certificates delete --zone my-zone --certificate-id abc123
 Validate a custom hostname certificate.
 
 ```bash
-b2c ecdn certificates validate --zone my-zone --certificate-id abc123
+b2c ecdn certificates validate --zone my-zone --custom-hostname-id abc123
 ```
 
 ---
@@ -270,6 +289,7 @@ b2c ecdn waf groups update --zone my-zone --group-id abc123 --mode on
 | Flag | Description | Options |
 |------|-------------|---------|
 | `--mode` | Group mode | `on`, `off` |
+| `--action` | Action for the WAF group | `block`, `challenge`, `monitor`, `default` |
 
 ---
 
@@ -298,8 +318,15 @@ b2c ecdn waf rules get --zone my-zone --rule-id abc123
 Update a WAF v1 rule.
 
 ```bash
-b2c ecdn waf rules update --zone my-zone --rule-id abc123 --mode on
+b2c ecdn waf rules update --zone my-zone --rule-id abc123 --action block
 ```
+
+#### Flags
+
+| Flag | Description | Options | Required |
+|------|-------------|---------|----------|
+| `--rule-id` | WAF rule ID to update | — | Yes |
+| `--action` | Action for the WAF rule | `block`, `challenge`, `monitor`, `disable`, `default` | Yes |
 
 ---
 
@@ -362,8 +389,15 @@ b2c ecdn waf owasp get --zone my-zone
 Update OWASP package settings.
 
 ```bash
-b2c ecdn waf owasp update --zone my-zone --sensitivity high
+b2c ecdn waf owasp update --zone my-zone --sensitivity high --action-mode challenge
 ```
+
+#### Flags
+
+| Flag | Description | Options | Required |
+|------|-------------|---------|----------|
+| `--sensitivity` | Sensitivity level | `low`, `medium`, `high`, `off` | Yes |
+| `--action-mode` | Action mode | `simulate`, `challenge`, `block` | Yes |
 
 ---
 
@@ -476,7 +510,7 @@ b2c ecdn page-shield notifications list --tenant-id zzxy_prd
 Create a notification webhook.
 
 ```bash
-b2c ecdn page-shield notifications create --tenant-id zzxy_prd --url https://example.com/webhook --secret my-secret --zones zone1,zone2
+b2c ecdn page-shield notifications create --tenant-id zzxy_prd --webhook-url https://example.com/webhook --secret my-secret --zones zone1,zone2
 ```
 
 ---
@@ -664,7 +698,7 @@ b2c ecdn mtls list --tenant-id zzxy_prd
 Create an mTLS certificate for code upload authentication.
 
 ```bash
-b2c ecdn mtls create --tenant-id zzxy_prd --name "Build Server" --ca-certificate-file ./ca.pem --leaf-certificate-file ./leaf.pem
+b2c ecdn mtls create --tenant-id zzxy_prd --name "Build Server" --certificate-file ./cert.pem --private-key-file ./key.pem
 ```
 
 #### Flags
@@ -672,8 +706,8 @@ b2c ecdn mtls create --tenant-id zzxy_prd --name "Build Server" --ca-certificate
 | Flag | Description | Required |
 |------|-------------|----------|
 | `--name` | Certificate name | Yes |
-| `--ca-certificate-file` | Path to CA certificate PEM | Yes |
-| `--leaf-certificate-file` | Path to leaf certificate PEM | Yes |
+| `--certificate-file` | Path to PEM-encoded certificate file | Yes |
+| `--private-key-file` | Path to PEM-encoded private key file | Yes |
 
 ---
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -37,6 +37,8 @@ Safety Mode provides protection against accidental or unwanted destructive opera
 | | `NO_DELETE` | Block DELETE operations |
 | | `NO_UPDATE` | Block DELETE and destructive operations (reset, stop, restart) |
 | | `READ_ONLY` | Block all write operations (GET only) |
+| `SFCC_SAFETY_CONFIRM` | `true`, `1` | Enable confirmation mode (prompt user instead of blocking destructive operations) |
+| `SFCC_SAFETY_CONFIG` | File path | Path to global safety config file (JSON format with optional `level`, `confirm`, and `rules`) |
 
 **Example:**
 ```bash

--- a/docs/cli/jobs.md
+++ b/docs/cli/jobs.md
@@ -169,6 +169,8 @@ In addition to [global flags](./index#global-flags):
 | `--start` | Starting index for pagination | `0` |
 | `--sort-by` | Sort by field (start_time, end_time, job_id, status) | `start_time` |
 | `--sort-order` | Sort order (asc, desc) | `desc` |
+| `--columns`, `-c` | Columns to display (comma-separated): id, jobId, status, startTime | |
+| `--extended`, `-x` | Show all columns including extended fields | `false` |
 
 ### Examples
 
@@ -279,6 +281,7 @@ In addition to [global flags](./index#global-flags):
 | `--keep-archive`, `-k` | Keep archive on instance after import | `false` |
 | `--remote`, `-r` | Target is a filename already on the instance (in Impex/src/instance/) | `false` |
 | `--timeout`, `-t` | Timeout in seconds | No timeout |
+| `--wait`, `-w` | Wait for import job to complete | `true` |
 | `--show-log` | Show job log on failure | `true` |
 
 ### Examples
@@ -334,7 +337,7 @@ In addition to [global flags](./index#global-flags):
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--output`, `-o` | Output path for the export | `.` (current directory) |
+| `--output`, `-o` | Output path for the export | `./export` |
 | `--data-units` | Data units JSON configuration | |
 | `--site` | Site ID(s) to export (comma-separated, repeatable) | |
 | `--site-data` | Site data types to export (comma-separated) | |

--- a/docs/cli/logging.md
+++ b/docs/cli/logging.md
@@ -17,12 +17,12 @@ Human-readable output with colors, suitable for interactive terminal use:
 [18:31:59] INFO: Upload complete
 ```
 
-### JSON Lines (`--json`)
+### JSON Lines (`--jsonl`)
 
 Machine-readable output for scripting, CI/CD pipelines, and log aggregation:
 
 ```bash
-b2c code deploy --json
+b2c code deploy --jsonl
 ```
 
 ```json
@@ -64,7 +64,8 @@ In debug/trace mode, context objects are displayed:
 |------|---------------------|-------------|
 | `--log-level` | `SFCC_LOG_LEVEL` | Set log verbosity |
 | `-D, --debug` | `SFCC_DEBUG` | Enable debug logging |
-| `--json` | | Output JSON lines |
+| `--jsonl, --json-logs` | `SFCC_JSON_LOGS` | Output log messages as JSON lines |
+| `--json` | | Output command result as JSON |
 
 ## Environment Variables
 
@@ -73,7 +74,6 @@ In debug/trace mode, context objects are displayed:
 | `SFCC_LOG_LEVEL` | Log level (trace, debug, info, warn, error, silent) |
 | `SFCC_DEBUG` | Enable debug logging |
 | `SFCC_LOG_TO_STDOUT` | Send logs to stdout instead of stderr |
-| `SFCC_LOG_COLORIZE` | Force colors on/off |
 | `SFCC_REDACT_SECRETS` | Set to `false` to disable secret redaction |
 | `NO_COLOR` | Industry standard to disable colors |
 | `DEBUG` | Set to `oclif*` for CLI framework debug logs |
@@ -125,14 +125,14 @@ SFCC_REDACT_SECRETS=false b2c code deploy --debug
 
 ## CI/CD Usage
 
-For CI/CD pipelines, use JSON output and disable colors:
+For CI/CD pipelines, use JSON lines log output and disable colors:
 
 ```bash
-NO_COLOR=1 b2c code deploy --json 2>&1 | tee deploy.log
+NO_COLOR=1 b2c code deploy --jsonl 2>&1 | tee deploy.log
 ```
 
 Or explicitly set the log level:
 
 ```bash
-SFCC_LOG_LEVEL=info b2c code deploy --json
+SFCC_LOG_LEVEL=info b2c code deploy --jsonl
 ```

--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -121,6 +121,8 @@ b2c logs list
 | `--filter`, `-f` | Filter by log prefix (can specify multiple) | All logs |
 | `--sort` | Sort field: `name`, `date`, `size` | `date` |
 | `--order`, `-o` | Sort order: `asc`, `desc` | `desc` |
+| `--columns`, `-c` | Columns to display (comma-separated). Available: name, prefix, size, modified | - |
+| `--extended`, `-x` | Show all columns including extended fields | `false` |
 | `--json` | Output as JSON | `false` |
 
 ### Examples

--- a/docs/cli/mrt.md
+++ b/docs/cli/mrt.md
@@ -103,8 +103,9 @@ b2c mrt project list --json
 Create a new MRT project.
 
 ```bash
-b2c mrt project create my-storefront --name "My Storefront"
-b2c mrt project create my-storefront --name "My Storefront" --organization my-org
+b2c mrt project create "My Storefront" --organization my-org
+b2c mrt project create "My Storefront" -o my-org --slug my-storefront
+b2c mrt project create "My Storefront" -o my-org --region us-east-1
 ```
 
 ### b2c mrt project get
@@ -313,6 +314,20 @@ Update an environment.
 b2c mrt env update -p my-storefront -e staging --name "Updated Staging"
 b2c mrt env update -p my-storefront -e production --allow-cookies
 ```
+
+**Flags:**
+| Flag | Description |
+|------|-------------|
+| `--name`, `-n` | Display name for the environment |
+| `--production` | Mark as a production environment |
+| `--hostname` | Hostname pattern for V8 Tag loading (use empty string to clear) |
+| `--external-hostname` | Full external hostname (use empty string to clear) |
+| `--external-domain` | External domain for Universal PWA SSR (use empty string to clear) |
+| `--allow-cookies` | Forward HTTP cookies to origin |
+| `--enable-source-maps` | Enable source map support in the environment |
+| `--log-level` | Log level for the environment (`DEBUG`, `INFO`, `WARN`, `ERROR`, `TRACE`, `FATAL`) |
+| `--whitelisted-ips` | IP whitelist (CIDR blocks, space-separated; use empty string to clear) |
+| `--proxy` | Proxy configuration in format `path=host` (repeatable) |
 
 ### b2c mrt env delete
 

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -153,7 +153,7 @@ b2c sandbox create --realm <REALM>
 | `--wait`, `-w` | Wait for sandbox to reach started or failed state | `false` |
 | `--poll-interval` | Polling interval in seconds when using --wait | `10` |
 | `--timeout` | Maximum wait time in seconds (0 for no timeout) | `600` |
-| `--set-permissions` / `--no-set-permissions` | Automatically set OCAPI and WebDAV permissions | `true` |
+| `--set-permissions` | Automatically set OCAPI and WebDAV permissions for the client ID used to create the sandbox | `true` |
 | `--permissions-client-id` | Client ID to use for default OCAPI/WebDAV permissions (defaults to auth client ID) | |
 | `--ocapi-settings` | Custom OCAPI settings JSON array (replaces defaults) | |
 | `--webdav-settings` | Custom WebDAV settings JSON array (replaces defaults) | |
@@ -182,7 +182,7 @@ b2c sandbox create --realm abcd --auto-scheduled
 b2c sandbox create --realm abcd --emails dev@example.com,ops@example.com
 
 # Create without automatic permissions
-b2c sandbox create --realm abcd --no-set-permissions
+b2c sandbox create --realm abcd --set-permissions=false
 
 # Use a different client ID for permissions
 b2c sandbox create --realm abcd --permissions-client-id my-other-client
@@ -651,12 +651,14 @@ b2c sandbox update <SANDBOXID> [FLAGS]
 | Flag | Description |
 |------|-------------|
 | `--ttl` | Number of hours to add to sandbox lifetime (0 or less for infinite). Must adhere to the maximum TTL configuration together with previous extensions. |
-| `--auto-scheduled` / `--no-auto-scheduled` | Enable or disable automatic start/stop scheduling |
+| `--auto-scheduled` | Enable or disable automatic start/stop scheduling |
 | `--resource-profile` | Resource profile (`medium`, `large`, `xlarge`, `xxlarge`) |
 | `--tags` | Comma-separated list of tags |
 | `--emails` | Comma-separated list of notification email addresses |
-| `--start-scheduler` | Start schedule JSON (or `"null"` to remove existing scheduler) |
-| `--stop-scheduler` | Stop schedule JSON (or `"null"` to remove existing scheduler) |
+| `--start-scheduler` | Start schedule JSON |
+| `--stop-scheduler` | Stop schedule JSON |
+| `--clear-start-scheduler` | Remove existing start scheduler |
+| `--clear-stop-scheduler` | Remove existing stop scheduler |
 
 At least one flag is required.
 
@@ -673,7 +675,7 @@ b2c sandbox update zzzv-123 --ttl 0
 b2c sandbox update zzzv-123 --auto-scheduled
 
 # Disable auto-scheduling
-b2c sandbox update zzzv-123 --no-auto-scheduled
+b2c sandbox update zzzv-123 --auto-scheduled=false
 
 # Set tags
 b2c sandbox update zzzv-123 --tags ci,nightly
@@ -684,8 +686,8 @@ b2c sandbox update zzzv-123 --resource-profile large
 # Set notification emails
 b2c sandbox update zzzv-123 --emails dev@example.com,qa@example.com
 
-# Enable automatic scheduling and set scheduler values
-b2c sandbox update zzzv-123 --auto-scheduled --start-scheduler '{"weekdays":["MONDAY"],"time":"08:00:00Z"}' --stop-scheduler "null"
+# Enable automatic scheduling, set a start scheduler, and remove the stop scheduler
+b2c sandbox update zzzv-123 --auto-scheduled --start-scheduler '{"weekdays":["MONDAY"],"time":"08:00:00Z"}' --clear-stop-scheduler
 
 # Combine multiple updates
 b2c sandbox update zzzv-123 --ttl 48 --resource-profile xlarge --tags ci,nightly
@@ -700,6 +702,7 @@ b2c sandbox update zzzv-123 --ttl 48 --json
 - Setting `--ttl` to 0 or less gives the sandbox an infinite lifetime (subject to realm configuration).
 - `--auto-scheduled` controls whether automatic start/stop behavior is enabled for the sandbox.
 - `--start-scheduler` and `--stop-scheduler` define scheduler values, but scheduler automation is effective only when `--auto-scheduled` is enabled.
+- Use `--clear-start-scheduler` and `--clear-stop-scheduler` to remove an existing scheduler.
 
 ---
 
@@ -1355,16 +1358,18 @@ b2c sandbox realm update <REALM> [FLAGS]
 |------|-------------|
 | `--max-sandbox-ttl` | Maximum sandbox TTL in hours (`0` for unlimited, subject to quotas) |
 | `--default-sandbox-ttl` | Default sandbox TTL in hours when no TTL is specified at creation |
-| `--start-scheduler` | Start schedule JSON for sandboxes in this realm (use `"null"` to remove) |
-| `--stop-scheduler` | Stop schedule JSON for sandboxes in this realm (use `"null"` to remove) |
+| `--start-scheduler` | Start schedule JSON for sandboxes in this realm |
+| `--stop-scheduler` | Stop schedule JSON for sandboxes in this realm |
+| `--clear-start-scheduler` | Remove existing start scheduler for sandboxes in this realm |
+| `--clear-stop-scheduler` | Remove existing stop scheduler for sandboxes in this realm |
 | `--emails` | Comma-separated list of realm notification email addresses |
-| `--local-users-allowed` / `--no-local-users-allowed` | Enable or disable local users in realm sandbox configuration |
+| `--local-users-allowed` | Enable or disable local user management for sandboxes in realm configuration |
 
-The scheduler flags expect a JSON value or the literal string `"null"`:
+The scheduler flags expect a JSON value; use the dedicated `--clear-*` flags to remove an existing scheduler:
 
 ```bash
 --start-scheduler '{"weekdays":["MONDAY"],"time":"08:00:00Z"}'
---stop-scheduler "null"    # remove existing stop scheduler
+--clear-stop-scheduler    # remove existing stop scheduler
 ```
 
 #### Examples
@@ -1379,7 +1384,7 @@ b2c sandbox realm update zzzz \
   --stop-scheduler '{"weekdays":["MONDAY","TUESDAY"],"time":"19:00:00Z"}'
 
 # Remove an existing stop scheduler
-b2c sandbox realm update zzzz --stop-scheduler "null"
+b2c sandbox realm update zzzz --clear-stop-scheduler
 
 # Update realm emails and local user setting
 b2c sandbox realm update zzzz --emails dev@example.com,ops@example.com --local-users-allowed

--- a/docs/cli/scaffold.md
+++ b/docs/cli/scaffold.md
@@ -31,16 +31,16 @@ b2c scaffold list [--category <category>] [--source <source>]
 
 | Flag | Description |
 |------|-------------|
-| `--category`, `-c` | Filter by category: `cartridge`, `custom-api`, `page-designer`, `job`, `metadata` |
+| `--category`, `-c` | Filter by category (built-in scaffolds use `cartridge`; custom scaffolds may use other categories) |
 | `--source`, `-s` | Filter by source: `built-in`, `user`, `project`, `plugin` |
 | `--columns` | Columns to display (comma-separated) |
-| `--extended`, `-x` | Show all columns including description and tags |
+| `--extended`, `-x` | Show all columns including description and path |
 
 ### Output
 
 Default columns: `id`, `displayName`, `category`, `source`
 
-Extended columns (with `-x`): adds `description`, `tags`, `path`
+Extended columns (with `-x`): adds `description` and `path`
 
 ### Examples
 
@@ -163,6 +163,14 @@ b2c scaffold search <query> [--category <category>]
 | Flag | Description |
 |------|-------------|
 | `--category`, `-c` | Filter results by category |
+| `--columns` | Columns to display (comma-separated): `id`, `displayName`, `category`, `source`, `description` |
+| `--extended`, `-x` | Show all columns including extended fields |
+
+### Output
+
+Default columns: `id`, `displayName`, `category`, `description`
+
+Extended columns (with `-x`): adds `source`
 
 ### Examples
 

--- a/docs/cli/scapi-schemas.md
+++ b/docs/cli/scapi-schemas.md
@@ -8,12 +8,49 @@ Commands for browsing and retrieving SCAPI (Salesforce Commerce API) schema spec
 
 ## Global SCAPI Schemas Flags
 
-These flags are available on all SCAPI Schemas commands:
+These flags are available on all SCAPI Schemas commands.
+
+### Tenant Flags
 
 | Flag | Environment Variable | Description |
 |------|---------------------|-------------|
 | `--tenant-id` | `SFCC_TENANT_ID` | (Required) Organization/tenant ID |
 | `--short-code` | `SFCC_SHORTCODE` | SCAPI short code |
+
+### Authentication Flags
+
+| Flag | Environment Variable | Description |
+|------|---------------------|-------------|
+| `--client-id` | `SFCC_CLIENT_ID` | Client ID for OAuth |
+| `--client-secret` | `SFCC_CLIENT_SECRET` | Client Secret for OAuth |
+| `--auth-scope` | `SFCC_OAUTH_SCOPES` | OAuth scopes to request (comma-separated, repeatable) |
+| `--auth-methods` | `SFCC_AUTH_METHODS` | Allowed auth methods in priority order (`client-credentials`, `jwt`, `implicit`, `basic`, `api-key`) |
+| `--user-auth` | | Use browser-based user authentication (implicit OAuth flow) |
+| `--account-manager-host` | `SFCC_ACCOUNT_MANAGER_HOST` | Account Manager hostname for OAuth (default: `account.demandware.com`) |
+| `--jwt-cert` | `SFCC_JWT_CERT` | Path to JWT certificate file (`cert.pem`) for JWT Bearer authentication |
+| `--jwt-key` | `SFCC_JWT_KEY` | Path to JWT private key file (`key.pem`) for JWT Bearer authentication |
+| `--jwt-passphrase` | `SFCC_JWT_PASSPHRASE` | Passphrase for encrypted JWT private key |
+
+### Common Flags
+
+| Flag | Environment Variable | Description |
+|------|---------------------|-------------|
+| `--config` | `SFCC_CONFIG` | Path to config file (in `dw.json` format; defaults to `./dw.json`) |
+| `-i`, `--instance` | `SFCC_INSTANCE` | Instance name from configuration file (e.g. `dw.json`) |
+| `--project-directory` | `SFCC_PROJECT_DIRECTORY` | Project directory |
+| `-L`, `--lang` | | Language for messages (e.g., `en`, `de`). Also respects `LANGUAGE` env var |
+| `--log-level` | `SFCC_LOG_LEVEL` | Set logging verbosity (`trace`, `debug`, `info`, `warn`, `error`, `silent`) |
+| `-D`, `--debug` | `SFCC_DEBUG` | Enable debug logging (shorthand for `--log-level debug`) |
+| `--extra-query` | `SFCC_EXTRA_QUERY` | Extra query parameters as JSON (e.g., `'{"debug":"true"}'`) |
+| `--extra-body` | `SFCC_EXTRA_BODY` | Extra body fields to merge as JSON (e.g., `'{"_internal":true}'`) |
+| `--extra-headers` | `SFCC_EXTRA_HEADERS` | Extra HTTP headers as JSON (e.g., `'{"X-Custom-Header": "value"}'`) |
+
+### Output Flags
+
+| Flag | Environment Variable | Description |
+|------|---------------------|-------------|
+| `--json` | | Output result as JSON |
+| `--jsonl` | `SFCC_JSON_LOGS` | Output log messages as JSON lines |
 
 ## Authentication
 
@@ -141,8 +178,7 @@ b2c scapi schemas get <apiFamily> <apiName> <apiVersion> --tenant-id <TENANT_ID>
 | `--expand-paths` | Paths to fully expand (comma-separated) | |
 | `--expand-schemas` | Schema names to fully expand (comma-separated) | |
 | `--expand-examples` | Example names to fully expand (comma-separated) | |
-| `--expand-custom-properties` | Expand custom properties | `true` |
-| `--no-expand-custom-properties` | Do not expand custom properties | |
+| `--expand-custom-properties` | Expand custom properties (boolean — use `--no-expand-custom-properties` to disable) | `true` |
 | `--expand-all` | Return full schema without collapsing | `false` |
 | `--list-paths` | List available paths and exit | `false` |
 | `--list-schemas` | List available schema names and exit | `false` |

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -20,10 +20,12 @@ b2c setup inspect [FLAGS]
 
 ### Flags
 
-| Flag       | Description                                                   | Default |
-| ---------- | ------------------------------------------------------------- | ------- |
-| `--unmask` | Show sensitive values unmasked (passwords, secrets, API keys) | `false` |
-| `--json`   | Output results as JSON                                        | `false` |
+| Flag                     | Description                                                   | Default                  |
+| ------------------------ | ------------------------------------------------------------- | ------------------------ |
+| `--unmask`               | Show sensitive values unmasked (passwords, secrets, API keys) | `false`                  |
+| `--account-manager-host` | Account Manager hostname for OAuth                            | `account.demandware.com` |
+| `--cloud-origin`         | MRT cloud origin URL                                          | `https://cloud.mobify.com` |
+| `--json`                 | Output results as JSON                                        | `false`                  |
 
 ### Examples
 
@@ -279,9 +281,11 @@ b2c setup instance list [FLAGS]
 
 ### Flags
 
-| Flag     | Description            | Default |
-| -------- | ---------------------- | ------- |
-| `--json` | Output results as JSON | `false` |
+| Flag               | Description                                                          | Default |
+| ------------------ | -------------------------------------------------------------------- | ------- |
+| `--columns`, `-c`  | Columns to display (comma-separated): name, hostname, source, active | All     |
+| `--extended`, `-x` | Show all columns including extended fields                           | `false` |
+| `--json`           | Output results as JSON                                               | `false` |
 
 ### Examples
 
@@ -477,6 +481,8 @@ b2c setup skills [SKILLSET]
 | `--update`, `-u`      | Update existing skills (overwrite)                                                             | `false`     |
 | `--version`           | Specific release version                                                                       | `latest`    |
 | `--force`             | Skip confirmation prompts (non-interactive)                                                    | `false`     |
+| `--columns`, `-c`     | Columns to display (comma-separated): name, description, skillSet, hasReferences               |             |
+| `--extended`, `-x`    | Show all columns including extended fields                                                     | `false`     |
 | `--json`              | Output results as JSON                                                                         | `false`     |
 
 ### Supported IDEs

--- a/docs/cli/sites.md
+++ b/docs/cli/sites.md
@@ -181,7 +181,7 @@ b2c sites cartridges add bm_extension --bm --position first
 Remove a cartridge from a site's cartridge path.
 
 ::: warning Destructive Operation
-This command modifies the site cartridge path. It is blocked in safe mode — use `--safety-level off` to allow it.
+This command modifies the site cartridge path. It is blocked in safe mode — set the `SFCC_SAFETY_LEVEL=NONE` environment variable or update the "safety" section in your `dw.json` configuration file to allow it.
 :::
 
 #### Usage
@@ -218,7 +218,7 @@ b2c sites cartridges remove bm_extension --bm
 Replace the entire cartridge path for a site.
 
 ::: warning Destructive Operation
-This command replaces the entire cartridge path. It is blocked in safe mode — use `--safety-level off` to allow it.
+This command replaces the entire cartridge path. It is blocked in safe mode — set the `SFCC_SAFETY_LEVEL=NONE` environment variable or configure `"safety": {"level": "NONE"}` in your `dw.json` to allow it.
 :::
 
 #### Usage

--- a/docs/cli/slas.md
+++ b/docs/cli/slas.md
@@ -189,7 +189,7 @@ Displays a list of SLAS clients with:
 
 ## b2c slas client create
 
-Create a new SLAS client.
+Create or update a SLAS client.
 
 ### Usage
 

--- a/docs/cli/webdav.md
+++ b/docs/cli/webdav.md
@@ -14,7 +14,7 @@ These flags are available on all WebDAV commands:
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--root`, `-r` | WebDAV root directory | `impex` |
+| `--root`, `-r` | WebDAV root directory | `IMPEX` |
 
 Available roots:
 
@@ -90,6 +90,13 @@ b2c webdav ls [PATH]
 |----------|-------------|---------|
 | `PATH` | Path relative to root | Root directory |
 
+### Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-c, --columns` | Columns to display (comma-separated). Available: name, type, size, modified, contentType | name, type, size |
+| `-x, --extended` | Show all columns including extended fields | `false` |
+
 ### Examples
 
 ```bash
@@ -128,7 +135,7 @@ Download a file from WebDAV.
 ### Usage
 
 ```bash
-b2c webdav get <REMOTE> [LOCAL]
+b2c webdav get <REMOTE>
 ```
 
 ### Arguments
@@ -136,7 +143,12 @@ b2c webdav get <REMOTE> [LOCAL]
 | Argument | Description | Required |
 |----------|-------------|----------|
 | `REMOTE` | Remote file path relative to root | Yes |
-| `LOCAL` | Local destination path | No (uses filename in current directory) |
+
+### Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-o, --output` | Output file path (use `-` for stdout) | Filename in current directory |
 
 ### Examples
 
@@ -145,7 +157,7 @@ b2c webdav get <REMOTE> [LOCAL]
 b2c webdav get src/instance/export.zip
 
 # Download to specific location
-b2c webdav get src/instance/export.zip ./downloads/export.zip
+b2c webdav get src/instance/export.zip -o ./downloads/export.zip
 
 # Download a log file
 b2c webdav get --root=logs customerror.log

--- a/docs/guide/analytics-reports-cip-ccac.md
+++ b/docs/guide/analytics-reports-cip-ccac.md
@@ -56,7 +56,7 @@ To enable non-production support, turn on **Enable Reports & Dashboards Data Tra
 
 Reports & Dashboards non-production URL:
 
-- `https://ccac.stg.analytics.commercecloud.salesforce.com`
+- `https://jdbc.stg.analytics.commercecloud.salesforce.com`
 
 For CLI commands, you can target the staging analytics host with `--staging`.
 

--- a/docs/guide/ci-cd.md
+++ b/docs/guide/ci-cd.md
@@ -166,7 +166,7 @@ Deploy cartridges with typed inputs.
     username: ${{ secrets.SFCC_USERNAME }}
     password: ${{ secrets.SFCC_PASSWORD }}
     code-version: ${{ vars.SFCC_CODE_VERSION }}
-    reload: true
+    activate: true
     cartridges: 'app_storefront_base,app_custom'
 ```
 
@@ -353,7 +353,7 @@ When `json` is enabled (the default), the `result` output contains the command's
   id: deploy
   with:
     code-version: v25_03_1
-    reload: true
+    activate: true
 
 - name: Show deploy result
   run: echo '${{ steps.deploy.outputs.result }}'

--- a/docs/guide/commerce-apps.md
+++ b/docs/guide/commerce-apps.md
@@ -104,7 +104,7 @@ After install, complete the setup wizard tasks in Business Manager or via CLI. I
 To remove an installed app:
 
 ```bash
-b2c cap uninstall my-integration --domain tax --site RefArch
+b2c cap uninstall my-integration --site RefArch
 ```
 
 ## VS Code Extension Integration
@@ -127,7 +127,7 @@ Install and uninstall commands require:
 - **WebDAV credentials** (`SFCC_USERNAME`, `SFCC_PASSWORD`) — for uploading the CAP zip
 
 ```bash
-export SFCC_HOSTNAME=my-instance.commercecloud.salesforce.com
+export SFCC_SERVER=my-instance.commercecloud.salesforce.com
 export SFCC_CLIENT_ID=your-client-id
 export SFCC_CLIENT_SECRET=your-client-secret
 export SFCC_USERNAME=your-bm-username
@@ -150,7 +150,7 @@ A typical CI/CD pipeline for Commerce App deployment:
 - name: Install CAP
   run: b2c cap install ./dist/my-integration-v${{ env.VERSION }}.zip --site ${{ env.SITE_ID }}
   env:
-    SFCC_HOSTNAME: ${{ secrets.SFCC_HOSTNAME }}
+    SFCC_SERVER: ${{ secrets.SFCC_SERVER }}
     SFCC_CLIENT_ID: ${{ secrets.SFCC_CLIENT_ID }}
     SFCC_CLIENT_SECRET: ${{ secrets.SFCC_CLIENT_SECRET }}
     SFCC_USERNAME: ${{ secrets.SFCC_USERNAME }}

--- a/docs/guide/extending.md
+++ b/docs/guide/extending.md
@@ -840,7 +840,7 @@ const envFilterTransformer: CartridgeTransformer = {
 
 ## Scaffold Providers
 
-Plugins can provide custom scaffolds via the `b2c:scaffold-providers` hook, or register providers programmatically via the SDK's `scaffoldRegistry`.
+Plugins can provide custom scaffolds via the `b2c:scaffold-providers` hook, or register providers programmatically via the SDK's `createScaffoldRegistry()` factory.
 
 ### Hook: `b2c:scaffold-providers`
 
@@ -914,13 +914,16 @@ const transformer: ScaffoldTransformer = {
 
 ### SDK Usage (without CLI)
 
-For programmatic SDK usage without the CLI, register providers directly with the scaffold registry:
+For programmatic SDK usage without the CLI, create a scaffold registry and register providers and transformers on it:
 
 ```typescript
-import { scaffoldRegistry } from '@salesforce/b2c-tooling-sdk/scaffold';
+import { createScaffoldRegistry } from '@salesforce/b2c-tooling-sdk/scaffold';
+
+// Create a registry instance
+const registry = createScaffoldRegistry();
 
 // Add a custom provider
-scaffoldRegistry.addProviders([{
+registry.addProviders([{
   name: 'my-provider',
   priority: 'after',
   async getScaffolds(options) {
@@ -929,7 +932,7 @@ scaffoldRegistry.addProviders([{
 }]);
 
 // Add a transformer
-scaffoldRegistry.addTransformers([{
+registry.addTransformers([{
   name: 'my-transformer',
   async transform(scaffolds, options) {
     return scaffolds;
@@ -937,31 +940,9 @@ scaffoldRegistry.addTransformers([{
 }]);
 ```
 
-### Example: Plugin Hook Implementation
-
-```typescript
-// src/hooks/scaffold-providers.ts
-import type { ScaffoldProvidersHook } from '@salesforce/b2c-tooling-sdk/cli';
-import type { ScaffoldProvider } from '@salesforce/b2c-tooling-sdk/scaffold';
-
-const hook: ScaffoldProvidersHook = async function(options) {
-  const customProvider: ScaffoldProvider = {
-    name: 'my-plugin-scaffolds',
-    priority: 'after',
-
-    async getScaffolds(discoveryOptions) {
-      // Load scaffolds from plugin's bundled templates
-      const scaffoldsDir = new URL('../scaffolds', import.meta.url).pathname;
-      // ... load and return scaffolds
-      return [];
-    },
-  };
-
-  return { providers: [customProvider] };
-};
-
-export default hook;
-```
+::: tip Programmatic Registration
+Scaffold providers are registered programmatically via `createScaffoldRegistry()` (see the example above). The SDK does not currently expose a typed `ScaffoldProvidersHook` for plugin-based registration — use the registry API from your plugin's command initialization instead.
+:::
 
 See [Scaffolding Guide](./scaffolding) for details on creating custom scaffolds.
 

--- a/docs/guide/ide-integration.md
+++ b/docs/guide/ide-integration.md
@@ -46,7 +46,7 @@ This creates two artifacts at the repo root:
 - `./.b2c-script-types/types/` — vendored copy of the Script API definitions.
 - `./jsconfig.json` — TypeScript Language Service configuration mapping `dw/*` to the vendored types.
 
-You can commit both into your repository if you want everyone on the team to share the same setup. To re-vendor after upgrading the CLI, re-run with `--force`. The `jsconfig.json` lives at the repo root by design — the `paths` mappings inside it are repo-root-relative and will not resolve correctly from a subdirectory.
+You can commit both into your repository if you want everyone on the team to share the same setup. To re-vendor after upgrading the CLI, re-run the command with `--force` to overwrite the existing files. The vendored types are refreshed automatically because the `--copy` flag defaults to true. The `jsconfig.json` lives at the repo root by design — the `paths` mappings inside it are repo-root-relative and will not resolve correctly from a subdirectory.
 
 The generated `jsconfig.json` looks like this — feel free to author it yourself if you prefer:
 
@@ -115,7 +115,7 @@ If your editor's LSP client is launched outside the repo root (for example, open
 
 ### Notes
 
-- The bundle is version-locked to a Script API release (currently 26.7). Re-run `b2c setup ide vscode-types --force` after upgrading the CLI to refresh the vendored copy. The plugin path returned by `b2c setup ide tsserver-plugin` always points at the bundle shipped with your installed CLI.
+- The bundle is version-locked to a Script API release (currently 26.7). Re-run `b2c setup ide vscode-types` after upgrading the CLI to refresh the vendored copy; use `--force` to overwrite existing files if they were previously created. The plugin path returned by `b2c setup ide tsserver-plugin` always points at the bundle shipped with your installed CLI.
 - The vendored `jsconfig.json` only configures `dw/*` IntelliSense. Cartridge-relative requires (`~/cartridge/...`, `*/cartridge/...`, `cartridgeName/cartridge/...`) cannot be expressed in standalone TypeScript `paths` mappings (TypeScript allows at most one `*` per pattern), so they will appear unresolved without the B2C DX VS Code extension or another host that loads `@salesforce/b2c-script-types/plugin` via LSP.
 
 ## Prophet VS Code Extension

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -29,7 +29,7 @@ npx @salesforce/b2c-cli --help
 ```
 
 ```bash [Homebrew]
-brew install SalesforceCommerceCloud/tools/b2c-cli
+brew install salesforcecommercecloud/tools/b2c-cli
 ```
 
 :::

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,5 +1,5 @@
 ---
-description: Install the B2C CLI via npm, Homebrew, or GitHub releases, and optionally install the SDK for programmatic use.
+description: Install the B2C CLI via npm or GitHub releases, and optionally install the SDK for programmatic use.
 ---
 
 # Installation
@@ -28,21 +28,6 @@ yarn global add @salesforce/b2c-cli
 ```
 
 :::
-
-## Install via Homebrew
-
-On macOS or Linux, you can install via Homebrew:
-
-```bash
-brew install salesforcecommercecloud/tools/b2c-cli
-```
-
-Or tap the repository first:
-
-```bash
-brew tap salesforcecommercecloud/tools
-brew install b2c-cli
-```
 
 ## Verify Installation
 

--- a/docs/guide/mrt-utilities.md
+++ b/docs/guide/mrt-utilities.md
@@ -15,7 +15,7 @@ The `@salesforce/mrt-utilities` package provides middleware and utilities to sim
 ## Prerequisites
 
 - Node.js 22.16.0 or later
-- [Express](https://expressjs.com/) 5.x (peer dependency)
+- [Express](https://expressjs.com/) 4.x or 5.x (peer dependency)
 
 ## Installation
 

--- a/docs/guide/scaffolding.md
+++ b/docs/guide/scaffolding.md
@@ -135,15 +135,15 @@ Creates a hook implementation with automatic hooks.json registration.
 
 **Parameters:**
 - `hookName` (required) - Hook function name in camelCase
-- `hookType` (required) - Hook type: ocapi, scapi, or system
+- `hookType` (required) - Hook type: scapi-ocapi or system
 - `hookPoint` (required) - Extension point (auto-discovered list)
 - `cartridgeName` (required) - Target cartridge
 
 ```bash
 b2c scaffold hook \
   --option hookName=validateBasket \
-  --option hookType=ocapi \
-  --option hookPoint=dw.ocapi.shop.basket.beforePOST \
+  --option hookType=scapi-ocapi \
+  --option scapiOcapiHookPoint=dw.ocapi.shop.basket.beforePOST \
   --option cartridgeName=app_custom
 ```
 

--- a/docs/guide/sdk-migration.md
+++ b/docs/guide/sdk-migration.md
@@ -65,7 +65,7 @@ const versions = await listCodeVersions(instance);
 
 // Account Manager operations (users, AM roles, orgs) use a separate client
 const amClient = createAccountManagerClient({}, config.createOAuth());
-const users = await listUsers(amClient.users, {size: 25});
+const users = await amClient.listUsers({size: 25});
 ```
 
 Both `instance` and `amClient` manage their own tokens — you never see or pass a token string. See the [Authentication Setup](./authentication) guide for credential configuration details.
@@ -266,7 +266,6 @@ Account Manager operations use a separate client (not `instance`), since they ta
 ```typescript
 import {resolveConfig} from '@salesforce/b2c-tooling-sdk/config';
 import {createAccountManagerClient} from '@salesforce/b2c-tooling-sdk/clients';
-import {listUsers, createUser, grantRole} from '@salesforce/b2c-tooling-sdk/operations/users';
 
 const config = await resolveConfig();
 
@@ -274,10 +273,10 @@ const config = await resolveConfig();
 const client = createAccountManagerClient({}, config.createOAuth());
 
 // List users
-const users = await listUsers(client.users, {size: 25});
+const users = await client.listUsers({size: 25});
 
 // Create a user
-const newUser = await createUser(client.users, {
+const newUser = await client.createUser({
   mail: 'user@example.com',
   firstName: 'Test',
   lastName: 'User',
@@ -285,11 +284,7 @@ const newUser = await createUser(client.users, {
 });
 
 // Grant a role
-await grantRole(client.users, {
-  userId: newUser.id,
-  roleId: 'bm-admin',
-  scope: 'my-realm',
-});
+await client.grantRole(newUser.id, 'bm-admin', 'my-realm');
 ```
 
 See the [Account Manager guide](./account-manager) for more details on AM operations.
@@ -306,9 +301,8 @@ The SDK separates Account Manager roles from Business Manager instance roles int
 | `user.revokeLocal(instance, login, role, ...)` | `revokeBmRole(instance, roleId, login)` | `operations/bm-roles` |
 
 ```typescript
-// Account Manager roles (organization-level)
-import {listRoles} from '@salesforce/b2c-tooling-sdk/operations/roles';
-const amRoles = await listRoles(client.roles, {size: 50});
+// Account Manager roles (organization-level) — use the unified client directly
+const amRoles = await client.listRoles({size: 50});
 
 // Business Manager roles (instance-level)
 import {listBmRoles, grantBmRole, revokeBmRole} from '@salesforce/b2c-tooling-sdk/operations/bm-roles';
@@ -320,10 +314,9 @@ await revokeBmRole(instance, 'Administrator', 'user@example.com');
 ### Organizations (`sfcc.org`)
 
 ```typescript
-import {listOrgs, getOrg} from '@salesforce/b2c-tooling-sdk/operations/orgs';
-
-const orgs = await listOrgs(client.orgs, {size: 25});
-const org = await getOrg(client.orgs, 'my-org-id');
+// Use the unified client directly
+const orgs = await client.listOrgs({size: 25});
+const org = await client.getOrg('my-org-id');
 ```
 
 ## Using Typed Clients Directly

--- a/docs/guide/sfcc-ci-migration.md
+++ b/docs/guide/sfcc-ci-migration.md
@@ -151,8 +151,6 @@ Most sfcc-ci environment variables are supported directly or through backward-co
 | `SFCC_OAUTH_USER_NAME` | `SFCC_OAUTH_USER_NAME` | Same |
 | `SFCC_OAUTH_USER_PASSWORD` | `SFCC_OAUTH_USER_PASSWORD` | Same |
 | `SFCC_SANDBOX_API_HOST` | `SFCC_SANDBOX_API_HOST` | Same |
-| `SFCC_SCAPI_SHORTCODE` | `SFCC_SHORTCODE` | Renamed |
-| `SFCC_SCAPI_TENANTID` | `SFCC_TENANT_ID` | Renamed |
 
 The B2C CLI also introduces new environment variables not present in sfcc-ci:
 
@@ -162,6 +160,8 @@ The B2C CLI also introduces new environment variables not present in sfcc-ci:
 | `SFCC_USERNAME` | WebDAV / Basic auth username |
 | `SFCC_PASSWORD` | WebDAV / Basic auth password |
 | `SFCC_CODE_VERSION` | Code version for deployments |
+| `SFCC_SHORTCODE` | SCAPI short code |
+| `SFCC_TENANT_ID` | SCAPI tenant ID |
 | `SFCC_AUTH_METHODS` | Auth method priority (comma-separated) |
 
 See the [Configuration guide](./configuration) for the complete list of environment variables and configuration sources.

--- a/docs/guide/storefront-next.md
+++ b/docs/guide/storefront-next.md
@@ -199,7 +199,7 @@ b2c mrt tail-logs -p <PROJECT> -e <ENVIRONMENT> --level ERROR --level WARN
 b2c mrt tail-logs -p <PROJECT> -e <ENVIRONMENT> --search "timeout|500"
 ```
 
-This is useful for diagnosing deployment failures, SSR errors, and API connectivity issues. See [MRT Commands](/cli/mrt#tail-logs) for all options.
+This is useful for diagnosing deployment failures, SSR errors, and API connectivity issues. See [MRT Commands](/cli/mrt#b2c-mrt-tail-logs) for all options.
 
 ## Summary
 

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -7,6 +7,7 @@
     "../packages/b2c-tooling-sdk/src/instance/index.ts",
     "../packages/b2c-tooling-sdk/src/logging/index.ts",
     "../packages/b2c-tooling-sdk/src/errors/index.ts",
+    "../packages/b2c-tooling-sdk/src/operations/cap/index.ts",
     "../packages/b2c-tooling-sdk/src/operations/code/index.ts",
     "../packages/b2c-tooling-sdk/src/operations/content/index.ts",
     "../packages/b2c-tooling-sdk/src/operations/cip/index.ts",

--- a/packages/b2c-tooling-sdk/src/auth/api-key.ts
+++ b/packages/b2c-tooling-sdk/src/auth/api-key.ts
@@ -27,6 +27,12 @@ export class ApiKeyStrategy implements AuthStrategy {
   private readonly headerValue: string;
   private readonly headerName: string;
 
+  /**
+   * Creates a new ApiKeyStrategy instance for API key authentication.
+   *
+   * @param key - The API key value to use for authentication
+   * @param headerName - The HTTP header name to populate with the API key. Defaults to 'x-api-key'. When set to 'Authorization', the key will be formatted as a Bearer token ('Bearer {key}'); for other header names, the key is set directly.
+   */
   constructor(key: string, headerName = 'x-api-key') {
     const logger = getLogger();
     this.headerName = headerName;

--- a/packages/b2c-tooling-sdk/src/auth/basic.ts
+++ b/packages/b2c-tooling-sdk/src/auth/basic.ts
@@ -6,9 +6,29 @@
 import type {AuthStrategy, FetchInit} from './types.js';
 import {getLogger} from '../logging/logger.js';
 
+/**
+ * Basic authentication strategy for WebDAV operations.
+ *
+ * Encodes username and access key as Base64 for HTTP Basic auth.
+ * Implements the {@link AuthStrategy} interface.
+ *
+ * @example
+ * ```typescript
+ * import { BasicAuthStrategy } from '@salesforce/b2c-tooling-sdk';
+ *
+ * const auth = new BasicAuthStrategy('username', 'access-key');
+ * const response = await auth.fetch('https://webdav.example.com/path');
+ * ```
+ */
 export class BasicAuthStrategy implements AuthStrategy {
   private encoded: string;
 
+  /**
+   * Creates a new BasicAuthStrategy instance for HTTP Basic authentication.
+   *
+   * @param user - The username for Basic authentication
+   * @param pass - The password or access key for Basic authentication
+   */
   constructor(user: string, pass: string) {
     this.encoded = Buffer.from(`${user}:${pass}`).toString('base64');
 

--- a/packages/b2c-tooling-sdk/src/auth/oauth-implicit.ts
+++ b/packages/b2c-tooling-sdk/src/auth/oauth-implicit.ts
@@ -116,6 +116,11 @@ export class ImplicitOAuthStrategy implements AuthStrategy {
   private redirectUri: string;
   private _hasHadSuccess = false;
 
+  /**
+   * Creates a new ImplicitOAuthStrategy instance.
+   *
+   * @param config - OAuth implicit flow configuration containing clientId, optional scopes, accountManagerHost, localPort, redirectUri, and openBrowser callback.
+   */
   constructor(private config: ImplicitOAuthConfig) {
     this.accountManagerHost = config.accountManagerHost || DEFAULT_ACCOUNT_MANAGER_HOST;
     this.localPort = config.localPort || parseInt(process.env.SFCC_OAUTH_LOCAL_PORT || '', 10) || DEFAULT_LOCAL_PORT;

--- a/packages/b2c-tooling-sdk/src/auth/oauth-jwt.ts
+++ b/packages/b2c-tooling-sdk/src/auth/oauth-jwt.ts
@@ -84,6 +84,17 @@ export class JwtOAuthStrategy implements AuthStrategy {
   private _hasHadSuccess = false;
   private readonly privateKey: crypto.KeyObject;
 
+  /**
+   * Creates a new JwtOAuthStrategy instance.
+   *
+   * Validates the provided configuration and caches the private key during construction
+   * to avoid repeated file I/O during token requests.
+   *
+   * @param config - JWT OAuth configuration containing clientId, certificate/key file paths, and Account Manager host
+   * @throws Error if clientId, certPath, keyPath, or accountManagerHost are missing
+   * @throws Error if certificate or key files do not exist, are unreadable, or have invalid PEM format
+   * @throws Error if the private key is encrypted but no passphrase is provided, or the passphrase is incorrect
+   */
   constructor(config: JwtOAuthConfig) {
     this.validateConfig(config);
     this.config = config;

--- a/packages/b2c-tooling-sdk/src/auth/oauth.ts
+++ b/packages/b2c-tooling-sdk/src/auth/oauth.ts
@@ -98,11 +98,37 @@ export function invalidateCachedOAuthToken(cacheKey: string): void {
   ACCESS_TOKEN_CACHE.delete(cacheKey);
 }
 
+/**
+ * OAuth 2.0 Client Credentials authentication strategy.
+ *
+ * Implements the client credentials flow for automated/server-side authentication
+ * with no user interaction required. Automatically manages token caching, expiration,
+ * and 401 retry logic with single-flight token requests to prevent thundering herd
+ * on the token endpoint.
+ *
+ * @example
+ * ```typescript
+ * import { OAuthStrategy } from '@salesforce/b2c-tooling-sdk';
+ *
+ * const auth = new OAuthStrategy({
+ *   clientId: 'your-client-id',
+ *   clientSecret: 'your-client-secret',
+ *   scopes: ['sfcc.products'],
+ * });
+ *
+ * const response = await auth.fetch('https://api.example.com/products');
+ * ```
+ */
 export class OAuthStrategy implements AuthStrategy {
   private accountManagerHost: string;
   private _hasHadSuccess = false;
   private cacheKey: string;
 
+  /**
+   * Creates a new OAuthStrategy instance with the provided OAuth configuration.
+   *
+   * @param config - OAuth client credentials and optional configuration
+   */
   constructor(private config: OAuthConfig) {
     this.accountManagerHost = config.accountManagerHost || DEFAULT_ACCOUNT_MANAGER_HOST;
     this.cacheKey = getOAuthCacheKey(
@@ -113,6 +139,18 @@ export class OAuthStrategy implements AuthStrategy {
     );
   }
 
+  /**
+   * Performs a fetch request with OAuth bearer token authentication.
+   *
+   * Automatically injects the Authorization header and client ID header with a valid
+   * access token. Implements 401 retry logic: if a previously-successful request
+   * returns 401, invalidates the cached token and retries once with a fresh token.
+   * Does not retry on initial 401 to avoid retrying with bad credentials.
+   *
+   * @param url - The URL to fetch
+   * @param init - Optional fetch init options (headers, body, method, etc.)
+   * @returns The fetch response
+   */
   async fetch(url: string, init: FetchInit = {}): Promise<Response> {
     const token = await this.getAccessToken();
 

--- a/packages/b2c-tooling-sdk/src/auth/resolve.ts
+++ b/packages/b2c-tooling-sdk/src/auth/resolve.ts
@@ -41,7 +41,13 @@ export interface ResolveAuthStrategyOptions {
   /**
    * Allowed authentication methods in priority order.
    * The first method with available credentials will be used.
-   * Defaults to all methods: ['client-credentials', 'implicit', 'basic', 'api-key']
+   * Defaults to: ['client-credentials', 'implicit', 'basic', 'api-key'].
+   *
+   * Note: the `'jwt'` method is defined in the {@link AuthMethod} type but is
+   * not automatically resolvable here, because JWT auth requires file paths
+   * (e.g. `certPath`/`keyPath`) that are not part of the generic
+   * {@link AuthCredentials} accepted by this resolver. To use JWT, instantiate
+   * `JwtOAuthStrategy` directly instead of relying on `resolveAuthStrategy`.
    */
   allowedMethods?: AuthMethod[];
 }

--- a/packages/b2c-tooling-sdk/src/auth/stateful-oauth-strategy.ts
+++ b/packages/b2c-tooling-sdk/src/auth/stateful-oauth-strategy.ts
@@ -34,6 +34,14 @@ export class StatefulOAuthStrategy implements AuthStrategy {
   private _session: StatefulSession;
   private _hasHadSuccess = false;
 
+  /**
+   * Creates a new StatefulOAuthStrategy instance.
+   *
+   * @param session - The stateful session containing clientId, accessToken, and optional refresh/renew credentials
+   * @param options - Strategy configuration options
+   * @param options.accountManagerHost - The Account Manager hostname (defaults to DEFAULT_ACCOUNT_MANAGER_HOST)
+   * @param options.scopes - Optional OAuth scopes to request during token refresh
+   */
   constructor(session: StatefulSession, options: StatefulOAuthStrategyOptions) {
     this._session = session;
     this.accountManagerHost = options.accountManagerHost || DEFAULT_ACCOUNT_MANAGER_HOST;

--- a/packages/b2c-tooling-sdk/src/cli/base-command.ts
+++ b/packages/b2c-tooling-sdk/src/cli/base-command.ts
@@ -241,6 +241,8 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
    * Use this when you need to pass custom initial attributes or use a different connection string.
    *
    * @param options - Telemetry options
+   * @param options.appInsightsKey - Optional Application Insights connection string (overrides pjson config)
+   * @param options.initialAttributes - Custom attributes to add to telemetry events
    * @returns The telemetry instance, or undefined if telemetry is disabled
    */
   protected async initTelemetry(options: {

--- a/packages/b2c-tooling-sdk/src/cli/index.ts
+++ b/packages/b2c-tooling-sdk/src/cli/index.ts
@@ -132,6 +132,13 @@ export type {
   B2COperationLifecycleHookOptions,
   B2COperationLifecycleHookResult,
   B2COperationLifecycleHook,
+  // Cartridge provider hook types
+  CartridgeDiscoveryOptions,
+  CartridgeProvider,
+  CartridgeTransformer,
+  CartridgeProvidersHookOptions,
+  CartridgeProvidersHookResult,
+  CartridgeProvidersHook,
 } from './hooks.js';
 export {createB2COperationContext, B2CLifecycleRunner} from './hooks.js';
 // Re-export module augmentation for @oclif/core Hooks interface

--- a/packages/b2c-tooling-sdk/src/cli/job-command.ts
+++ b/packages/b2c-tooling-sdk/src/cli/job-command.ts
@@ -33,7 +33,7 @@ export abstract class JobCommand<T extends typeof Command> extends InstanceComma
    * Display a job's log file content and error message if available.
    * Outputs to stderr since this is typically shown for failed jobs.
    *
-   * @param execution - Job execution with log file info
+   * @param execution - Failed job execution object with log file information
    */
   protected async showJobLog(execution: JobExecution): Promise<void> {
     // Extract error message from failed step executions

--- a/packages/b2c-tooling-sdk/src/cli/mrt-command.ts
+++ b/packages/b2c-tooling-sdk/src/cli/mrt-command.ts
@@ -97,6 +97,7 @@ export abstract class MrtCommand<T extends typeof Command> extends BaseCommand<T
 
   /**
    * Validates that MRT credentials are configured, errors if not.
+   * @throws {Error} If MRT API key is not configured
    */
   protected requireMrtCredentials(): void {
     if (!this.hasMrtCredentials()) {

--- a/packages/b2c-tooling-sdk/src/cli/oauth-command.ts
+++ b/packages/b2c-tooling-sdk/src/cli/oauth-command.ts
@@ -165,6 +165,7 @@ export abstract class OAuthCommand<T extends typeof Command> extends BaseCommand
    * For the implicit flow, falls back to getDefaultClientId() when no client ID
    * is explicitly configured.
    *
+   * @returns An OAuth strategy instance ({@link OAuthStrategy}, {@link JwtOAuthStrategy}, {@link ImplicitOAuthStrategy}, or {@link StatefulOAuthStrategy}) based on configured credentials and allowed authentication methods.
    * @throws Error if no allowed method has the required credentials configured
    */
   protected getOAuthStrategy(): OAuthStrategy | JwtOAuthStrategy | ImplicitOAuthStrategy | StatefulOAuthStrategy {

--- a/packages/b2c-tooling-sdk/src/clients/am-api.ts
+++ b/packages/b2c-tooling-sdk/src/clients/am-api.ts
@@ -38,7 +38,13 @@ import {getLogger} from '../logging/logger.js';
 export const ROLE_TENANT_FILTER_PATTERN = /^(\w+:\w{4,}_\w{3,}(,\w{4,}_\w{3,})*(;)?)*$/;
 
 /**
- * Returns true if the value matches the Account Manager role tenant filter format.
+ * Validates whether a string matches the Account Manager role tenant filter format.
+ *
+ * Format: `ROLE_ENUM:realm_instance(,realm_instance)*(;ROLE_ENUM:...)*`
+ * Examples: `SALESFORCE_COMMERCE_API:abcd_prd` or `bm-admin:tenant1,tenant2;ECOM_USER:wxyz_stg`
+ *
+ * @param value - The string to validate
+ * @returns True if the value matches the role tenant filter format, false otherwise
  */
 export function isValidRoleTenantFilter(value: string): boolean {
   return value.length > 0 && ROLE_TENANT_FILTER_PATTERN.test(value);
@@ -746,6 +752,12 @@ export async function listApiClients(
 
 /**
  * Retrieves an API client by ID.
+ *
+ * @param client - Account Manager API Clients client instance
+ * @param apiClientId - ID of the API client to retrieve
+ * @param expand - Optional array of fields to expand in the response
+ * @returns Promise resolving to the API client details
+ * @throws Error if the API client is not found (404) or if the request fails
  */
 export async function getApiClient(
   client: AccountManagerApiClientsClient,
@@ -825,6 +837,12 @@ export async function createApiClient(
 
 /**
  * Updates an existing API client.
+ *
+ * @param client - Account Manager API Clients client
+ * @param apiClientId - API client ID to update
+ * @param body - API client update data
+ * @returns Updated API client
+ * @throws Error if request fails or if the request body contains validation errors
  */
 export async function updateApiClient(
   client: AccountManagerApiClientsClient,

--- a/packages/b2c-tooling-sdk/src/clients/cip.ts
+++ b/packages/b2c-tooling-sdk/src/clients/cip.ts
@@ -3,6 +3,15 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
+/**
+ * CIP (Commerce Intelligence Platform) client for B2C Commerce analytics.
+ *
+ * Provides a typed client for the CIP Avatica JDBC interface, enabling
+ * programmatic execution of analytics queries and retrieval of result sets
+ * with column metadata.
+ *
+ * @module clients/cip
+ */
 import path from 'node:path';
 import {randomUUID} from 'node:crypto';
 import {createRequire} from 'node:module';

--- a/packages/b2c-tooling-sdk/src/clients/granular-replications.ts
+++ b/packages/b2c-tooling-sdk/src/clients/granular-replications.ts
@@ -3,6 +3,15 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
+/**
+ * Granular Replications API client for B2C Commerce.
+ *
+ * Provides a fully typed client for Granular Replications API operations using
+ * openapi-fetch with OAuth authentication middleware. Used for publishing individual
+ * items (products, price tables, content assets) from staging to production.
+ *
+ * @module clients/granular-replications
+ */
 import createClient, {type Client} from 'openapi-fetch';
 import type {AuthStrategy} from '../auth/types.js';
 import type {paths, components} from './granular-replications.generated.js';
@@ -28,6 +37,14 @@ export type PublishProcessResponse = components['schemas']['PublishProcessRespon
 export type PublishProcessListResponse = components['schemas']['PublishProcessListResponse'];
 export type PublishIdResponse = components['schemas']['PublishIdResponse'];
 
+/**
+ * Configuration for creating a Granular Replications API client.
+ *
+ * @property shortCode - The instance short code (e.g., 'kv7kzm78')
+ * @property tenantId - The tenant ID (e.g., 'zzxy_prd')
+ * @property scopes - Optional custom OAuth scopes. Defaults to sfcc.granular-replications.rw and tenant-specific scope
+ * @property middlewareRegistry - Optional custom middleware registry for request/response interceptors
+ */
 export interface GranularReplicationsClientConfig {
   shortCode: string;
   tenantId: string;

--- a/packages/b2c-tooling-sdk/src/config/dw-json.ts
+++ b/packages/b2c-tooling-sdk/src/config/dw-json.ts
@@ -174,7 +174,7 @@ export interface LoadDwJsonResult {
  * Finds dw.json by searching upward from the starting directory.
  *
  * @param projectDirectory - Directory to start searching from (defaults to cwd)
- * @returns Path to dw.json if found, undefined otherwise
+ * @returns A Promise that resolves to the path to dw.json if found, or undefined if not found
  *
  * @example
  * const dwPath = findDwJson();
@@ -266,7 +266,7 @@ function selectConfig(json: DwJsonMultiConfig, instanceName?: string): DwJsonCon
  * with the full configs array.
  *
  * @param options - Loading options
- * @returns The raw multi-config structure and path, or undefined if not found
+ * @returns A Promise that resolves to the raw multi-config structure and path, or undefined if not found
  */
 export async function loadFullDwJson(
   options: LoadDwJsonOptions = {},

--- a/packages/b2c-tooling-sdk/src/config/mapping.ts
+++ b/packages/b2c-tooling-sdk/src/config/mapping.ts
@@ -118,6 +118,20 @@ export function normalizeConfigKeys(raw: Record<string, unknown>): Record<string
 }
 
 /**
+ * Parses a cartridges value that may be a colon-separated string,
+ * comma-separated string, or already an array.
+ */
+function parseCartridges(value: string | string[] | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (Array.isArray(value)) return value.length > 0 ? value : undefined;
+  const items = value
+    .split(/[,:]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
+/**
  * Maps dw.json fields to normalized config format.
  *
  * This is the SINGLE place where dw.json field mapping happens.
@@ -137,20 +151,6 @@ export function normalizeConfigKeys(raw: Record<string, unknown>): Record<string
  * // { hostname: 'example.com', codeVersion: 'v1' }
  * ```
  */
-/**
- * Parses a cartridges value that may be a colon-separated string,
- * comma-separated string, or already an array.
- */
-function parseCartridges(value: string | string[] | undefined): string[] | undefined {
-  if (value === undefined) return undefined;
-  if (Array.isArray(value)) return value.length > 0 ? value : undefined;
-  const items = value
-    .split(/[,:]/)
-    .map((s) => s.trim())
-    .filter(Boolean);
-  return items.length > 0 ? items : undefined;
-}
-
 export function mapDwJsonToNormalizedConfig(json: DwJsonConfig): NormalizedConfig {
   return {
     hostname: json.hostname,

--- a/packages/b2c-tooling-sdk/src/config/sources/dw-json-source.ts
+++ b/packages/b2c-tooling-sdk/src/config/sources/dw-json-source.ts
@@ -28,6 +28,16 @@ export class DwJsonSource implements ConfigSource {
   readonly name = 'DwJsonSource';
   readonly priority = 0;
 
+  /**
+   * Load configuration from dw.json.
+   *
+   * Searches for dw.json in the project directory and returns the resolved
+   * configuration for the requested instance (or the active/root config when
+   * no instance name is provided).
+   *
+   * @param options - Resolution options including instance name and project directory
+   * @returns The loaded configuration and file location, or undefined if dw.json is not found
+   */
   async load(options: ResolveConfigOptions): Promise<ConfigLoadResult | undefined> {
     const logger = getLogger();
 

--- a/packages/b2c-tooling-sdk/src/config/types.ts
+++ b/packages/b2c-tooling-sdk/src/config/types.ts
@@ -393,32 +393,6 @@ export interface CreateOAuthOptions {
 }
 
 /**
- * Result of configuration resolution with factory methods.
- *
- * Provides both raw configuration values and factory methods for creating
- * B2C SDK objects (B2CInstance, AuthStrategy, MrtClient) based on the
- * resolved configuration.
- *
- * @example
- * ```typescript
- * import { resolveConfig } from '@salesforce/b2c-tooling-sdk/config';
- *
- * const config = resolveConfig({
- *   hostname: process.env.SFCC_SERVER,
- *   clientId: process.env.SFCC_CLIENT_ID,
- * });
- *
- * if (config.hasB2CInstanceConfig()) {
- *   const instance = config.createB2CInstance();
- *   await instance.webdav.propfind('Cartridges');
- * }
- *
- * if (config.hasMrtConfig()) {
- *   const mrtAuth = config.createMrtAuth();
- * }
- * ```
- */
-/**
  * Information about a configured instance.
  */
 export interface InstanceInfo {
@@ -446,6 +420,33 @@ export interface CreateInstanceOptions {
   setActive?: boolean;
 }
 
+/**
+ * Result of configuration resolution with factory methods.
+ *
+ * Provides both raw configuration values and factory methods for creating
+ * B2C SDK objects (B2CInstance, AuthStrategy, MrtClient) based on the
+ * resolved configuration. Use the `has*` methods to check availability before
+ * calling factory methods, which throw errors if required configuration is missing.
+ *
+ * @example
+ * ```typescript
+ * import { resolveConfig } from '@salesforce/b2c-tooling-sdk/config';
+ *
+ * const config = resolveConfig({
+ *   hostname: process.env.SFCC_SERVER,
+ *   clientId: process.env.SFCC_CLIENT_ID,
+ * });
+ *
+ * if (config.hasB2CInstanceConfig()) {
+ *   const instance = config.createB2CInstance();
+ *   await instance.webdav.propfind('Cartridges');
+ * }
+ *
+ * if (config.hasMrtConfig()) {
+ *   const mrtAuth = config.createMrtAuth();
+ * }
+ * ```
+ */
 export interface ResolvedB2CConfig {
   /** Raw configuration values */
   readonly values: NormalizedConfig;

--- a/packages/b2c-tooling-sdk/src/discovery/detector.ts
+++ b/packages/b2c-tooling-sdk/src/discovery/detector.ts
@@ -109,7 +109,7 @@ export class WorkspaceTypeDetector {
  * This is a convenience function for simple detection use cases.
  *
  * @param workspacePath - Path to the workspace directory
- * @param options - Detection options
+ * @param [options] - Detection options for customizing behavior
  * @returns Detection result with all matched project types
  *
  * @example

--- a/packages/b2c-tooling-sdk/src/discovery/patterns/sfra.ts
+++ b/packages/b2c-tooling-sdk/src/discovery/patterns/sfra.ts
@@ -33,7 +33,7 @@ import {readPackageJson} from '../utils.js';
  * @example
  * ```
  * // Use in custom detection
- * import { sfraPattern } from '@salesforce/b2c-tooling-sdk/discovery';
+ * import { sfraPattern, detectWorkspaceType } from '@salesforce/b2c-tooling-sdk/discovery';
  *
  * const customPatterns = [sfraPattern, ...otherPatterns];
  * const result = await detectWorkspaceType(workspacePath, { patterns: customPatterns });

--- a/packages/b2c-tooling-sdk/src/docs/schema.ts
+++ b/packages/b2c-tooling-sdk/src/docs/schema.ts
@@ -46,6 +46,14 @@ function getFuse(): Fuse<SchemaEntry> {
 
 /**
  * List all available schema entries.
+ *
+ * @returns Array of all schema entries in the index
+ *
+ * @example
+ * ```typescript
+ * const schemas = listSchemas();
+ * schemas.forEach(s => console.log(s.id));
+ * ```
  */
 export function listSchemas(): SchemaEntry[] {
   const index = loadIndex();
@@ -54,6 +62,9 @@ export function listSchemas(): SchemaEntry[] {
 
 /**
  * Read a schema by its exact ID.
+ *
+ * @param id - The exact schema ID to look up
+ * @returns An object containing the schema entry, file content, and file path; or null if the schema ID is not found
  */
 export function readSchema(id: string): {entry: SchemaEntry; content: string; path: string} | null {
   const index = loadIndex();
@@ -71,7 +82,11 @@ export function readSchema(id: string): {entry: SchemaEntry; content: string; pa
 
 /**
  * Find a schema by fuzzy query and return its content.
+ * First attempts an exact ID match, then falls back to fuzzy search.
  * Returns the best match or null if no match found.
+ *
+ * @param query - The search query string (can be exact schema ID or fuzzy search term)
+ * @returns Object containing the schema entry, file content, and file path; or null if no match found
  */
 export function readSchemaByQuery(query: string): {entry: SchemaEntry; content: string; path: string} | null {
   // First try exact match
@@ -97,6 +112,16 @@ export function readSchemaByQuery(query: string): {entry: SchemaEntry; content: 
 
 /**
  * Search schemas by fuzzy query.
+ *
+ * @param query - The search query string to match against schema IDs
+ * @param limit - Maximum number of results to return (default: 20)
+ * @returns Array of schema search results with relevance scores, sorted by match score (lower scores indicate better matches)
+ *
+ * @example
+ * ```typescript
+ * const results = searchSchemas('catalog');
+ * results.forEach(r => console.log(r.entry.id, r.score));
+ * ```
  */
 export function searchSchemas(query: string, limit = 20): SchemaSearchResult[] {
   const fuse = getFuse();

--- a/packages/b2c-tooling-sdk/src/i18n/index.ts
+++ b/packages/b2c-tooling-sdk/src/i18n/index.ts
@@ -60,7 +60,17 @@
  */
 import i18next, {type TOptions, type Resource} from 'i18next';
 
-// Re-export TOptions for consumers
+/**
+ * Options for i18next translation string interpolation.
+ *
+ * Passed as the third parameter to {@link t | t()} to provide dynamic values
+ * for placeholder variables in translation strings (i18next double-brace syntax).
+ *
+ * @example
+ * t('error.fileNotFound', 'File {{path}} not found.', { path: '/foo/bar' })
+ *
+ * @see https://www.i18next.com/interpolation.html
+ */
 export type {TOptions} from 'i18next';
 import {locales} from './locales/index.js';
 
@@ -196,6 +206,7 @@ export function t(key: string, defaultValue: string, options?: TOptions): string
  * Call this early in CLI initialization if --lang flag is provided.
  *
  * @param lang - Language code (e.g., 'en', 'de')
+ * @returns void
  *
  * @example
  * // In BaseCommand.init()
@@ -209,6 +220,8 @@ export function setLanguage(lang: string): void {
 
 /**
  * Get the currently active language.
+ *
+ * @returns The currently active language code (e.g., 'en', 'de')
  */
 export function getLanguage(): string {
   return instance.language;
@@ -236,6 +249,8 @@ export function getLanguage(): string {
  *     serverRequired: 'Le serveur est requis.'
  *   }
  * })
+ *
+ * @returns The i18next instance for advanced usage
  */
 export function getI18nInstance() {
   return instance;

--- a/packages/b2c-tooling-sdk/src/instance/index.ts
+++ b/packages/b2c-tooling-sdk/src/instance/index.ts
@@ -19,7 +19,7 @@
  * ```typescript
  * import { resolveConfig } from '@salesforce/b2c-tooling-sdk/config';
  *
- * const config = resolveConfig({
+ * const config = await resolveConfig({
  *   clientId: process.env.SFCC_CLIENT_ID,
  *   clientSecret: process.env.SFCC_CLIENT_SECRET,
  * });
@@ -73,7 +73,7 @@ export interface InstanceConfig {
  * // From configuration (recommended)
  * import { resolveConfig } from '@salesforce/b2c-tooling-sdk/config';
  *
- * const config = resolveConfig({
+ * const config = await resolveConfig({
  *   clientId: process.env.SFCC_CLIENT_ID,
  *   clientSecret: process.env.SFCC_CLIENT_SECRET,
  * });
@@ -114,6 +114,8 @@ export class B2CInstance {
    * Uses Basic auth if username/password are configured,
    * otherwise falls back to OAuth.
    *
+   * @returns The lazy-initialized WebDAV client for file operations.
+   *
    * @example
    * await instance.webdav.mkcol('Cartridges/v1');
    * await instance.webdav.put('Cartridges/v1/app.zip', content);
@@ -135,6 +137,8 @@ export class B2CInstance {
    *
    * Returns the openapi-fetch client directly with full type safety.
    * Always uses OAuth authentication.
+   *
+   * @returns The OCAPI Data API client (openapi-fetch Client with full type safety).
    *
    * @example
    * const { data, error } = await instance.ocapi.GET('/sites', {});

--- a/packages/b2c-tooling-sdk/src/logging/logger.ts
+++ b/packages/b2c-tooling-sdk/src/logging/logger.ts
@@ -130,15 +130,50 @@ function createPinoLogger(options: LoggerOptions): Logger {
   return pino(pinoOptions, prettyStream);
 }
 
+/**
+ * Creates a logger instance with the specified options.
+ *
+ * Merges provided options with any global configuration set via {@link configureLogger}.
+ * Options provided here override global settings.
+ *
+ * @param options - Configuration options for the logger. See {@link LoggerOptions} for details.
+ * @returns A configured logger instance
+ * @example
+ * const logger = createLogger({ level: 'debug', colorize: true });
+ * logger.info('Starting application');
+ */
 export function createLogger(options: LoggerOptions = {}): Logger {
   return createPinoLogger({...globalOptions, ...options});
 }
 
+/**
+ * Configures global logger defaults for the entire application.
+ *
+ * Subsequent calls to {@link createLogger} and {@link getLogger} will inherit these settings.
+ * This is typically called once at application startup.
+ *
+ * @param options - Global logger configuration to apply
+ * @example
+ * configureLogger({ level: 'info', json: true });
+ * const logger = getLogger(); // Uses configured defaults
+ */
 export function configureLogger(options: LoggerOptions): void {
   globalOptions = {...globalOptions, ...options};
   globalLogger = createPinoLogger(globalOptions);
 }
 
+/**
+ * Retrieves the global logger instance.
+ *
+ * Returns the same logger instance on repeated calls. If not yet configured,
+ * creates one with default settings (silent level).
+ * Configure defaults via {@link configureLogger} before first use.
+ *
+ * @returns The global logger instance
+ * @example
+ * const logger = getLogger();
+ * logger.warn('An issue occurred');
+ */
 export function getLogger(): Logger {
   if (!globalLogger) {
     globalLogger = createPinoLogger(globalOptions);
@@ -146,11 +181,35 @@ export function getLogger(): Logger {
   return globalLogger;
 }
 
+/**
+ * Resets the global logger to its initial state.
+ *
+ * Clears the cached global logger instance and resets global configuration
+ * back to default (silent level). This is primarily useful for testing or
+ * when reconfiguring logging in a fresh context.
+ *
+ * @example
+ * // Configure logger for one test
+ * configureLogger({ level: 'debug' });
+ * // Reset for next test
+ * resetLogger();
+ * const logger = getLogger(); // New logger with silent level
+ */
 export function resetLogger(): void {
   globalLogger = null;
   globalOptions = {level: 'silent'};
 }
 
+/**
+ * Creates a logger instance that suppresses all output.
+ *
+ * Useful for testing or scenarios where logging should be completely disabled.
+ *
+ * @returns A silent logger instance with no output
+ * @example
+ * const logger = createSilentLogger();
+ * logger.info('This will not print'); // No output produced
+ */
 export function createSilentLogger(): Logger {
   return createLogger({level: 'silent'});
 }

--- a/packages/b2c-tooling-sdk/src/logging/types.ts
+++ b/packages/b2c-tooling-sdk/src/logging/types.ts
@@ -7,8 +7,25 @@
  * Logging types.
  */
 
+/**
+ * Valid log level values, ordered from most verbose to least verbose.
+ *
+ * - `trace`: Most verbose, detailed debugging information
+ * - `debug`: Debugging information
+ * - `info`: General informational messages (default)
+ * - `warn`: Warning messages
+ * - `error`: Error messages
+ * - `fatal`: Fatal errors
+ * - `silent`: Suppress all output
+ */
 export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal' | 'silent';
 
+/**
+ * Context object for structured logging entries.
+ *
+ * A dictionary where any string key can hold any value,
+ * used to attach contextual metadata to log messages.
+ */
 export interface LogContext {
   [key: string]: unknown;
 }
@@ -21,6 +38,12 @@ export interface LogDestination {
   emit?(event: string, ...args: unknown[]): boolean;
 }
 
+/**
+ * Configuration options for creating or configuring a logger.
+ *
+ * All options are optional and have sensible defaults.
+ * Options provided to {@link createLogger} merge with global defaults set via {@link configureLogger}.
+ */
 export interface LoggerOptions {
   /** Log level. Default: 'info' */
   level?: LogLevel;
@@ -38,6 +61,15 @@ export interface LoggerOptions {
   colorize?: boolean;
 }
 
+/**
+ * Logger interface for structured logging with support for multiple log levels.
+ *
+ * Each log method supports two overloads:
+ * - `method(message: string, context?: LogContext)` - message-first format
+ * - `method(context: LogContext, message: string)` - context-first format for structured logging
+ *
+ * Use {@link Logger.child} to create a child logger with bound context that will be included in all subsequent log entries.
+ */
 export interface Logger {
   trace(message: string, context?: LogContext): void;
   trace(context: LogContext, message: string): void;

--- a/packages/b2c-tooling-sdk/src/operations/cap/install.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cap/install.ts
@@ -187,6 +187,20 @@ export async function commerceAppInstall(
   };
 }
 
+/**
+ * Reads and parses the commerce-app.json manifest file from a CAP directory.
+ *
+ * @param capDir - Path to the CAP directory containing commerce-app.json
+ * @returns Parsed manifest object
+ * @throws Error if commerce-app.json does not exist in the directory
+ * @throws Error if commerce-app.json is not valid JSON
+ *
+ * @example
+ * ```typescript
+ * const manifest = readManifest('./my-commerce-app');
+ * console.log(`App: ${manifest.id}@${manifest.version}`);
+ * ```
+ */
 export function readManifest(capDir: string): CommerceAppManifest {
   const manifestPath = path.join(capDir, 'commerce-app.json');
   if (!fs.existsSync(manifestPath)) {

--- a/packages/b2c-tooling-sdk/src/operations/cap/pull.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cap/pull.ts
@@ -12,25 +12,74 @@ import type {CommerceFeatureState} from './list.js';
 
 const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/SalesforceCommerceCloud/commerce-apps/main';
 
+/**
+ * Options for pulling Commerce Apps from an instance or GitHub.
+ *
+ * When pulling apps, the SDK will attempt to fetch from the B2C instance first,
+ * then fall back to the official Commerce Apps GitHub repository.
+ */
 export interface PullCommerceAppsOptions {
+  /** Output directory for extracted Commerce Apps (defaults to 'commerce-apps' in current working directory). */
   outputDir?: string;
 }
 
+/**
+ * Source where a pulled app was obtained.
+ * - `'instance'`: App was downloaded from the B2C instance via WebDAV.
+ * - `'github'`: App was downloaded from the GitHub repository (fallback).
+ */
 export type PullSource = 'instance' | 'github';
 
+/**
+ * Details of a successfully pulled Commerce App.
+ */
 export interface PulledApp {
+  /** Feature name (app ID). */
   featureName: string;
+  /** Version ID of the pulled app. */
   version: string;
+  /** Domain of the app (e.g., 'tax', 'shipping'). */
   domain: string;
+  /** Source where the app was obtained (`'instance'` or `'github'`). */
   source: PullSource;
+  /** Absolute path where the app was extracted. */
   extractedPath: string;
 }
 
+/**
+ * Result of pulling Commerce Apps from an instance or GitHub.
+ */
 export interface PullCommerceAppsResult {
+  /** Successfully pulled apps with extraction details. */
   pulled: PulledApp[];
+  /** Apps that failed to pull with error details. */
   failed: Array<{featureName: string; error: string}>;
 }
 
+/**
+ * Pulls installed Commerce Apps from a B2C Commerce instance or GitHub repository.
+ *
+ * Attempts to download installed app packages from WebDAV on the instance first,
+ * with fallback to the official GitHub repository if not found on the instance.
+ * Extracts the downloaded zip archives to local directories.
+ *
+ * @param instance - The B2C Commerce instance to pull apps from.
+ * @param features - Array of CommerceFeatureState objects representing installed apps.
+ * @param options - Pull configuration options (e.g., outputDir for extraction).
+ * @returns A promise resolving to a result object containing successfully pulled apps and any failures.
+ *
+ * @example
+ * ```typescript
+ * const result = await listInstalledApps(instance);
+ * const pullResult = await pullCommerceApps(instance, result.features, {
+ *   outputDir: './commerce-apps',
+ * });
+ * console.log(`Successfully pulled ${pullResult.pulled.length} app(s)`);
+ * if (pullResult.failed.length > 0) {
+ *   console.error('Failed to pull apps:', pullResult.failed);
+ * }
+ * ```
+ */
 export async function pullCommerceApps(
   instance: B2CInstance,
   features: CommerceFeatureState[],

--- a/packages/b2c-tooling-sdk/src/operations/cip/index.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cip/index.ts
@@ -74,6 +74,10 @@ function escapeSqlLiteral(value: string): string {
 
 /**
  * Lists tables from the CIP metadata catalog.
+ *
+ * @param client - CIP client instance for executing metadata queries
+ * @param options - Optional filtering and pagination options (schema, table name pattern, table type, fetch size)
+ * @returns Promise resolving to a list of table metadata records with schema information and table count
  */
 export async function listCipTables(
   client: CipClient,
@@ -112,6 +116,11 @@ export async function listCipTables(
 
 /**
  * Describes table columns from the CIP metadata catalog.
+ *
+ * @param client - CIP client instance for metadata queries
+ * @param tableName - Name of the table to describe
+ * @param options - Optional schema selection and pagination options
+ * @returns Promise resolving to table column descriptions and metadata
  */
 export async function describeCipTable(
   client: CipClient,
@@ -145,6 +154,8 @@ export async function describeCipTable(
 
 /**
  * Lists all curated CIP reports.
+ *
+ * @returns Array of all available curated CIP report definitions
  */
 export function listCipReports(): CipReportDefinition[] {
   return [...CIP_REPORTS];
@@ -152,6 +163,9 @@ export function listCipReports(): CipReportDefinition[] {
 
 /**
  * Looks up a curated CIP report by name.
+ *
+ * @param name - The report name to look up
+ * @returns The report definition if found, undefined if no report matches the provided name
  */
 export function getCipReportByName(name: string): CipReportDefinition | undefined {
   return CIP_REPORTS.find((report) => report.name === name);
@@ -174,6 +188,11 @@ function validateReportParams(report: CipReportDefinition, params: Record<string
 
 /**
  * Builds SQL for a curated report after validating provided parameters.
+ *
+ * @param name - The name of the report to build SQL for
+ * @param params - Parameter values to substitute into the report template, keyed by parameter name
+ * @returns The report definition and generated SQL string ready for execution
+ * @throws {Error} If the report name is not found in the catalog or required parameters are missing
  */
 export function buildCipReportSql(name: string, params: Record<string, string>): CipReportSqlResult {
   const report = getCipReportByName(name);
@@ -191,6 +210,11 @@ export function buildCipReportSql(name: string, params: Record<string, string>):
 
 /**
  * Executes a curated report query and returns decoded rows.
+ *
+ * @param client - The CIP client instance to execute the query with
+ * @param reportName - The name of the curated report to execute
+ * @param options - Report execution options including params and fetch size
+ * @returns Promise resolving to the query result containing decoded rows and report metadata
  */
 export async function executeCipReport(
   client: CipClient,

--- a/packages/b2c-tooling-sdk/src/operations/code/download.ts
+++ b/packages/b2c-tooling-sdk/src/operations/code/download.ts
@@ -182,6 +182,7 @@ async function extractZip(
  * @param cartridgeName - Name of the cartridge to download
  * @param outputPath - Local path to extract the cartridge into
  * @param onProgress - Optional progress callback
+ * @returns Promise that resolves when the cartridge has been successfully downloaded and extracted
  */
 export async function downloadSingleCartridge(
   instance: B2CInstance,

--- a/packages/b2c-tooling-sdk/src/operations/code/upload-files.ts
+++ b/packages/b2c-tooling-sdk/src/operations/code/upload-files.ts
@@ -72,6 +72,7 @@ export function fileToCartridgePath(absolutePath: string, cartridges: CartridgeM
  * @param uploads - Files to upload
  * @param deletes - Files to delete
  * @param options - Callbacks for upload/delete/error events
+ * @returns Resolves when uploads and deletes complete
  */
 export async function uploadFiles(
   instance: B2CInstance,

--- a/packages/b2c-tooling-sdk/src/operations/code/versions.ts
+++ b/packages/b2c-tooling-sdk/src/operations/code/versions.ts
@@ -62,6 +62,7 @@ export async function getActiveCodeVersion(instance: B2CInstance): Promise<CodeV
  *
  * @param instance - B2C instance
  * @param codeVersionId - Code version ID to activate
+ * @returns Promise that resolves when the code version is activated
  * @throws Error if activation fails
  *
  * @example
@@ -139,6 +140,7 @@ export async function reloadCodeVersion(instance: B2CInstance, codeVersionId?: s
  *
  * @param instance - B2C instance
  * @param codeVersionId - Code version ID to delete
+ * @returns Promise that resolves when the code version is successfully deleted
  * @throws Error if deletion fails (e.g., trying to delete active version)
  *
  * @example
@@ -167,6 +169,7 @@ export async function deleteCodeVersion(instance: B2CInstance, codeVersionId: st
  *
  * @param instance - B2C instance
  * @param codeVersionId - Code version ID to create
+ * @returns Promise that resolves when the code version is successfully created
  * @throws Error if creation fails
  *
  * @example

--- a/packages/b2c-tooling-sdk/src/operations/content/validate.ts
+++ b/packages/b2c-tooling-sdk/src/operations/content/validate.ts
@@ -12,6 +12,12 @@ import {Validator, type ValidatorResult, type Schema} from 'jsonschema';
 // Resolve the content-schemas data directory from the package root
 const require = createRequire(import.meta.url);
 const packageRoot = path.dirname(require.resolve('@salesforce/b2c-tooling-sdk/package.json'));
+/**
+ * Absolute path to the directory containing JSON schema definitions for content metadefinitions.
+ *
+ * Used internally to load and register schemas for validation of pagetype, componenttype,
+ * aspecttype, and other content asset definitions.
+ */
 export const CONTENT_SCHEMAS_DIR = path.join(packageRoot, 'data/content-schemas');
 
 /** Top-level schema types that users validate files against. */
@@ -191,6 +197,9 @@ function toValidationError(err: ValidatorResult['errors'][number]): MetaDefiniti
 /**
  * Validate a parsed JSON object against a content metadefinition schema.
  *
+ * @param data - The JSON object to validate against the detected or specified schema type
+ * @param options - Validation options including optional schema type override
+ * @returns A validation result containing the valid flag, detected schema type, and any validation errors
  * @throws {MetaDefinitionDetectionError} When the schema type cannot be detected and no explicit type is provided.
  */
 export function validateMetaDefinition(
@@ -218,6 +227,9 @@ export function validateMetaDefinition(
  *
  * Uses file path conventions for type detection before falling back to property heuristics.
  *
+ * @param filePath - Absolute or relative path to the JSON metadefinition file
+ * @param options - Optional validation options including explicit schema type override
+ * @returns Validation result with valid flag, detected schema type, errors array, and source file path
  * @throws {MetaDefinitionDetectionError} When the schema type cannot be detected and no explicit type is provided.
  */
 export function validateMetaDefinitionFile(

--- a/packages/b2c-tooling-sdk/src/operations/debug/sdapi-client.ts
+++ b/packages/b2c-tooling-sdk/src/operations/debug/sdapi-client.ts
@@ -84,11 +84,20 @@ export class SdapiClient {
   // Breakpoints
   // -----------------------------------------------------------------------
 
+  /**
+   * Retrieves all currently set breakpoints for the debugger session.
+   * @returns Promise resolving to array of breakpoints, or empty array if none are set.
+   */
   async getBreakpoints(): Promise<SdapiBreakpoint[]> {
     const data = await this.request<SdapiBreakpoints>('GET', '/breakpoints');
     return data.breakpoints ?? [];
   }
 
+  /**
+   * Sets or replaces breakpoints for the debugger.
+   * @param breakpoints Array of breakpoint definitions to set.
+   * @returns Promise resolving to array of confirmed breakpoints from the server.
+   */
   async setBreakpoints(breakpoints: BreakpointInput[]): Promise<SdapiBreakpoint[]> {
     const data = await this.request<SdapiBreakpoints>('POST', '/breakpoints', {
       body: {breakpoints},
@@ -108,11 +117,20 @@ export class SdapiClient {
   // Threads
   // -----------------------------------------------------------------------
 
+  /**
+   * Gets all active script threads.
+   * @returns Promise resolving to array of script threads, or empty array if none are active.
+   */
   async getThreads(): Promise<SdapiScriptThread[]> {
     const data = await this.request<SdapiScriptThreads>('GET', '/threads');
     return data.script_threads ?? [];
   }
 
+  /**
+   * Retrieves a specific thread by ID.
+   * @param threadId The thread identifier.
+   * @returns Promise resolving to the thread object with its current state.
+   */
   async getThread(threadId: number): Promise<SdapiScriptThread> {
     return this.request<SdapiScriptThread>('GET', `/threads/${threadId}`);
   }
@@ -169,6 +187,13 @@ export class SdapiClient {
     return this.request<SdapiObjectMembers>('GET', `/threads/${threadId}/frames/${frameIndex}/members${suffix}`);
   }
 
+  /**
+   * Evaluates a JavaScript expression in a frame context.
+   * @param threadId The thread ID of the halted thread.
+   * @param frameIndex The stack frame index (0 = topmost frame).
+   * @param expr The JavaScript expression to evaluate.
+   * @returns Promise resolving to the evaluation result.
+   */
   async evaluate(threadId: number, frameIndex: number, expr: string): Promise<SdapiEvalResult> {
     const params = new URLSearchParams({expr});
     return this.request<SdapiEvalResult>('GET', `/threads/${threadId}/frames/${frameIndex}/eval?${params.toString()}`);

--- a/packages/b2c-tooling-sdk/src/operations/jobs/run.ts
+++ b/packages/b2c-tooling-sdk/src/operations/jobs/run.ts
@@ -434,6 +434,15 @@ export async function searchJobExecutions(
  * @param instance - B2C instance
  * @param jobId - Job ID to search for
  * @returns Running execution or undefined if none found
+ * @throws Error if the search request fails (inherited from {@link searchJobExecutions})
+ *
+ * @example
+ * ```typescript
+ * const running = await findRunningJobExecution(instance, 'my-job');
+ * if (running) {
+ *   console.log(`Currently running execution: ${running.id} (status: ${running.execution_status})`);
+ * }
+ * ```
  */
 export async function findRunningJobExecution(instance: B2CInstance, jobId: string): Promise<JobExecution | undefined> {
   const results = await searchJobExecutions(instance, {

--- a/packages/b2c-tooling-sdk/src/operations/logs/tail.ts
+++ b/packages/b2c-tooling-sdk/src/operations/logs/tail.ts
@@ -47,11 +47,15 @@ const LOG_ENTRY_START = /^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d+\s+\w+\]/;
  * - The content portion from the first line (after LEVEL)
  * - Plus any continuation lines (stack traces, etc.)
  *
+ * If the standard B2C log format is not matched, returns an unparsed entry with only
+ * the file, message, and raw fields. The timestamp and level fields will be undefined
+ * in this case, but the raw log line is preserved for debugging or recovery purposes.
+ *
  * @param firstLine - First line of the log entry
  * @param file - File name the entry came from
  * @param fullMessage - Complete raw message including all lines
  * @param pathNormalizer - Optional function to normalize paths in the message
- * @returns Parsed log entry
+ * @returns Parsed log entry; fields timestamp and level may be undefined if format doesn't match
  */
 export function parseLogEntry(
   firstLine: string,

--- a/packages/b2c-tooling-sdk/src/operations/mrt/certificate.ts
+++ b/packages/b2c-tooling-sdk/src/operations/mrt/certificate.ts
@@ -45,6 +45,37 @@ export interface ListCertificatesResult {
   certificates: MrtCertificateListCreate[];
 }
 
+/**
+ * Lists certificates for an organization.
+ *
+ * @param options - List options for filtering and pagination
+ * @param options.organizationSlug - The organization slug to list certificates for
+ * @param options.limit - Maximum number of results to return (optional)
+ * @param options.offset - Number of results to skip (optional)
+ * @param options.ordering - Field to order results by (optional)
+ * @param options.search - Search query to filter results (optional)
+ * @param options.customOnly - When true, return only customer-managed certificates (optional)
+ * @param options.origin - Custom API origin (optional, defaults to DEFAULT_MRT_ORIGIN)
+ * @param auth - Authentication strategy (ApiKeyStrategy)
+ * @returns A paginated list result containing certificate count, pagination links, and certificate data
+ * @throws Error if the API request fails
+ *
+ * @example
+ * ```typescript
+ * import {ApiKeyStrategy} from '@salesforce/b2c-tooling-sdk/auth';
+ * import {listCertificates} from '@salesforce/b2c-tooling-sdk/operations/mrt';
+ *
+ * const auth = new ApiKeyStrategy(process.env.MRT_API_KEY!, 'Authorization');
+ *
+ * const result = await listCertificates({
+ *   organizationSlug: 'my-org',
+ *   limit: 10,
+ *   customOnly: true,
+ * }, auth);
+ *
+ * console.log(`Found ${result.count} certificates`);
+ * ```
+ */
 export async function listCertificates(
   options: ListCertificatesOptions,
   auth: AuthStrategy,
@@ -79,6 +110,14 @@ export interface GetCertificateOptions {
   origin?: string;
 }
 
+/**
+ * Retrieves a certificate by ID.
+ *
+ * @param options - Options including organizationSlug and certId
+ * @param auth - Authentication strategy
+ * @returns The certificate details
+ * @throws Error if the request fails
+ */
 export async function getCertificate(options: GetCertificateOptions, auth: AuthStrategy): Promise<MrtCertificate> {
   const {organizationSlug, certId, origin} = options;
   const client = createMrtClient({origin: origin || DEFAULT_MRT_ORIGIN}, auth);
@@ -101,6 +140,27 @@ export interface CreateCertificateOptions {
   origin?: string;
 }
 
+/**
+ * Creates a certificate for a domain in an organization.
+ *
+ * @param options - Create options with organization slug and domain name
+ * @param auth - Authentication strategy
+ * @returns A promise that resolves to the created certificate
+ * @throws Error if the request fails (e.g., invalid domain, duplicate certificate)
+ *
+ * @example
+ * ```typescript
+ * import {ApiKeyStrategy} from '@salesforce/b2c-tooling-sdk/auth';
+ * import {createCertificate} from '@salesforce/b2c-tooling-sdk/operations/mrt';
+ *
+ * const auth = new ApiKeyStrategy(process.env.MRT_API_KEY!, 'Authorization');
+ *
+ * const cert = await createCertificate({
+ *   organizationSlug: 'my-org',
+ *   domainName: 'shop.example.com',
+ * }, auth);
+ * ```
+ */
 export async function createCertificate(
   options: CreateCertificateOptions,
   auth: AuthStrategy,
@@ -128,6 +188,13 @@ export interface DeleteCertificateOptions {
   origin?: string;
 }
 
+/**
+ * Deletes a certificate from an organization.
+ *
+ * @param options - Delete options including organization slug and certificate ID
+ * @param auth - Authentication strategy (ApiKeyStrategy)
+ * @throws {Error} If the request fails or certificate cannot be deleted
+ */
 export async function deleteCertificate(options: DeleteCertificateOptions, auth: AuthStrategy): Promise<void> {
   const {organizationSlug, certId, origin} = options;
   const client = createMrtClient({origin: origin || DEFAULT_MRT_ORIGIN}, auth);
@@ -148,6 +215,27 @@ export interface RestartCertificateValidationOptions {
 /**
  * Restarts validation for a certificate. Only works for certificates that have
  * not yet been validated.
+ *
+ * @param options - Configuration options
+ * @param options.organizationSlug - The organization slug
+ * @param options.certId - The certificate ID
+ * @param options.origin - Optional MRT API origin URL
+ * @param auth - Authentication strategy (ApiKeyStrategy)
+ * @returns The restarted certificate object
+ * @throws Error if the request fails
+ *
+ * @example
+ * ```typescript
+ * import {ApiKeyStrategy} from '@salesforce/b2c-tooling-sdk/auth';
+ * import {restartCertificateValidation} from '@salesforce/b2c-tooling-sdk/operations/mrt';
+ *
+ * const auth = new ApiKeyStrategy(process.env.MRT_API_KEY!, 'Authorization');
+ *
+ * const cert = await restartCertificateValidation({
+ *   organizationSlug: 'my-org',
+ *   certId: 12345,
+ * }, auth);
+ * ```
  */
 export async function restartCertificateValidation(
   options: RestartCertificateValidationOptions,

--- a/packages/b2c-tooling-sdk/src/operations/mrt/organization-member.ts
+++ b/packages/b2c-tooling-sdk/src/operations/mrt/organization-member.ts
@@ -61,6 +61,26 @@ export interface ListOrgMembersResult {
   members: MrtOrgMember[];
 }
 
+/**
+ * Lists members of an MRT organization.
+ *
+ * @param options - List options including organization slug and optional pagination/filtering parameters
+ * @param auth - Authentication strategy (ApiKeyStrategy or other AuthStrategy implementation)
+ * @returns Promise resolving to paginated list of organization members with count, next, previous, and members array
+ * @throws Error if the request fails
+ *
+ * @example
+ * ```typescript
+ * import { ApiKeyStrategy } from '@salesforce/b2c-tooling-sdk/auth';
+ * import { listOrgMembers } from '@salesforce/b2c-tooling-sdk/operations/mrt';
+ *
+ * const auth = new ApiKeyStrategy(process.env.MRT_API_KEY!, 'Authorization');
+ *
+ * const result = await listOrgMembers({
+ *   organizationSlug: 'my-org'
+ * }, auth);
+ * ```
+ */
 export async function listOrgMembers(
   options: ListOrgMembersOptions,
   auth: AuthStrategy,
@@ -98,6 +118,34 @@ export interface AddOrgMemberOptions {
   origin?: string;
 }
 
+/**
+ * Adds a member to an MRT organization.
+ *
+ * @param options - Add member options
+ * @param options.organizationSlug - Organization slug identifier
+ * @param options.email - Email of the member to add
+ * @param options.role - Role value (0 = Owner, 1 = Member)
+ * @param options.canViewAllProjects - Optional: grant permission to view all projects
+ * @param options.customDomainCertPermission - Optional: custom domain certificate permission (1 = Disabled, 2 = Enabled)
+ * @param options.origin - Optional: MRT API origin endpoint
+ * @param auth - Authentication strategy (e.g., ApiKeyStrategy)
+ * @returns The created organization member
+ * @throws Error if the request fails
+ *
+ * @example
+ * ```typescript
+ * import { ApiKeyStrategy } from '@salesforce/b2c-tooling-sdk/auth';
+ * import { addOrgMember } from '@salesforce/b2c-tooling-sdk/operations/mrt';
+ *
+ * const auth = new ApiKeyStrategy(process.env.MRT_API_KEY!, 'Authorization');
+ *
+ * const member = await addOrgMember({
+ *   organizationSlug: 'my-org',
+ *   email: 'user@example.com',
+ *   role: 1  // Member
+ * }, auth);
+ * ```
+ */
 export async function addOrgMember(options: AddOrgMemberOptions, auth: AuthStrategy): Promise<MrtOrgMember> {
   const logger = getLogger();
   const {organizationSlug, email, role, canViewAllProjects, customDomainCertPermission, origin} = options;
@@ -127,6 +175,29 @@ export interface GetOrgMemberOptions {
   origin?: string;
 }
 
+/**
+ * Gets an organization member by email.
+ *
+ * @param options - Get options including organization slug and email
+ * @param auth - Authentication strategy (ApiKeyStrategy)
+ * @returns The organization member details
+ * @throws Error if the request fails or member is not found
+ *
+ * @example
+ * ```typescript
+ * import { ApiKeyStrategy } from '@salesforce/b2c-tooling-sdk/auth';
+ * import { getOrgMember } from '@salesforce/b2c-tooling-sdk/operations/mrt';
+ *
+ * const auth = new ApiKeyStrategy(process.env.MRT_API_KEY!, 'Authorization');
+ *
+ * const member = await getOrgMember({
+ *   organizationSlug: 'my-org',
+ *   email: 'user@example.com'
+ * }, auth);
+ *
+ * console.log(`Member role: ${member.role}`);
+ * ```
+ */
 export async function getOrgMember(options: GetOrgMemberOptions, auth: AuthStrategy): Promise<MrtOrgMember> {
   const {organizationSlug, email, origin} = options;
   const client = createMrtClient({origin: origin || DEFAULT_MRT_ORIGIN}, auth);
@@ -148,6 +219,14 @@ export interface UpdateOrgMemberOptions {
   origin?: string;
 }
 
+/**
+ * Updates an organization member's permissions and settings.
+ *
+ * @param options - Update options with organizationSlug, email, and optional canViewAllProjects and customDomainCertPermission
+ * @param auth - Authentication strategy (required for API authorization)
+ * @returns Promise resolving to the updated organization member with full member details
+ * @throws Error if the API request fails
+ */
 export async function updateOrgMember(options: UpdateOrgMemberOptions, auth: AuthStrategy): Promise<MrtOrgMember> {
   const {organizationSlug, email, canViewAllProjects, customDomainCertPermission, origin} = options;
   const client = createMrtClient({origin: origin || DEFAULT_MRT_ORIGIN}, auth);
@@ -173,6 +252,16 @@ export interface RemoveOrgMemberOptions {
   origin?: string;
 }
 
+/**
+ * Removes a member from an MRT organization.
+ *
+ * @param options - Remove options
+ * @param options.organizationSlug - Slug of the organization
+ * @param options.email - Email address of the member to remove
+ * @param options.origin - Optional MRT API origin (defaults to DEFAULT_MRT_ORIGIN)
+ * @param auth - Authentication strategy
+ * @throws {Error} If the API request fails
+ */
 export async function removeOrgMember(options: RemoveOrgMemberOptions, auth: AuthStrategy): Promise<void> {
   const {organizationSlug, email, origin} = options;
   const client = createMrtClient({origin: origin || DEFAULT_MRT_ORIGIN}, auth);

--- a/packages/b2c-tooling-sdk/src/operations/ods/wait-for-clone.ts
+++ b/packages/b2c-tooling-sdk/src/operations/ods/wait-for-clone.ts
@@ -7,8 +7,24 @@
 import type {OdsClient} from '../../clients/ods.js';
 import {getLogger} from '../../logging/logger.js';
 
+/**
+ * Status of a sandbox clone operation in the ODS system.
+ *
+ * Standard values are `COMPLETED`, `FAILED`, `IN_PROGRESS`, and `PENDING`. Any
+ * other string value is also accepted for forward compatibility with future
+ * statuses returned by the API.
+ */
 export type CloneState = 'COMPLETED' | 'FAILED' | 'IN_PROGRESS' | 'PENDING' | (string & {});
 
+/**
+ * Error thrown when a sandbox clone operation does not complete within the
+ * configured timeout while polling.
+ *
+ * @param sandboxId - ID of the source sandbox
+ * @param cloneId - ID of the clone operation
+ * @param timeoutSeconds - Timeout duration in seconds
+ * @param lastStatus - Last observed clone status before the timeout occurred, if any
+ */
 export class ClonePollingTimeoutError extends Error {
   constructor(
     public readonly sandboxId: string,
@@ -25,6 +41,13 @@ export class ClonePollingTimeoutError extends Error {
   }
 }
 
+/**
+ * Error thrown when an API request to fetch clone status fails.
+ *
+ * @param sandboxId - ID of the source sandbox
+ * @param cloneId - ID of the clone operation
+ * @param message - Underlying error message from the API call
+ */
 export class ClonePollingError extends Error {
   constructor(
     public readonly sandboxId: string,
@@ -36,6 +59,13 @@ export class ClonePollingError extends Error {
   }
 }
 
+/**
+ * Error thrown when a sandbox clone operation enters the `FAILED` state.
+ *
+ * @param sandboxId - ID of the source sandbox
+ * @param cloneId - ID of the clone operation
+ * @param status - Clone status observed when the failure was detected
+ */
 export class CloneFailedError extends Error {
   constructor(
     public readonly sandboxId: string,
@@ -47,6 +77,9 @@ export class CloneFailedError extends Error {
   }
 }
 
+/**
+ * Information passed to the `onPoll` callback on each clone status poll.
+ */
 export interface WaitForClonePollInfo {
   sandboxId: string;
   cloneId: string;
@@ -55,6 +88,9 @@ export interface WaitForClonePollInfo {
   progressPercentage?: number;
 }
 
+/**
+ * Configuration options for {@link waitForClone} polling behavior.
+ */
 export interface WaitForCloneOptions {
   sandboxId: string;
   cloneId: string;
@@ -71,11 +107,23 @@ async function defaultSleep(ms: number): Promise<void> {
 }
 
 /**
- * Waits for a sandbox clone to reach COMPLETED or FAILED state by polling its status.
+ * Waits for a sandbox clone to reach `COMPLETED` or `FAILED` state by polling
+ * its status against the ODS API.
+ *
+ * Polls at `pollIntervalSeconds` until the clone completes, the configured
+ * timeout is exceeded, or the clone enters a failed state. An initial poll
+ * delay equal to `pollIntervalSeconds` is applied before the first status
+ * check.
  *
  * @param client - ODS client for API calls
  * @param options - Polling configuration options
- *
+ * @param options.sandboxId - ID of the source sandbox
+ * @param options.cloneId - ID of the clone operation to monitor
+ * @param options.pollIntervalSeconds - Seconds between status checks
+ * @param options.timeoutSeconds - Maximum seconds to wait (`0` disables the timeout)
+ * @param options.onPoll - Optional callback invoked after each status poll
+ * @param options.sleep - Optional custom sleep function (primarily for testing)
+ * @returns Promise that resolves when the clone reaches `COMPLETED`
  * @throws {ClonePollingTimeoutError} If the timeout is exceeded before completion
  * @throws {ClonePollingError} If the API request fails
  * @throws {CloneFailedError} If the clone enters the FAILED state

--- a/packages/b2c-tooling-sdk/src/operations/ods/wait-for-sandbox.ts
+++ b/packages/b2c-tooling-sdk/src/operations/ods/wait-for-sandbox.ts
@@ -7,8 +7,28 @@
 import type {OdsClient} from '../../clients/ods.js';
 import {getLogger} from '../../logging/logger.js';
 
+/**
+ * State of a sandbox in the ODS system.
+ *
+ * Standard states:
+ * - `deleted` - Sandbox has been deleted
+ * - `failed` - Sandbox creation or operation failed
+ * - `started` - Sandbox is running
+ * - `stopped` - Sandbox is stopped
+ *
+ * Also accepts any other string value via `(string & {})` for forward compatibility
+ * with future ODS API states.
+ */
 export type SandboxState = 'deleted' | 'failed' | 'started' | 'stopped' | (string & {});
 
+/**
+ * Error thrown when a sandbox does not reach its target state within the specified timeout period.
+ *
+ * @param sandboxId - ID of the sandbox being monitored
+ * @param targetState - The desired state that was not reached before timeout
+ * @param timeoutSeconds - Timeout duration in seconds that was exceeded
+ * @param lastState - Optional last observed state before timeout occurred
+ */
 export class SandboxPollingTimeoutError extends Error {
   constructor(
     public readonly sandboxId: string,
@@ -25,6 +45,12 @@ export class SandboxPollingTimeoutError extends Error {
   }
 }
 
+/**
+ * Error thrown when fetching sandbox status fails during polling.
+ *
+ * @param sandboxId - ID of the sandbox being polled
+ * @param message - Error message or details from the API response
+ */
 export class SandboxPollingError extends Error {
   constructor(
     public readonly sandboxId: string,
@@ -35,6 +61,13 @@ export class SandboxPollingError extends Error {
   }
 }
 
+/**
+ * Error thrown when a sandbox reaches a terminal error state (failed or deleted) during polling.
+ *
+ * @param sandboxId - ID of the sandbox that reached a terminal state
+ * @param targetState - The desired state that was being waited for
+ * @param state - The terminal state that was reached
+ */
 export class SandboxTerminalStateError extends Error {
   constructor(
     public readonly sandboxId: string,
@@ -46,12 +79,29 @@ export class SandboxTerminalStateError extends Error {
   }
 }
 
+/**
+ * Information provided to the `onPoll` callback on each poll during sandbox state monitoring.
+ *
+ * @property sandboxId - ID of the sandbox being monitored
+ * @property elapsedSeconds - Total elapsed time in seconds since polling started
+ * @property state - Current observed state of the sandbox
+ */
 export interface WaitForSandboxPollInfo {
   sandboxId: string;
   elapsedSeconds: number;
   state: SandboxState;
 }
 
+/**
+ * Configuration options for {@link waitForSandbox} sandbox state polling.
+ *
+ * @property sandboxId - ID of the sandbox to monitor
+ * @property targetState - Desired sandbox state to wait for
+ * @property pollIntervalSeconds - Interval between status checks in seconds
+ * @property timeoutSeconds - Maximum time to wait in seconds (0 = no timeout)
+ * @property onPoll - Optional callback invoked on each poll with current state
+ * @property sleep - Optional custom sleep function (primarily for testing)
+ */
 export interface WaitForSandboxOptions {
   sandboxId: string;
   targetState: SandboxState;

--- a/packages/b2c-tooling-sdk/src/operations/orgs/index.ts
+++ b/packages/b2c-tooling-sdk/src/operations/orgs/index.ts
@@ -56,7 +56,13 @@ import type {
   ListOrgsOptions,
 } from '../../clients/am-api.js';
 
-// Re-export types
+/**
+ * Core organization types re-exported for convenience:
+ *
+ * - {@link AccountManagerOrganization} - Single organization from Account Manager
+ * - {@link OrganizationCollection} - Paginated collection of organizations with pagination metadata (totalElements, totalPages, number, size)
+ * - {@link ListOrgsOptions} - Options for listing organizations with pagination and bulk retrieval (size, page, all)
+ */
 export type {AccountManagerOrganization, OrganizationCollection, ListOrgsOptions} from '../../clients/am-api.js';
 
 /**
@@ -65,19 +71,19 @@ export type {AccountManagerOrganization, OrganizationCollection, ListOrgsOptions
  * @param client - Account Manager Organizations client
  * @param orgId - Organization ID
  * @returns Organization details
- * @throws Error if organization is not found
+ * @throws {Error} If the organization is not found (404), authentication fails (401), permission is denied (403), or other request failures occur
  */
 export async function getOrg(client: AccountManagerOrgsClient, orgId: string): Promise<AccountManagerOrganization> {
   return client.getOrg(orgId);
 }
 
 /**
- * Gets an organization by name (searches for exact or partial match).
+ * Gets an organization by name (performs case-sensitive prefix search using startsWith, filters to exact match if multiple results are found, throws if ambiguous).
  *
  * @param client - Account Manager Organizations client
  * @param name - Organization name
  * @returns Organization details
- * @throws Error if organization is not found or ambiguous
+ * @throws {Error} If the organization is not found or if multiple organizations match the name
  */
 export async function getOrgByName(
   client: AccountManagerOrgsClient,
@@ -90,8 +96,8 @@ export async function getOrgByName(
  * Lists organizations with pagination.
  *
  * @param client - Account Manager Organizations client
- * @param options - List options (size, page, all)
- * @returns Organization collection
+ * @param options - Pagination options. Set `all: true` to retrieve all organizations using the max page size of 5000
+ * @returns {OrganizationCollection} Paginated organization collection with pagination metadata (totalElements, totalPages, number, size)
  */
 export async function listOrgs(
   client: AccountManagerOrgsClient,

--- a/packages/b2c-tooling-sdk/src/plugins/discovery.ts
+++ b/packages/b2c-tooling-sdk/src/plugins/discovery.ts
@@ -13,6 +13,12 @@ import type {Logger} from '../logging/types.js';
  */
 const SUPPORTED_HOOKS = ['b2c:config-sources', 'b2c:http-middleware', 'b2c:auth-middleware'] as const;
 
+/**
+ * Union type of all supported hook names in the plugin system.
+ *
+ * Represents any of the hook names that the plugin discovery system recognizes:
+ * `b2c:config-sources`, `b2c:http-middleware`, or `b2c:auth-middleware`.
+ */
 export type SupportedHookName = (typeof SUPPORTED_HOOKS)[number];
 
 /**

--- a/packages/b2c-tooling-sdk/src/scaffold/engine.ts
+++ b/packages/b2c-tooling-sdk/src/scaffold/engine.ts
@@ -149,21 +149,29 @@ export class ScaffoldEngine {
   }
 
   /**
-   * Render an EJS template string
+   * Render an EJS template string using the current context.
+   * @param template - The EJS template string to render
+   * @returns The rendered string
    */
   render(template: string): string {
     return renderTemplate(template, this.context);
   }
 
   /**
-   * Render a file path template
+   * Render a file path template using double-brace placeholder syntax.
+   * Supports direct variable references (double-brace name double-brace) and helper
+   * function calls (e.g. double-brace `kebabCase moduleName` double-brace).
+   * @param pathTemplate - The path template string with double-brace placeholders
+   * @returns The rendered path string with placeholders replaced by context values
    */
   renderPath(pathTemplate: string): string {
     return renderPathTemplate(pathTemplate, this.context);
   }
 
   /**
-   * Render an EJS template file
+   * Render an EJS template file asynchronously.
+   * @param filePath - Path to the EJS template file
+   * @returns Promise resolving to the rendered template output as a string
    */
   async renderFile(filePath: string): Promise<string> {
     const result = await ejs.renderFile(filePath, this.context, {

--- a/packages/b2c-tooling-sdk/src/scaffold/registry.ts
+++ b/packages/b2c-tooling-sdk/src/scaffold/registry.ts
@@ -152,7 +152,10 @@ export class ScaffoldRegistry {
   }
 
   /**
-   * Add scaffold providers
+   * Add scaffold providers to the registry for discovery.
+   * Providers are appended to the existing list and evaluated in priority order.
+   * Clears the cache to ensure new scaffolds are discovered on next query.
+   * @param providers - Array of scaffold providers to add
    */
   addProviders(providers: ScaffoldProvider[]): void {
     this.providers.push(...providers);
@@ -160,7 +163,10 @@ export class ScaffoldRegistry {
   }
 
   /**
-   * Add scaffold transformers
+   * Add scaffold transformers to the registry.
+   * Transformers are applied to all scaffolds during discovery after deduplication.
+   * Clears the cache to ensure transformers are reapplied on the next getScaffolds() call.
+   * @param transformers - Array of scaffold transformers to add
    */
   addTransformers(transformers: ScaffoldTransformer[]): void {
     this.transformers.push(...transformers);

--- a/packages/b2c-tooling-sdk/src/scaffold/sources.ts
+++ b/packages/b2c-tooling-sdk/src/scaffold/sources.ts
@@ -12,7 +12,8 @@ import type {OcapiComponents} from '../clients/index.js';
 import type {ScaffoldChoice, ScaffoldParameter, DynamicParameterSource, SourceResult} from './types.js';
 
 /**
- * SCAPI/OCAPI hook extension points.
+ * SCAPI/OCAPI hook extension points for basket, order, customer, auth, and product resources.
+ * Each choice includes a hook value and display label suitable for parameter selection.
  */
 export const SCAPI_OCAPI_HOOK_POINTS: ScaffoldChoice[] = [
   // Basket

--- a/packages/b2c-tooling-sdk/src/scaffold/types.ts
+++ b/packages/b2c-tooling-sdk/src/scaffold/types.ts
@@ -91,7 +91,7 @@ export interface ScaffoldParameter {
 export interface FileMapping {
   /** Template file path relative to the scaffold's files/ directory */
   template: string;
-  /** Destination path (supports {{variable}} substitution) */
+  /** Destination path (supports double-brace variable substitution) */
   destination: string;
   /** Conditional expression: only generate if truthy */
   condition?: string;
@@ -103,7 +103,7 @@ export interface FileMapping {
  * File modification definition for modifying existing files
  */
 export interface FileModification {
-  /** Target file path (supports {{variable}} substitution) */
+  /** Target file path (supports double-brace variable substitution) */
   target: string;
   /** Type of modification */
   type: 'json-merge' | 'insert-after' | 'insert-before' | 'append' | 'prepend';

--- a/packages/b2c-tooling-sdk/src/schemas/index.ts
+++ b/packages/b2c-tooling-sdk/src/schemas/index.ts
@@ -38,6 +38,7 @@
  * import {
  *   getPathKeys,
  *   getSchemaNames,
+ *   getExampleNames,
  *   isCollapsedSchema,
  *   getApiType
  * } from '@salesforce/b2c-tooling-sdk/schemas';
@@ -47,6 +48,9 @@
  *
  * // Get available schemas
  * const schemas = getSchemaNames(schema); // ["Product", "Order", ...]
+ *
+ * // Get available examples
+ * const examples = getExampleNames(schema); // ["ProductExample", "OrderExample", ...]
  *
  * // Check if schema is collapsed
  * if (isCollapsedSchema(schema)) {

--- a/packages/b2c-tooling-sdk/src/skills/github.ts
+++ b/packages/b2c-tooling-sdk/src/skills/github.ts
@@ -156,6 +156,10 @@ function parseRelease(release: {
 
 /**
  * Fetch release information from GitHub API.
+ *
+ * @param version - Release version to fetch. Can be 'latest' (default), a version number, or a full tag.
+ * @returns Release information including asset URLs and version metadata.
+ * @throws Error if release not found or GitHub API error.
  */
 export async function getRelease(version: string = 'latest'): Promise<ReleaseInfo> {
   const logger = getLogger();
@@ -203,6 +207,9 @@ export async function getRelease(version: string = 'latest'): Promise<ReleaseInf
 
 /**
  * List available releases with skills artifacts.
+ *
+ * @param limit - Maximum number of releases to return (default: 10).
+ * @returns Array of recent release information.
  */
 export async function listReleases(limit: number = 10): Promise<ReleaseInfo[]> {
   const logger = getLogger();
@@ -529,6 +536,8 @@ export async function downloadSkillsArtifact(skillSet: SkillSet, options: Downlo
 
 /**
  * Clear the skills cache.
+ *
+ * @param version - Optional specific version to clear. If omitted, clears the entire cache.
  */
 export async function clearCache(version?: string): Promise<void> {
   const cacheDir = getCacheDir();

--- a/packages/b2c-tooling-sdk/src/skills/sources.ts
+++ b/packages/b2c-tooling-sdk/src/skills/sources.ts
@@ -11,6 +11,12 @@ function pluginsTag(version: string): string {
   return `b2c-agent-plugins@${bare}`;
 }
 
+/**
+ * Registry mapping skill sets to their source configurations.
+ *
+ * Each skill set (b2c, b2c-cli, storefront-next, cap-dev) maps to its respective
+ * GitHub repository and download configuration for artifact retrieval.
+ */
 export const SKILL_SOURCES: Record<SkillSet, SkillSourceConfig> = {
   b2c: {
     id: 'b2c',
@@ -46,6 +52,13 @@ export const SKILL_SOURCES: Record<SkillSet, SkillSourceConfig> = {
   },
 };
 
+/**
+ * Get the source configuration for a specific skill set.
+ *
+ * @param skillSet - The skill set identifier ('b2c', 'b2c-cli', 'storefront-next', or 'cap-dev')
+ * @returns The source configuration for the skill set
+ * @throws Error if the skill set is not recognized
+ */
 export function getSkillSource(skillSet: SkillSet): SkillSourceConfig {
   const source = SKILL_SOURCES[skillSet];
   if (!source) {
@@ -54,4 +67,8 @@ export function getSkillSource(skillSet: SkillSet): SkillSourceConfig {
   return source;
 }
 
+/**
+ * All available skill set identifiers.
+ * Derived from the keys of SKILL_SOURCES.
+ */
 export const ALL_SKILL_SETS: SkillSet[] = Object.keys(SKILL_SOURCES) as SkillSet[];


### PR DESCRIPTION
## Summary

Multi-agent doc audit + adversarial verify + repair pass across the docs site and SDK JSDoc. Each finding was raised by an audit agent against the oclif manifest / SDK source / package contributions, then independently verified by a skeptic agent before being applied (255 confirmed, 79 refuted).

## What changed

- **CLI reference** (`docs/cli/*.md`): corrected stale flag tables, examples, env-var names, and command signatures against the live `oclif.manifest.json` (e.g. eCDN mTLS create flags, sandbox `--no-*` boolean flags, WebDAV `get` argument shape, scapi-schemas defaults).
- **Guides** (`docs/guide/*.md`): fixed inaccurate technical claims, broken cross-links, and outdated examples in installation, sdk-migration, scaffolding, ide-integration, commerce-apps, extending, etc.
- **API reference** (`docs/typedoc.json`): added `operations/cap` to the entry points so the Commerce Apps SDK module surfaces in the API docs.
- **API homepage** (`docs/api-readme.md`): cleaned up stale references.
- **SDK JSDoc** (`packages/b2c-tooling-sdk/src/**`): added or corrected JSDoc on previously-undocumented public exports across auth, clients, cli base classes, instance, logging, ods, mrt, cap, cip, debug, scaffold, schemas, skills, i18n, plugins, etc. — directly improves the typedoc-generated API reference without touching runtime behavior.
- **Changeset**: `@salesforce/b2c-dx-docs` + `@salesforce/b2c-tooling-sdk` patch.

## Verification

- `pnpm run lint:agent` — clean
- `pnpm run typecheck:agent` — clean
- `pnpm run -r format:check` — clean
- `pnpm run docs:build` — typedoc + vitepress build succeeds
- `pnpm run test:agent` — only pre-existing env-dependent failure remains (`InstanceCommand integration` — fails on `main` too, environmental)