### PR TITLE
Prevent sandbox clone profile downgrades and remove duplicate source option in vs extension

### DIFF
--- a/packages/b2c-vs-extension/src/sandbox-tree/sandbox-clone-helpers.ts
+++ b/packages/b2c-vs-extension/src/sandbox-tree/sandbox-clone-helpers.ts
@@ -10,8 +10,20 @@ export interface SandboxLike {
   realm?: string;
   instance?: string;
   state?: string;
+  profile?: string;
+  resourceProfile?: string;
   clonedFrom?: string;
 }
+
+export const CLONE_PROFILES = ['medium', 'large', 'xlarge', 'xxlarge'] as const;
+export type CloneProfile = (typeof CLONE_PROFILES)[number];
+
+const CLONE_PROFILE_RANK: Record<CloneProfile, number> = {
+  medium: 0,
+  large: 1,
+  xlarge: 2,
+  xxlarge: 3,
+};
 
 /** States of a cloned sandbox that indicate the clone is still being set up from its source. */
 export const CLONE_IN_PROGRESS_STATES = new Set(['cloning', 'creating', 'failed']);
@@ -21,6 +33,37 @@ export const TRANSITIONAL_STATES = new Set(['creating', 'starting', 'stopping', 
 
 export function getRealmInstanceId(s: SandboxLike): string | undefined {
   return s.realm && s.instance ? `${s.realm}-${s.instance}` : undefined;
+}
+
+export function normalizeCloneProfile(profile: string | undefined): CloneProfile | undefined {
+  const normalized = profile?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  return CLONE_PROFILES.find((p) => p === normalized);
+}
+
+export function getSandboxSourceProfile(sandbox: Pick<SandboxLike, 'profile' | 'resourceProfile'>): string | undefined {
+  return sandbox.profile ?? sandbox.resourceProfile;
+}
+
+export function getAllowedCloneTargetProfiles(sourceProfile: string | undefined): CloneProfile[] {
+  const normalizedSource = normalizeCloneProfile(sourceProfile);
+  if (!normalizedSource) return [...CLONE_PROFILES];
+  const sourceRank = CLONE_PROFILE_RANK[normalizedSource];
+  return CLONE_PROFILES.filter((p) => CLONE_PROFILE_RANK[p] >= sourceRank);
+}
+
+export function getExplicitCloneTargetProfiles(sourceProfile: string | undefined): CloneProfile[] {
+  const allowedProfiles = getAllowedCloneTargetProfiles(sourceProfile);
+  const normalizedSource = normalizeCloneProfile(sourceProfile);
+  if (!normalizedSource) return allowedProfiles;
+  return allowedProfiles.filter((p) => p !== normalizedSource);
+}
+
+export function isCloneProfileDowngrade(sourceProfile: string | undefined, targetProfile: string | undefined): boolean {
+  const normalizedSource = normalizeCloneProfile(sourceProfile);
+  const normalizedTarget = normalizeCloneProfile(targetProfile);
+  if (!normalizedSource || !normalizedTarget) return false;
+  return CLONE_PROFILE_RANK[normalizedTarget] < CLONE_PROFILE_RANK[normalizedSource];
 }
 
 /** Return the set of realm-instance identifiers that are currently a source of an in-progress clone. */

--- a/packages/b2c-vs-extension/src/sandbox-tree/sandbox-commands.ts
+++ b/packages/b2c-vs-extension/src/sandbox-tree/sandbox-commands.ts
@@ -7,6 +7,13 @@ import {getApiErrorMessage} from '@salesforce/b2c-tooling-sdk';
 import {createOdsClient} from '@salesforce/b2c-tooling-sdk/clients';
 import * as vscode from 'vscode';
 import {registerSafeCommand, runWithSafety} from '../safety.js';
+import {
+  CLONE_PROFILES,
+  getExplicitCloneTargetProfiles,
+  getSandboxSourceProfile,
+  isCloneProfileDowngrade,
+  type CloneProfile,
+} from './sandbox-clone-helpers.js';
 import type {SandboxConfigProvider} from './sandbox-config.js';
 import type {RealmTreeItem, SandboxTreeDataProvider, SandboxTreeItem} from './sandbox-tree-provider.js';
 
@@ -292,8 +299,6 @@ export function registerSandboxCommands(
     );
   });
 
-  const CLONE_PROFILES = ['medium', 'large', 'xlarge', 'xxlarge'] as const;
-  type CloneProfile = (typeof CLONE_PROFILES)[number];
   const CLONE_POLL_INTERVAL_MS = 10_000;
   const CLONE_POLL_TIMEOUT_MS = 60 * 60_000;
 
@@ -314,12 +319,27 @@ export function registerSandboxCommands(
     if (ttlStr === undefined) return;
     const ttl = Number(ttlStr);
 
+    const sourceProfile = getSandboxSourceProfile(node.sandbox);
+    const explicitTargetProfiles = getExplicitCloneTargetProfiles(sourceProfile);
     const profilePick = await vscode.window.showQuickPick(
-      [{label: 'Same as source', value: undefined}, ...CLONE_PROFILES.map((p) => ({label: p, value: p}))],
-      {title: 'Clone Sandbox — Resource Profile', placeHolder: 'Select profile for the clone'},
+      [{label: 'Same as source', value: undefined}, ...explicitTargetProfiles.map((p) => ({label: p, value: p}))],
+      {
+        title: 'Clone Sandbox — Resource Profile',
+        placeHolder:
+          explicitTargetProfiles.length < CLONE_PROFILES.length
+            ? `Select profile for the clone (downgrades from ${sourceProfile ?? 'source profile'} are blocked)`
+            : 'Select profile for the clone',
+      },
     );
     if (!profilePick) return;
     const targetProfile = profilePick.value as CloneProfile | undefined;
+
+    if (isCloneProfileDowngrade(sourceProfile, targetProfile)) {
+      vscode.window.showErrorMessage(
+        `Profile downgrade not allowed: source profile is ${sourceProfile}. Choose same or higher profile.`,
+      );
+      return;
+    }
 
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     const emailsStr = await vscode.window.showInputBox({

--- a/packages/b2c-vs-extension/src/test/sandbox-clone-helpers.test.ts
+++ b/packages/b2c-vs-extension/src/test/sandbox-clone-helpers.test.ts
@@ -5,11 +5,17 @@
  */
 import * as assert from 'assert';
 import {
+  CLONE_PROFILES,
   CLONE_IN_PROGRESS_STATES,
   TRANSITIONAL_STATES,
   computeSandboxDisplay,
   getActiveCloneSourceIds,
+  getAllowedCloneTargetProfiles,
+  getExplicitCloneTargetProfiles,
   getRealmInstanceId,
+  getSandboxSourceProfile,
+  isCloneProfileDowngrade,
+  normalizeCloneProfile,
   type SandboxLike,
 } from '../sandbox-tree/sandbox-clone-helpers.js';
 
@@ -18,6 +24,57 @@ function sandbox(partial: Partial<SandboxLike> & {id: string}): SandboxLike {
 }
 
 suite('sandbox-clone-helpers', () => {
+  suite('clone profile helpers', () => {
+    test('normalizeCloneProfile handles case and whitespace', () => {
+      assert.strictEqual(normalizeCloneProfile(' LARGE '), 'large');
+      assert.strictEqual(normalizeCloneProfile('xlarge'), 'xlarge');
+      assert.strictEqual(normalizeCloneProfile(undefined), undefined);
+      assert.strictEqual(normalizeCloneProfile(''), undefined);
+      assert.strictEqual(normalizeCloneProfile('tiny'), undefined);
+    });
+
+    test('getAllowedCloneTargetProfiles returns all profiles when source profile is unknown', () => {
+      assert.deepStrictEqual(getAllowedCloneTargetProfiles(undefined), [...CLONE_PROFILES]);
+      assert.deepStrictEqual(getAllowedCloneTargetProfiles('tiny'), [...CLONE_PROFILES]);
+    });
+
+    test('getAllowedCloneTargetProfiles blocks downgrades for large source', () => {
+      assert.deepStrictEqual(getAllowedCloneTargetProfiles('large'), ['large', 'xlarge', 'xxlarge']);
+    });
+
+    test('getSandboxSourceProfile falls back to resourceProfile when profile is missing', () => {
+      assert.strictEqual(getSandboxSourceProfile({resourceProfile: 'large'}), 'large');
+    });
+
+    test('getSandboxSourceProfile prefers profile when both are present', () => {
+      assert.strictEqual(getSandboxSourceProfile({profile: 'xlarge', resourceProfile: 'large'}), 'xlarge');
+    });
+
+    test('getAllowedCloneTargetProfiles allows only xxlarge for xxlarge source', () => {
+      assert.deepStrictEqual(getAllowedCloneTargetProfiles('xxlarge'), ['xxlarge']);
+    });
+
+    test('getExplicitCloneTargetProfiles excludes source profile for large source', () => {
+      assert.deepStrictEqual(getExplicitCloneTargetProfiles('large'), ['xlarge', 'xxlarge']);
+    });
+
+    test('getExplicitCloneTargetProfiles returns empty list for xxlarge source', () => {
+      assert.deepStrictEqual(getExplicitCloneTargetProfiles('xxlarge'), []);
+    });
+
+    test('getExplicitCloneTargetProfiles keeps all options when source profile is unknown', () => {
+      assert.deepStrictEqual(getExplicitCloneTargetProfiles(undefined), [...CLONE_PROFILES]);
+    });
+
+    test('isCloneProfileDowngrade detects downgrade and allows same/upgrade', () => {
+      assert.strictEqual(isCloneProfileDowngrade('large', 'medium'), true);
+      assert.strictEqual(isCloneProfileDowngrade('large', 'large'), false);
+      assert.strictEqual(isCloneProfileDowngrade('large', 'xlarge'), false);
+      assert.strictEqual(isCloneProfileDowngrade('large', undefined), false);
+      assert.strictEqual(isCloneProfileDowngrade(undefined, 'medium'), false);
+    });
+  });
+
   suite('getRealmInstanceId', () => {
     test('joins realm and instance', () => {
       assert.strictEqual(getRealmInstanceId(sandbox({id: 'x', realm: 'zzzz', instance: '004'})), 'zzzz-004');


### PR DESCRIPTION

## Summary

This PR updates sandbox clone profile selection in the VS extension to prevent profile downgrades and remove duplicate profile choices.

### Changes
- Prevent downgrade selections in clone profile picker (same-or-upgrade only).
- Keep `Same as source` and remove duplicate explicit source-profile option.
- Add defensive downgrade validation before sending clone request.
- Add/extend unit tests for profile normalization, source-profile resolution, allowed/explicit target profiles, and downgrade detection.

### Example behavior
For a source sandbox with `large` profile, clone dropdown now shows:
- `Same as source`
- `xlarge`
- `xxlarge`

(`medium` and duplicate `large` are not shown.)

### Validation
- `pnpm --filter b2c-vs-extension run typecheck:agent`
- `pnpm --filter b2c-vs-extension run lint:agent src/sandbox-tree/sandbox-commands.ts src/sandbox-tree/sandbox-clone-helpers.ts src/test/sandbox-clone-helpers.test.ts`

## Dependencies

- [x] No net-new third-party dependencies were added
- [x] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
