### PR TITLE
@W-22899416: import site archives larger than the instance size limit via --split

### DIFF
--- a/.changeset/multi-part-site-import.md
+++ b/.changeset/multi-part-site-import.md
@@ -1,0 +1,11 @@
+---
+'@salesforce/b2c-cli': minor
+'@salesforce/b2c-tooling-sdk': minor
+'@salesforce/b2c-agent-plugins': patch
+---
+
+`b2c job import` now supports `--split` for importing directories larger than the instance archive size limit. With `--split` (and optional `--max-size`, default `190mb`), the import is broken into several smaller archives: order-sensitive metadata/XML is imported first — kept together when it fits, otherwise split at data-unit boundaries in dependency order — followed by static assets packed by compressed size. A normal import that exceeds the limit now warns and recommends `--split`.
+
+Example: `b2c job import ./big-site-data --split --max-size 150mb`
+
+The SDK adds a corresponding `siteArchiveImportSplit()` operation.

--- a/docs/cli/jobs.md
+++ b/docs/cli/jobs.md
@@ -278,6 +278,8 @@ In addition to [global flags](./index#global-flags):
 |------|-------------|---------|
 | `--keep-archive`, `-k` | Keep archive on instance after import | `false` |
 | `--remote`, `-r` | Target is a filename already on the instance (in Impex/src/instance/) | `false` |
+| `--split`, `-s` | Split a large directory import into multiple archive parts to stay under the instance size limit | `false` |
+| `--max-size` | Per-archive size limit for `--split` (e.g. `190`, `190mb`, `512kb`; a bare number is MiB) | `190mb` |
 | `--timeout`, `-t` | Timeout in seconds | No timeout |
 | `--show-log` | Show job log on failure | `true` |
 
@@ -307,6 +309,12 @@ b2c job import ./my-site-data 'libraries/**'
 
 # Mix sites and libraries
 b2c job import ./my-site-data sites/RefArch 'libraries/*'
+
+# Split a large import that exceeds the instance archive size limit
+b2c job import ./big-site-data --split
+
+# Split with a custom per-archive size limit
+b2c job import ./big-site-data --split --max-size 150mb
 ```
 
 ### Notes
@@ -315,6 +323,21 @@ b2c job import ./my-site-data sites/RefArch 'libraries/*'
 - The archive is uploaded to `Impex/src/instance/` on the instance
 - By default, the archive is deleted after successful import (use `--keep-archive` to retain)
 - When `PATHS` are given, only those files/directories are included in the archive — their location under `TARGET` is preserved (e.g. `sites/RefArch/...` stays at `sites/RefArch/...`).
+
+### Importing archives larger than the instance limit
+
+A B2C Commerce instance rejects a single import archive above its size limit (typically 200 MB). The `--split` flag works around this **for directory imports** by importing the data in multiple smaller archive parts:
+
+1. **Metadata/XML first.** All order-sensitive XML (catalogs, libraries, sites, `meta`, etc.) is imported first, kept together in a single archive when it fits. Keeping it together means the import job resolves all internal references and dependency ordering within one archive. If the XML alone exceeds the limit, it is split at top-level data-unit boundaries (e.g. `catalogs`, `libraries`, `sites`) in dependency order — never splitting an individual unit, so a catalog and its internal references always stay together.
+2. **Static assets after.** Static resources (anything under a `static/` folder — images, fonts, binaries) are deferred into subsequent archive parts, packed by **compressed** size. They are order-independent and attach to the catalogs/libraries created by the metadata import.
+
+Parts are imported **sequentially** and the command stops on the first failure.
+
+Packing is by estimated compressed size (already-compressed file types such as JPG/PNG/ZIP are measured as stored). The default per-part ceiling is `190mb` to leave headroom under the instance limit; tune it with `--max-size`.
+
+If a **single file** or a **single data unit's XML** is larger than `--max-size` on its own, it cannot be placed in any part (a file is never split across archives) and the command errors — reduce the export scope for that unit or raise `--max-size` if the instance allows a larger archive.
+
+When you run a normal (non-`--split`) directory import and the assembled archive exceeds the limit, the command warns and recommends re-running with `--split`. `--split` cannot be combined with `--remote`, subset `PATHS`, or `--no-wait`.
 
 ---
 

--- a/packages/b2c-cli/src/commands/job/import.ts
+++ b/packages/b2c-cli/src/commands/job/import.ts
@@ -7,10 +7,37 @@ import {Args, Flags} from '@oclif/core';
 import {JobCommand} from '@salesforce/b2c-tooling-sdk/cli';
 import {
   siteArchiveImport,
+  siteArchiveImportSplit,
   JobExecutionError,
   type SiteArchiveImportResult,
+  type WaitForJobOptions,
 } from '@salesforce/b2c-tooling-sdk/operations/jobs';
+import type {B2COperationContext} from '@salesforce/b2c-tooling-sdk/cli';
 import {t, withDocs} from '../../i18n/index.js';
+
+/**
+ * Parses a human-friendly size string into bytes. A bare number is interpreted
+ * as mebibytes (the default unit); suffixes `b`, `kb`, `mb`, `gb` (and their
+ * `kib`/`mib`/`gib` forms) are also accepted, case-insensitively.
+ */
+function parseSize(input: string): number {
+  const match = /^\s*(\d+(?:\.\d+)?)\s*(b|kb|kib|mb|mib|gb|gib)?\s*$/i.exec(input);
+  if (!match) {
+    throw new Error(`Invalid size: "${input}". Use e.g. 190, 190mb, or 512kb.`);
+  }
+  const value = Number(match[1]);
+  const unit = (match[2] ?? 'mb').toLowerCase();
+  const multipliers: Record<string, number> = {
+    b: 1,
+    kb: 1024,
+    kib: 1024,
+    mb: 1024 * 1024,
+    mib: 1024 * 1024,
+    gb: 1024 * 1024 * 1024,
+    gib: 1024 * 1024 * 1024,
+  };
+  return Math.floor(value * multipliers[unit]);
+}
 
 export default class JobImport extends JobCommand<typeof JobImport> {
   static args = {
@@ -37,6 +64,8 @@ export default class JobImport extends JobCommand<typeof JobImport> {
     '<%= config.bin %> <%= command.id %> existing-archive.zip --remote',
     '<%= config.bin %> <%= command.id %> ./my-site-data sites/RefArch libraries/mylib',
     "<%= config.bin %> <%= command.id %> ./my-site-data 'libraries/**'",
+    '<%= config.bin %> <%= command.id %> ./big-site-data --split',
+    '<%= config.bin %> <%= command.id %> ./big-site-data --split --max-size 150mb',
   ];
 
   static flags = {
@@ -56,6 +85,17 @@ export default class JobImport extends JobCommand<typeof JobImport> {
       char: 'r',
       description: 'Target is a filename already on the instance (in Impex/src/instance/)',
       default: false,
+    }),
+    split: Flags.boolean({
+      char: 's',
+      description:
+        'Split a large directory import into multiple archive parts (XML first, static assets deferred) to stay under the instance size limit',
+      default: false,
+    }),
+    'max-size': Flags.string({
+      description: 'Per-archive size limit for --split (e.g. 190, 190mb, 512kb; bare number is MiB)',
+      default: '190mb',
+      dependsOn: ['split'],
     }),
     timeout: Flags.integer({
       char: 't',
@@ -78,9 +118,10 @@ export default class JobImport extends JobCommand<typeof JobImport> {
 
   protected operations = {
     siteArchiveImport,
+    siteArchiveImportSplit,
   };
 
-  async run(): Promise<SiteArchiveImportResult> {
+  async run(): Promise<SiteArchiveImportResult | SiteArchiveImportResult[]> {
     this.requireOAuthCredentials();
     this.requireWebDavCredentials();
 
@@ -94,14 +135,14 @@ export default class JobImport extends JobCommand<typeof JobImport> {
       wait,
       'keep-archive': keepArchive,
       remote,
+      split,
+      'max-size': maxSizeRaw,
       timeout,
       'poll-interval': pollInterval,
       'show-log': showLog = true,
     } = this.flags;
 
-    if (extraPaths.length > 0 && remote) {
-      this.error('Path arguments are not supported with --remote.');
-    }
+    const maxBytes = this.validateFlags({remote, split, wait, extraPaths, maxSizeRaw});
 
     const hostname = this.resolvedConfig.values.hostname!;
 
@@ -122,6 +163,8 @@ export default class JobImport extends JobCommand<typeof JobImport> {
       keepArchive,
       hostname,
       paths: extraPaths.length > 0 ? extraPaths : undefined,
+      split,
+      maxBytes: split ? maxBytes : undefined,
     });
 
     // Run beforeOperation hooks - check for skip
@@ -164,61 +207,35 @@ export default class JobImport extends JobCommand<typeof JobImport> {
     }
 
     try {
-      const importTarget = remote ? {remoteFilename: target} : target;
-
-      const result = await this.operations.siteArchiveImport(this.instance, importTarget, {
-        keepArchive,
-        wait,
-        paths: extraPaths.length > 0 ? extraPaths : undefined,
-        waitOptions: {
-          timeoutSeconds: timeout,
-          pollIntervalSeconds: pollInterval,
-          onPoll: (info) => {
-            if (!this.jsonEnabled()) {
-              this.log(
-                t('commands.job.import.progress', '  Status: {{status}} ({{elapsed}}s elapsed)', {
-                  status: info.status,
-                  elapsed: String(info.elapsedSeconds),
-                }),
-              );
-            }
-          },
+      const waitOptions = {
+        timeoutSeconds: timeout,
+        pollIntervalSeconds: pollInterval,
+        onPoll: (info: {status: string; elapsedSeconds: number}) => {
+          if (!this.jsonEnabled()) {
+            this.log(
+              t('commands.job.import.progress', '  Status: {{status}} ({{elapsed}}s elapsed)', {
+                status: info.status,
+                elapsed: String(info.elapsedSeconds),
+              }),
+            );
+          }
         },
-      });
+      };
 
-      if (wait) {
-        const durationSec = result.execution.duration ? (result.execution.duration / 1000).toFixed(1) : 'N/A';
-        this.log(
-          t('commands.job.import.completed', 'Import completed: {{status}} (duration: {{duration}}s)', {
-            status: result.execution.exit_status?.code || result.execution.execution_status,
-            duration: durationSec,
-          }),
-        );
-      } else {
-        this.log(
-          t('commands.job.import.started', 'Import job started: {{executionId}} (status: {{status}})', {
-            executionId: result.execution.id,
-            status: result.execution.execution_status,
-          }),
-        );
+      if (split) {
+        return await this.runSplitImport({context, target, maxBytes, keepArchive, waitOptions});
       }
 
-      if (result.archiveKept) {
-        this.log(
-          t('commands.job.import.archiveKept', 'Archive kept at: Impex/src/instance/{{filename}}', {
-            filename: result.archiveFilename,
-          }),
-        );
-      }
-
-      // Run afterOperation hooks with success
-      await this.runAfterHooks(context, {
-        success: true,
-        duration: Date.now() - context.startTime,
-        data: result,
+      return await this.runSingleImport({
+        context,
+        target,
+        remote,
+        wait,
+        keepArchive,
+        maxBytes,
+        paths: extraPaths.length > 0 ? extraPaths : undefined,
+        waitOptions,
       });
-
-      return result;
     } catch (error) {
       // Run afterOperation hooks with failure
       await this.runAfterHooks(context, {
@@ -248,6 +265,184 @@ export default class JobImport extends JobCommand<typeof JobImport> {
       throw error;
     } finally {
       cleanupSafetyRule();
+    }
+  }
+
+  /**
+   * Runs a single-archive import, wiring an oversize callback that recommends
+   * `--split` when the assembled archive exceeds the size ceiling.
+   */
+  private async runSingleImport(opts: {
+    context: B2COperationContext;
+    target: string;
+    remote: boolean;
+    wait: boolean;
+    keepArchive: boolean;
+    maxBytes: number;
+    paths: string[] | undefined;
+    waitOptions: WaitForJobOptions;
+  }): Promise<SiteArchiveImportResult> {
+    const {context, target, remote, wait, keepArchive, maxBytes, paths, waitOptions} = opts;
+    const importTarget = remote ? {remoteFilename: target} : target;
+
+    const result = await this.operations.siteArchiveImport(this.instance, importTarget, {
+      keepArchive,
+      wait,
+      paths,
+      // Measure the assembled archive against the same default ceiling and, if
+      // it's over, recommend --split so the user can act immediately.
+      maxBytes: remote ? undefined : maxBytes,
+      onOversize: ({bytes, maxBytes: limit}) => {
+        if (!this.jsonEnabled()) {
+          this.warn(
+            t(
+              'commands.job.import.oversize',
+              'Archive is {{size}} MiB, over the {{limit}} MiB limit — the instance may reject it. Re-run with --split to import it in multiple parts.',
+              {
+                size: (bytes / (1024 * 1024)).toFixed(1),
+                limit: (limit / (1024 * 1024)).toFixed(0),
+              },
+            ),
+          );
+        }
+      },
+      waitOptions,
+    });
+
+    if (wait) {
+      const durationSec = result.execution.duration ? (result.execution.duration / 1000).toFixed(1) : 'N/A';
+      this.log(
+        t('commands.job.import.completed', 'Import completed: {{status}} (duration: {{duration}}s)', {
+          status: result.execution.exit_status?.code || result.execution.execution_status,
+          duration: durationSec,
+        }),
+      );
+    } else {
+      this.log(
+        t('commands.job.import.started', 'Import job started: {{executionId}} (status: {{status}})', {
+          executionId: result.execution.id,
+          status: result.execution.execution_status,
+        }),
+      );
+    }
+
+    if (result.archiveKept) {
+      this.log(
+        t('commands.job.import.archiveKept', 'Archive kept at: Impex/src/instance/{{filename}}', {
+          filename: result.archiveFilename,
+        }),
+      );
+    }
+
+    await this.runAfterHooks(context, {
+      success: true,
+      duration: Date.now() - context.startTime,
+      data: result,
+    });
+
+    return result;
+  }
+
+  /**
+   * Runs a multi-part split import of a directory, logging the plan and each
+   * part's progress. A failing part throws JobExecutionError (handled by the
+   * caller's catch), so a normal return means all parts imported successfully.
+   */
+  private async runSplitImport(opts: {
+    context: B2COperationContext;
+    target: string;
+    maxBytes: number;
+    keepArchive: boolean;
+    waitOptions: WaitForJobOptions;
+  }): Promise<SiteArchiveImportResult[]> {
+    const {context, target, maxBytes, keepArchive, waitOptions} = opts;
+    const results = await this.operations.siteArchiveImportSplit(this.instance, target, {
+      maxBytes,
+      keepArchive,
+      waitOptions,
+      onPlan: (plan) => {
+        if (!this.jsonEnabled()) {
+          this.log(
+            t(
+              'commands.job.import.splitPlan',
+              'Split into {{parts}} archive part(s): {{xml}} metadata, {{assets}} static asset(s) (max {{size}} MiB each)',
+              {
+                parts: String(plan.partCount),
+                xml: String(plan.xmlPartCount),
+                assets: String(plan.assetPartCount),
+                size: (plan.maxBytes / (1024 * 1024)).toFixed(0),
+              },
+            ),
+          );
+        }
+      },
+      onPart: (info) => {
+        if (!this.jsonEnabled()) {
+          this.log(
+            t(
+              'commands.job.import.splitPart',
+              '  Part {{index}}/{{total}} ({{kind}}): {{filename}} — {{files}} file(s), {{size}} MiB',
+              {
+                index: String(info.index),
+                total: String(info.total),
+                kind: info.kind,
+                filename: info.filename,
+                files: String(info.fileCount),
+                size: (info.bytes / (1024 * 1024)).toFixed(1),
+              },
+            ),
+          );
+        }
+      },
+    });
+
+    this.log(
+      t('commands.job.import.splitCompleted', 'Import completed: {{parts}} part(s) imported', {
+        parts: String(results.length),
+      }),
+    );
+
+    await this.runAfterHooks(context, {
+      success: true,
+      duration: Date.now() - context.startTime,
+      data: results,
+    });
+
+    return results;
+  }
+
+  /**
+   * Validates the flag combination and resolves the `--max-size` value to
+   * bytes. Calls `this.error` (which exits) on any invalid combination.
+   */
+  private validateFlags(opts: {
+    remote: boolean;
+    split: boolean;
+    wait: boolean;
+    extraPaths: string[];
+    maxSizeRaw: string | undefined;
+  }): number {
+    const {remote, split, wait, extraPaths, maxSizeRaw} = opts;
+
+    if (extraPaths.length > 0 && remote) {
+      this.error('Path arguments are not supported with --remote.');
+    }
+    if (split && remote) {
+      this.error('--split is not supported with --remote.');
+    }
+    if (split && extraPaths.length > 0) {
+      this.error('--split imports the whole directory; path arguments are not supported with --split.');
+    }
+    if (split && !wait) {
+      this.error('--split requires waiting for each part; it cannot be combined with --no-wait.');
+    }
+
+    try {
+      // Fall back to the flag default when unset (e.g. in unit tests that
+      // construct flags directly and bypass oclif defaults).
+      return parseSize(maxSizeRaw ?? '190mb');
+    } catch (error) {
+      this.error(error instanceof Error ? error.message : String(error));
     }
   }
 }

--- a/packages/b2c-cli/test/commands/job/import.test.ts
+++ b/packages/b2c-cli/test/commands/job/import.test.ts
@@ -226,4 +226,127 @@ describe('job import', () => {
 
     expect(errorStub.called).to.equal(true);
   });
+
+  it('calls siteArchiveImportSplit with parsed max-size when --split is set', async () => {
+    const command: any = await createCommand(
+      {split: true, 'max-size': '150mb', wait: true, json: true},
+      {target: './big'},
+    );
+    stubCommon(command);
+
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    sinon.stub(command, 'runAfterHooks').resolves(void 0);
+
+    const splitStub = sinon.stub().resolves([
+      {
+        execution: {execution_status: 'finished', exit_status: {code: 'OK'}} as any,
+        archiveFilename: 'big-xml.zip',
+        archiveKept: false,
+      },
+      {
+        execution: {execution_status: 'finished', exit_status: {code: 'OK'}} as any,
+        archiveFilename: 'big-assets-1.zip',
+        archiveKept: false,
+      },
+    ]);
+    const importStub = sinon.stub().rejects(new Error('plain import should not be called'));
+    command.operations = {...command.operations, siteArchiveImport: importStub, siteArchiveImportSplit: splitStub};
+
+    const result = await command.run();
+
+    expect(splitStub.calledOnce).to.equal(true);
+    expect(importStub.called).to.equal(false);
+    expect(splitStub.getCall(0).args[1]).to.equal('./big');
+    expect(splitStub.getCall(0).args[2].maxBytes).to.equal(150 * 1024 * 1024);
+    expect(result).to.have.lengthOf(2);
+  });
+
+  it('parses a bare --max-size number as MiB', async () => {
+    const command: any = await createCommand(
+      {split: true, 'max-size': '128', wait: true, json: true},
+      {target: './big'},
+    );
+    stubCommon(command);
+
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    sinon.stub(command, 'runAfterHooks').resolves(void 0);
+
+    const splitStub = sinon.stub().resolves([
+      {
+        execution: {execution_status: 'finished', exit_status: {code: 'OK'}} as any,
+        archiveFilename: 'big-xml.zip',
+        archiveKept: false,
+      },
+    ]);
+    command.operations = {...command.operations, siteArchiveImportSplit: splitStub};
+
+    await command.run();
+
+    expect(splitStub.getCall(0).args[2].maxBytes).to.equal(128 * 1024 * 1024);
+  });
+
+  it('errors when --split is combined with --remote', async () => {
+    const command: any = await createCommand({split: true, remote: true, wait: true, json: true}, {target: 'a.zip'});
+    stubCommon(command);
+
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
+
+    try {
+      await command.run();
+      expect.fail('Should have thrown');
+    } catch {
+      // expected
+    }
+
+    expect(errorStub.called).to.equal(true);
+    expect(errorStub.getCall(0).args[0]).to.match(/--split is not supported with --remote/);
+  });
+
+  it('errors on an invalid --max-size value', async () => {
+    const command: any = await createCommand(
+      {split: true, 'max-size': 'huge', wait: true, json: true},
+      {target: './big'},
+    );
+    stubCommon(command);
+
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
+
+    try {
+      await command.run();
+      expect.fail('Should have thrown');
+    } catch {
+      // expected
+    }
+
+    expect(errorStub.called).to.equal(true);
+    expect(errorStub.getCall(0).args[0]).to.match(/Invalid size/);
+  });
+
+  it('passes an onOversize callback that warns and recommends --split', async () => {
+    const command: any = await createCommand({json: false}, {target: './dir'});
+    stubCommon(command);
+
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    sinon.stub(command, 'runAfterHooks').resolves(void 0);
+    const warnStub = sinon.stub(command, 'warn').returns(void 0);
+
+    const importStub = sinon.stub().callsFake(async (_instance: any, _target: any, options: any) => {
+      // Simulate the SDK detecting an oversized archive.
+      options.onOversize({bytes: 200 * 1024 * 1024, maxBytes: 190 * 1024 * 1024});
+      return {
+        execution: {execution_status: 'finished', exit_status: {code: 'OK'}} as any,
+        archiveFilename: 'a.zip',
+        archiveKept: false,
+      };
+    });
+    command.operations = {...command.operations, siteArchiveImport: importStub};
+
+    await command.run();
+
+    expect(importStub.getCall(0).args[2].maxBytes).to.equal(190 * 1024 * 1024);
+    expect(warnStub.called).to.equal(true);
+    expect(warnStub.getCall(0).args[0]).to.match(/--split/);
+  });
 });

--- a/packages/b2c-tooling-sdk/src/operations/jobs/index.ts
+++ b/packages/b2c-tooling-sdk/src/operations/jobs/index.ts
@@ -21,6 +21,7 @@
  * ## System Jobs
  *
  * - {@link siteArchiveImport} - Import a site archive
+ * - {@link siteArchiveImportSplit} - Import a large site archive in multiple parts
  * - {@link siteArchiveExport} - Export a site archive
  * - {@link siteArchiveExportToPath} - Export and save to local path
  *
@@ -93,6 +94,7 @@ export type {
 // Site archive import/export
 export {
   siteArchiveImport,
+  siteArchiveImportSplit,
   siteArchiveExport,
   siteArchiveExportToBuffer,
   siteArchiveExportToPath,
@@ -101,6 +103,9 @@ export {
 export type {
   SiteArchiveImportOptions,
   SiteArchiveImportResult,
+  SiteArchiveImportSplitOptions,
+  SplitImportPlanInfo,
+  SplitImportPartInfo,
   SiteArchiveExportOptions,
   SiteArchiveExportResult,
   ExportDataUnitsConfiguration,

--- a/packages/b2c-tooling-sdk/src/operations/jobs/site-archive.ts
+++ b/packages/b2c-tooling-sdk/src/operations/jobs/site-archive.ts
@@ -11,6 +11,7 @@
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as zlib from 'node:zlib';
 import {glob, hasMagic} from 'glob';
 import JSZip from 'jszip';
 import {B2CInstance} from '../../instance/index.js';
@@ -43,6 +44,20 @@ export interface SiteArchiveImportOptions {
    * Ignored when target is a zip file, Buffer, or remote filename.
    */
   paths?: string[];
+  /**
+   * Optional soft size ceiling (in bytes) for the assembled archive. When set
+   * along with {@link SiteArchiveImportOptions.onOversize} and the archive
+   * exceeds it, the callback is invoked before upload — the import still
+   * proceeds. The SDK itself does not warn or block; the consumer decides how
+   * to react. Use {@link siteArchiveImportSplit} to split oversized imports.
+   */
+  maxBytes?: number;
+  /**
+   * Called before upload when the assembled archive exceeds `maxBytes`. Lets
+   * the consumer (e.g. the CLI) surface its own guidance. Receives the archive
+   * size and the configured ceiling.
+   */
+  onOversize?: (info: {bytes: number; maxBytes: number}) => void;
 }
 
 /**
@@ -114,7 +129,7 @@ export async function siteArchiveImport(
   options: SiteArchiveImportOptions & {archiveName?: string} = {},
 ): Promise<SiteArchiveImportResult> {
   const logger = getLogger();
-  const {keepArchive = false, wait = true, waitOptions, archiveName, paths} = options;
+  const {keepArchive = false, wait = true, waitOptions, archiveName, paths, maxBytes, onOversize} = options;
 
   let zipFilename: string;
   let needsUpload = true;
@@ -187,6 +202,14 @@ export async function siteArchiveImport(
 
   // Upload archive if needed
   const uploadPath = `Impex/src/instance/${zipFilename}`;
+
+  // Bubble (do not block, do not warn) when the assembled archive exceeds the
+  // configured ceiling so the caller can advise the user. The SDK has no
+  // opinion on how to react — that's the consumer's call. Buffers have a known
+  // length; streams are not measured here.
+  if (maxBytes && onOversize && Buffer.isBuffer(archiveContent) && archiveContent.length > maxBytes) {
+    onOversize({bytes: archiveContent.length, maxBytes});
+  }
 
   if (needsUpload && archiveContent) {
     logger.debug({path: uploadPath}, `Uploading archive to ${uploadPath}`);
@@ -411,6 +434,441 @@ async function wrapArchiveContents(
     compression: 'DEFLATE',
     compressionOptions: {level: 9},
   });
+}
+
+/**
+ * A file discovered under the import root, with its on-disk and estimated
+ * compressed sizes. Compressed size drives bin packing for split imports.
+ */
+interface SplitFileEntry {
+  /** Absolute path on disk. */
+  abs: string;
+  /** Path relative to the import root, using POSIX separators. */
+  rel: string;
+  /** On-disk (uncompressed) size in bytes. */
+  size: number;
+  /** Estimated size contribution inside a zip (compressed + entry overhead). */
+  packedSize: number;
+}
+
+/**
+ * Result of classifying the files under an import root into the two tiers used
+ * for split imports.
+ */
+interface ClassifiedFiles {
+  /** Order-sensitive files (XML / metadata) — imported first, kept together. */
+  xml: SplitFileEntry[];
+  /** Order-independent static resources — deferred to later archive parts. */
+  assets: SplitFileEntry[];
+}
+
+/**
+ * Options for {@link siteArchiveImportSplit}.
+ */
+export interface SiteArchiveImportSplitOptions {
+  /**
+   * Maximum size in bytes for each archive part (default: 190 MiB). Parts are
+   * packed by estimated compressed size to stay under this ceiling; the
+   * instance import limit is the constraint this works around.
+   */
+  maxBytes?: number;
+  /** Keep archive parts on the instance after import (default: false). */
+  keepArchive?: boolean;
+  /** Wait options applied to each part's import job. */
+  waitOptions?: WaitForJobOptions;
+  /** Base archive name; parts are suffixed (e.g. `<name>-core`, `<name>-assets-1`). */
+  archiveName?: string;
+  /** Called when the overall plan is known, before any upload. */
+  onPlan?: (plan: SplitImportPlanInfo) => void;
+  /** Called before each part begins uploading. */
+  onPart?: (info: SplitImportPartInfo) => void;
+}
+
+/**
+ * Summary of the computed split plan, surfaced via {@link SiteArchiveImportSplitOptions.onPlan}.
+ */
+export interface SplitImportPlanInfo {
+  /** Total number of archive parts that will be imported. */
+  partCount: number;
+  /** Number of parts containing order-sensitive XML/metadata. */
+  xmlPartCount: number;
+  /** Number of parts containing deferred static assets. */
+  assetPartCount: number;
+  /** Per-archive byte ceiling used for packing. */
+  maxBytes: number;
+}
+
+/**
+ * Per-part progress info, surfaced via {@link SiteArchiveImportSplitOptions.onPart}.
+ */
+export interface SplitImportPartInfo {
+  /** 1-based index of this part. */
+  index: number;
+  /** Total number of parts. */
+  total: number;
+  /** Tier of this part. */
+  kind: 'xml' | 'assets';
+  /** Archive filename for this part. */
+  filename: string;
+  /** Number of files in this part. */
+  fileCount: number;
+  /** Assembled archive size in bytes. */
+  bytes: number;
+}
+
+/** Known-incompressible file extensions — packed/estimated as stored (size ≈ on-disk). */
+const INCOMPRESSIBLE_EXTENSIONS = new Set([
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.gif',
+  '.webp',
+  '.avif',
+  '.ico',
+  '.bmp',
+  '.tif',
+  '.tiff',
+  '.zip',
+  '.gz',
+  '.tgz',
+  '.bz2',
+  '.xz',
+  '.7z',
+  '.rar',
+  '.mp4',
+  '.m4v',
+  '.mov',
+  '.avi',
+  '.webm',
+  '.mkv',
+  '.mp3',
+  '.m4a',
+  '.aac',
+  '.ogg',
+  '.wav',
+  '.flac',
+  '.pdf',
+  '.woff',
+  '.woff2',
+  '.jar',
+  '.swf',
+]);
+
+/** Per-entry zip overhead estimate (local + central headers + descriptor), plus 2× name. */
+const ZIP_ENTRY_OVERHEAD = 100;
+
+/**
+ * Dependency-ordered priority of top-level data-unit directories. Lower runs
+ * first when XML must be split across multiple archive parts. Unlisted
+ * directories sort after these (still before nothing — appended last).
+ */
+const UNIT_PRIORITY: Record<string, number> = {
+  meta: 0,
+  catalogs: 1,
+  pricebooks: 2,
+  'price-books': 2,
+  'inventory-lists': 3,
+  inventory: 3,
+  libraries: 4,
+  sites: 5,
+};
+
+/** Human-readable byte size (MiB/KiB/B). */
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KiB`;
+  }
+  return `${bytes} B`;
+}
+
+/**
+ * Estimates the in-archive size of a file: its on-disk size for known
+ * incompressible types (stored), or the exact DEFLATE size otherwise. A small
+ * per-entry overhead is added to account for zip headers.
+ */
+async function estimateCompressedSize(abs: string, rel: string, size: number): Promise<number> {
+  const ext = path.extname(abs).toLowerCase();
+  const overhead = ZIP_ENTRY_OVERHEAD + Buffer.byteLength(rel) * 2;
+
+  if (INCOMPRESSIBLE_EXTENSIONS.has(ext)) {
+    return size + overhead;
+  }
+
+  const content = await fs.promises.readFile(abs);
+  const deflated = zlib.deflateRawSync(content, {level: 9});
+  return deflated.length + overhead;
+}
+
+/**
+ * Walks the import root and classifies every file into the XML (order-sensitive)
+ * or asset (deferrable static resource) tier, estimating each file's packed
+ * size. A file is treated as a static asset when its path contains a `static/`
+ * segment (the canonical location for catalog/library static resources).
+ */
+async function classifyFiles(rootDir: string): Promise<ClassifiedFiles> {
+  const rootAbs = path.resolve(rootDir);
+  const xml: SplitFileEntry[] = [];
+  const assets: SplitFileEntry[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    const entries = await fs.promises.readdir(dir, {withFileTypes: true});
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile()) {
+        const stat = await fs.promises.stat(full);
+        const rel = path.relative(rootAbs, full).split(path.sep).join('/');
+        const packedSize = await estimateCompressedSize(full, rel, stat.size);
+        const fileEntry: SplitFileEntry = {abs: full, rel, size: stat.size, packedSize};
+        const segments = rel.split('/');
+        const isStatic = segments.includes('static');
+        if (isStatic) {
+          assets.push(fileEntry);
+        } else {
+          xml.push(fileEntry);
+        }
+      }
+    }
+  }
+
+  await walk(rootAbs);
+  return {xml, assets};
+}
+
+/**
+ * Bin-packs files into groups whose total packed size stays under `budget`,
+ * using first-fit-decreasing. Throws if any single file exceeds the budget on
+ * its own (it cannot be placed in any archive and the file itself is not split).
+ */
+function packBySize(entries: SplitFileEntry[], budget: number): SplitFileEntry[][] {
+  const sorted = [...entries].sort((a, b) => b.packedSize - a.packedSize);
+  const bins: {entries: SplitFileEntry[]; used: number}[] = [];
+
+  for (const entry of sorted) {
+    if (entry.packedSize > budget) {
+      throw new Error(
+        `File too large to fit in a single archive part: ${entry.rel} ` +
+          `(${formatBytes(entry.packedSize)} compressed exceeds ${formatBytes(budget)} budget). ` +
+          `A single file cannot be split across archives.`,
+      );
+    }
+    const bin = bins.find((b) => b.used + entry.packedSize <= budget);
+    if (bin) {
+      bin.entries.push(entry);
+      bin.used += entry.packedSize;
+    } else {
+      bins.push({entries: [entry], used: entry.packedSize});
+    }
+  }
+
+  return bins.map((b) => b.entries);
+}
+
+/**
+ * Packs order-sensitive XML files into archive parts. When everything fits
+ * under `budget`, returns a single part (the preferred outcome — all XML
+ * together avoids cross-archive ordering concerns). Otherwise splits at
+ * top-level data-unit directory boundaries (e.g. `catalogs`, `libraries`,
+ * `sites`) in dependency order, keeping each unit's files together so internal
+ * references (e.g. between catalogs) stay in one archive.
+ *
+ * @throws if a single top-level unit's XML alone exceeds the budget.
+ */
+function packXml(entries: SplitFileEntry[], budget: number): SplitFileEntry[][] {
+  const total = entries.reduce((sum, e) => sum + e.packedSize, 0);
+  if (total <= budget) {
+    return [entries];
+  }
+
+  // Group by top-level directory (the data-unit boundary).
+  const groups = new Map<string, SplitFileEntry[]>();
+  for (const entry of entries) {
+    const top = entry.rel.split('/')[0];
+    const group = groups.get(top);
+    if (group) {
+      group.push(entry);
+    } else {
+      groups.set(top, [entry]);
+    }
+  }
+
+  // Order groups by dependency priority, unlisted units last (alphabetical).
+  const orderedKeys = [...groups.keys()].sort((a, b) => {
+    const pa = UNIT_PRIORITY[a] ?? Number.MAX_SAFE_INTEGER;
+    const pb = UNIT_PRIORITY[b] ?? Number.MAX_SAFE_INTEGER;
+    return pa !== pb ? pa - pb : a.localeCompare(b);
+  });
+
+  const parts: SplitFileEntry[][] = [];
+  let current: SplitFileEntry[] = [];
+  let currentSize = 0;
+
+  for (const key of orderedKeys) {
+    const group = groups.get(key)!;
+    const groupSize = group.reduce((sum, e) => sum + e.packedSize, 0);
+
+    if (groupSize > budget) {
+      throw new Error(
+        `Data unit "${key}" is too large to fit in a single archive part ` +
+          `(${formatBytes(groupSize)} compressed exceeds ${formatBytes(budget)} budget). ` +
+          `Its XML cannot be split without risking broken internal references; ` +
+          `reduce the export scope for this unit or raise --max-size.`,
+      );
+    }
+
+    if (currentSize + groupSize > budget && current.length > 0) {
+      parts.push(current);
+      current = [];
+      currentSize = 0;
+    }
+    current.push(...group);
+    currentSize += groupSize;
+  }
+
+  if (current.length > 0) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+/**
+ * Imports a large site archive by splitting it into multiple archive parts that
+ * each stay under a size ceiling, then importing them sequentially.
+ *
+ * This works around the instance-side limit on a single import archive. The
+ * strategy:
+ * 1. **Order-sensitive XML/metadata** is imported first, kept together in one
+ *    archive when it fits (preferred). If it must be split, it splits at
+ *    top-level data-unit boundaries in dependency order, never splitting a
+ *    single unit — so catalogs (and their internal references) ride together.
+ * 2. **Static assets** (catalog/library static resources) are deferred to
+ *    subsequent archive parts, bin-packed by compressed size. They are
+ *    order-independent and attach to the units created by the XML import.
+ *
+ * Parts are imported sequentially and the operation stops on the first failure.
+ *
+ * @param instance - B2C instance to import to
+ * @param dir - Local directory to import (must be a directory)
+ * @param options - Split import options
+ * @returns One import result per archive part, in import order
+ * @throws Error if a single file or data unit cannot fit under `maxBytes`
+ * @throws JobExecutionError if any part's import job fails
+ *
+ * @example
+ * ```typescript
+ * const results = await siteArchiveImportSplit(instance, './big-site-data', {
+ *   maxBytes: 190 * 1024 * 1024,
+ *   onPart: (p) => console.log(`Part ${p.index}/${p.total}: ${p.kind} (${p.fileCount} files)`),
+ * });
+ * ```
+ */
+export async function siteArchiveImportSplit(
+  instance: B2CInstance,
+  dir: string,
+  options: SiteArchiveImportSplitOptions = {},
+): Promise<SiteArchiveImportResult[]> {
+  const logger = getLogger();
+  const {maxBytes = 190 * 1024 * 1024, keepArchive = false, waitOptions, archiveName, onPlan, onPart} = options;
+
+  if (!fs.existsSync(dir)) {
+    throw new Error(`Target not found: ${dir}`);
+  }
+  const stat = await fs.promises.stat(dir);
+  if (!stat.isDirectory()) {
+    throw new Error('siteArchiveImportSplit requires a directory target');
+  }
+
+  // Pack with a safety margin below the ceiling; the post-build assertion is
+  // the real guard against estimation drift.
+  const budget = Math.floor(maxBytes * 0.95);
+
+  logger.debug({dir, maxBytes, budget}, `Classifying files under ${dir} for split import`);
+  const {xml, assets} = await classifyFiles(dir);
+
+  const xmlParts = xml.length > 0 ? packXml(xml, budget) : [];
+  const assetParts = assets.length > 0 ? packBySize(assets, budget) : [];
+
+  const baseName = archiveName ?? `import-${Date.now()}`;
+
+  // Build the ordered list of parts: XML first, then assets.
+  interface PlannedPart {
+    kind: 'xml' | 'assets';
+    entries: SplitFileEntry[];
+    dirName: string;
+  }
+  const planned: PlannedPart[] = [];
+  xmlParts.forEach((entries, i) => {
+    const suffix = xmlParts.length > 1 ? `-xml-${i + 1}` : '-xml';
+    planned.push({kind: 'xml', entries, dirName: `${baseName}${suffix}`});
+  });
+  assetParts.forEach((entries, i) => {
+    planned.push({kind: 'assets', entries, dirName: `${baseName}-assets-${i + 1}`});
+  });
+
+  if (planned.length === 0) {
+    throw new Error(`No files found to import under: ${dir}`);
+  }
+
+  onPlan?.({
+    partCount: planned.length,
+    xmlPartCount: xmlParts.length,
+    assetPartCount: assetParts.length,
+    maxBytes,
+  });
+  logger.debug(
+    {partCount: planned.length, xmlParts: xmlParts.length, assetParts: assetParts.length},
+    `Split plan: ${planned.length} part(s) (${xmlParts.length} xml, ${assetParts.length} asset)`,
+  );
+
+  const results: SiteArchiveImportResult[] = [];
+  const rootAbs = path.resolve(dir);
+
+  for (let i = 0; i < planned.length; i++) {
+    const part = planned[i];
+    const buffer = await createArchiveFromPaths(
+      rootAbs,
+      part.entries.map((e) => e.abs),
+      part.dirName,
+    );
+
+    // Guard against estimation drift: a part must not exceed the ceiling.
+    if (buffer.length > maxBytes) {
+      throw new Error(
+        `Archive part ${part.dirName} assembled to ${formatBytes(buffer.length)}, ` +
+          `which exceeds the ${formatBytes(maxBytes)} limit. ` +
+          `This can happen when incompressible data was under-estimated; ` +
+          `try a lower --max-size.`,
+      );
+    }
+
+    onPart?.({
+      index: i + 1,
+      total: planned.length,
+      kind: part.kind,
+      filename: `${part.dirName}.zip`,
+      fileCount: part.entries.length,
+      bytes: buffer.length,
+    });
+    logger.debug(
+      {part: part.dirName, kind: part.kind, files: part.entries.length, bytes: buffer.length},
+      `Importing part ${i + 1}/${planned.length}: ${part.dirName} (${formatBytes(buffer.length)})`,
+    );
+
+    const result = await siteArchiveImport(instance, buffer, {
+      archiveName: part.dirName,
+      keepArchive,
+      wait: true,
+      waitOptions,
+    });
+    results.push(result);
+  }
+
+  return results;
 }
 
 /**

--- a/packages/b2c-tooling-sdk/test/operations/jobs/site-archive.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/jobs/site-archive.test.ts
@@ -17,6 +17,7 @@ import {MockAuthStrategy} from '../../helpers/mock-auth.js';
 import JSZip from 'jszip';
 import {
   siteArchiveImport,
+  siteArchiveImportSplit,
   siteArchiveExport,
   siteArchiveExportToPath,
 } from '../../../src/operations/jobs/site-archive.js';
@@ -581,6 +582,355 @@ describe('operations/jobs/site-archive', () => {
         // The error message includes the job ID
         expect(error.message).to.include('failed');
       }
+    });
+  });
+
+  describe('siteArchiveImportSplit', () => {
+    /**
+     * Registers MSW handlers that capture every uploaded archive and respond to
+     * the import job execution for each part. Each PUT body is collected so
+     * tests can inspect how files were partitioned across archives.
+     */
+    function captureSplitUploads(): {uploads: Buffer[]; executions: () => number} {
+      const uploads: Buffer[] = [];
+      let execCount = 0;
+
+      server.use(
+        http.all(`${WEBDAV_BASE}/*`, async ({request}) => {
+          const url = new URL(request.url);
+          if (request.method === 'PUT' && url.pathname.includes('Impex/src/instance/')) {
+            uploads.push(Buffer.from(await request.arrayBuffer()));
+            return new HttpResponse(null, {status: 201});
+          }
+          if (request.method === 'DELETE') {
+            return new HttpResponse(null, {status: 204});
+          }
+          return new HttpResponse(null, {status: 404});
+        }),
+        http.post(`${OCAPI_BASE}/jobs/sfcc-site-archive-import/executions`, () => {
+          execCount++;
+          return HttpResponse.json({
+            id: `split-exec-${execCount}`,
+            execution_status: 'finished',
+            exit_status: {code: 'OK'},
+          });
+        }),
+        http.get(`${OCAPI_BASE}/jobs/sfcc-site-archive-import/executions/:id`, ({params}) =>
+          HttpResponse.json({
+            id: params.id,
+            execution_status: 'finished',
+            exit_status: {code: 'OK'},
+            is_log_file_existing: false,
+          }),
+        ),
+      );
+
+      return {uploads, executions: () => execCount};
+    }
+
+    /** Collects the non-directory entry paths from a captured archive buffer. */
+    async function entriesOf(buffer: Buffer): Promise<string[]> {
+      const zip = await JSZip.loadAsync(buffer);
+      return Object.keys(zip.files).filter((p) => !zip.files[p].dir);
+    }
+
+    it('keeps all XML in a single part when it fits under the limit', async () => {
+      const root = path.join(tempDir, 'site-data');
+      fs.mkdirSync(path.join(root, 'catalogs', 'cat-a'), {recursive: true});
+      fs.mkdirSync(path.join(root, 'libraries', 'lib-a'), {recursive: true});
+      fs.writeFileSync(path.join(root, 'catalogs', 'cat-a', 'catalog.xml'), '<catalog/>');
+      fs.writeFileSync(path.join(root, 'libraries', 'lib-a', 'library.xml'), '<library/>');
+
+      const {uploads} = captureSplitUploads();
+
+      const results = await siteArchiveImportSplit(mockInstance, root, {
+        archiveName: 'big',
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      // No static assets → exactly one (xml) part.
+      expect(results).to.have.lengthOf(1);
+      expect(uploads).to.have.lengthOf(1);
+
+      const entries = await entriesOf(uploads[0]);
+      expect(entries).to.include('big-xml/catalogs/cat-a/catalog.xml');
+      expect(entries).to.include('big-xml/libraries/lib-a/library.xml');
+    });
+
+    it('defers static assets into separate parts after the XML', async () => {
+      const root = path.join(tempDir, 'site-data');
+      fs.mkdirSync(path.join(root, 'catalogs', 'cat-a', 'static'), {recursive: true});
+      fs.writeFileSync(path.join(root, 'catalogs', 'cat-a', 'catalog.xml'), '<catalog/>');
+      // A large incompressible asset that exceeds the per-part budget on its own
+      // would error, so size it under a tiny limit but big enough to force its
+      // own asset part separate from the XML.
+      const asset = Buffer.alloc(50 * 1024, 7); // compressible-but-we-store-by-ext? .bin is compressible
+      fs.writeFileSync(path.join(root, 'catalogs', 'cat-a', 'static', 'image.jpg'), asset);
+
+      const {uploads} = captureSplitUploads();
+
+      const results = await siteArchiveImportSplit(mockInstance, root, {
+        archiveName: 'big',
+        maxBytes: 1024 * 1024,
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      // One XML part + one asset part, XML imported first.
+      expect(results).to.have.lengthOf(2);
+      expect(uploads).to.have.lengthOf(2);
+
+      const first = await entriesOf(uploads[0]);
+      const second = await entriesOf(uploads[1]);
+      expect(first).to.include('big-xml/catalogs/cat-a/catalog.xml');
+      expect(first).to.not.include('big-xml/catalogs/cat-a/static/image.jpg');
+      expect(second.some((p) => p.endsWith('catalogs/cat-a/static/image.jpg'))).to.be.true;
+    });
+
+    it('splits assets across multiple parts to stay under the size limit', async () => {
+      const root = path.join(tempDir, 'site-data');
+      fs.mkdirSync(path.join(root, 'libraries', 'lib-a', 'static'), {recursive: true});
+      fs.writeFileSync(path.join(root, 'libraries', 'lib-a', 'library.xml'), '<library/>');
+
+      // Three ~40KB incompressible (jpg) assets with an 80KB budget → each
+      // asset is stored (not deflated), so they cannot all share one archive.
+      for (let i = 0; i < 3; i++) {
+        fs.writeFileSync(
+          path.join(root, 'libraries', 'lib-a', 'static', `img-${i}.jpg`),
+          Buffer.alloc(40 * 1024, i + 1),
+        );
+      }
+
+      const {uploads} = captureSplitUploads();
+
+      const results = await siteArchiveImportSplit(mockInstance, root, {
+        archiveName: 'big',
+        maxBytes: 80 * 1024,
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      // 1 xml part + at least 2 asset parts (3×40KB stored can't fit 2-per-80KB
+      // with overhead → 3 asset parts in practice).
+      const xmlParts = results.length - (results.length - 1);
+      expect(xmlParts).to.equal(1);
+      expect(results.length).to.be.greaterThan(2);
+
+      // Every asset must appear exactly once across all asset archives.
+      const allEntries: string[] = [];
+      for (const buf of uploads) {
+        allEntries.push(...(await entriesOf(buf)));
+      }
+      for (let i = 0; i < 3; i++) {
+        const matches = allEntries.filter((p) => p.endsWith(`static/img-${i}.jpg`));
+        expect(matches, `img-${i}.jpg should appear once`).to.have.lengthOf(1);
+      }
+    });
+
+    it('throws when a single asset exceeds the per-part limit', async () => {
+      const root = path.join(tempDir, 'site-data');
+      fs.mkdirSync(path.join(root, 'libraries', 'lib-a', 'static'), {recursive: true});
+      fs.writeFileSync(path.join(root, 'libraries', 'lib-a', 'library.xml'), '<library/>');
+      // 200KB incompressible asset, 50KB budget → cannot fit, cannot split.
+      fs.writeFileSync(path.join(root, 'libraries', 'lib-a', 'static', 'huge.jpg'), Buffer.alloc(200 * 1024, 9));
+
+      captureSplitUploads();
+
+      try {
+        await siteArchiveImportSplit(mockInstance, root, {
+          maxBytes: 50 * 1024,
+          waitOptions: FAST_WAIT_OPTIONS,
+        });
+        expect.fail('Should have thrown');
+      } catch (error: any) {
+        expect(error.message).to.include('too large to fit in a single archive');
+      }
+    });
+
+    it('throws when a single data unit XML exceeds the per-part limit', async () => {
+      const root = path.join(tempDir, 'site-data');
+      fs.mkdirSync(path.join(root, 'catalogs', 'cat-a'), {recursive: true});
+      // Incompressible content (xorshift PRNG) so the deflated size stays large
+      // and reliably exceeds the budget even after compression. A .xml under a
+      // catalog is classified as order-sensitive (not a static asset).
+      const big = Buffer.alloc(100 * 1024);
+      let state = 0x12345678;
+      for (let i = 0; i < big.length; i++) {
+        state ^= state << 13;
+        state ^= state >>> 17;
+        state ^= state << 5;
+        big[i] = state & 0xff;
+      }
+      fs.writeFileSync(path.join(root, 'catalogs', 'cat-a', 'catalog.xml'), big);
+
+      captureSplitUploads();
+
+      try {
+        await siteArchiveImportSplit(mockInstance, root, {
+          maxBytes: 10 * 1024, // 10KB budget — the ~100KB XML unit cannot fit
+          waitOptions: FAST_WAIT_OPTIONS,
+        });
+        expect.fail('Should have thrown');
+      } catch (error: any) {
+        expect(error.message).to.match(/too large to fit in a single archive part/);
+      }
+    });
+
+    it('imports parts sequentially, one job execution per part', async () => {
+      const root = path.join(tempDir, 'site-data');
+      fs.mkdirSync(path.join(root, 'libraries', 'lib-a', 'static'), {recursive: true});
+      fs.writeFileSync(path.join(root, 'libraries', 'lib-a', 'library.xml'), '<library/>');
+      for (let i = 0; i < 2; i++) {
+        fs.writeFileSync(
+          path.join(root, 'libraries', 'lib-a', 'static', `img-${i}.jpg`),
+          Buffer.alloc(40 * 1024, i + 1),
+        );
+      }
+
+      const {uploads, executions} = captureSplitUploads();
+
+      const results = await siteArchiveImportSplit(mockInstance, root, {
+        archiveName: 'big',
+        maxBytes: 60 * 1024,
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      expect(executions()).to.equal(results.length);
+      expect(uploads).to.have.lengthOf(results.length);
+      // First part is always the XML/metadata tier.
+      const first = await entriesOf(uploads[0]);
+      expect(first.some((p) => p.endsWith('library.xml'))).to.be.true;
+    });
+
+    it('reports the plan and each part via callbacks', async () => {
+      const root = path.join(tempDir, 'site-data');
+      fs.mkdirSync(path.join(root, 'libraries', 'lib-a', 'static'), {recursive: true});
+      fs.writeFileSync(path.join(root, 'libraries', 'lib-a', 'library.xml'), '<library/>');
+      fs.writeFileSync(path.join(root, 'libraries', 'lib-a', 'static', 'img.jpg'), Buffer.alloc(40 * 1024, 1));
+
+      captureSplitUploads();
+
+      let plan: any = null;
+      const parts: any[] = [];
+
+      await siteArchiveImportSplit(mockInstance, root, {
+        maxBytes: 1024 * 1024,
+        waitOptions: FAST_WAIT_OPTIONS,
+        onPlan: (p) => {
+          plan = p;
+        },
+        onPart: (info) => {
+          parts.push(info);
+        },
+      });
+
+      expect(plan).to.not.be.null;
+      expect(plan.partCount).to.equal(2);
+      expect(plan.xmlPartCount).to.equal(1);
+      expect(plan.assetPartCount).to.equal(1);
+      expect(parts).to.have.lengthOf(2);
+      expect(parts[0].kind).to.equal('xml');
+      expect(parts[1].kind).to.equal('assets');
+    });
+
+    it('rejects a non-directory target', async () => {
+      const zipPath = path.join(tempDir, 'archive.zip');
+      fs.writeFileSync(zipPath, Buffer.from('PK\x03\x04'));
+
+      try {
+        await siteArchiveImportSplit(mockInstance, zipPath, {waitOptions: FAST_WAIT_OPTIONS});
+        expect.fail('Should have thrown');
+      } catch (error: any) {
+        expect(error.message).to.include('requires a directory');
+      }
+    });
+  });
+
+  describe('siteArchiveImport oversize callback', () => {
+    it('invokes onOversize when the archive exceeds maxBytes', async () => {
+      const root = path.join(tempDir, 'site-data');
+      fs.mkdirSync(path.join(root, 'libraries', 'lib-a', 'static'), {recursive: true});
+      fs.writeFileSync(path.join(root, 'libraries', 'lib-a', 'library.xml'), '<library/>');
+      // Incompressible content so the assembled archive genuinely exceeds the
+      // tiny ceiling (the archive DEFLATEs everything, so all-identical bytes
+      // would shrink to near-nothing).
+      const incompressible = Buffer.alloc(40 * 1024);
+      let state = 0x2545f491;
+      for (let i = 0; i < incompressible.length; i++) {
+        state ^= state << 13;
+        state ^= state >>> 17;
+        state ^= state << 5;
+        incompressible[i] = state & 0xff;
+      }
+      fs.writeFileSync(path.join(root, 'libraries', 'lib-a', 'static', 'img.jpg'), incompressible);
+
+      server.use(
+        http.all(
+          `${WEBDAV_BASE}/*`,
+          async ({request}) => new HttpResponse(null, {status: request.method === 'PUT' ? 201 : 204}),
+        ),
+        http.post(`${OCAPI_BASE}/jobs/sfcc-site-archive-import/executions`, () =>
+          HttpResponse.json({id: 'os-1', execution_status: 'finished', exit_status: {code: 'OK'}}),
+        ),
+        http.get(`${OCAPI_BASE}/jobs/sfcc-site-archive-import/executions/os-1`, () =>
+          HttpResponse.json({
+            id: 'os-1',
+            execution_status: 'finished',
+            exit_status: {code: 'OK'},
+            is_log_file_existing: false,
+          }),
+        ),
+      );
+
+      let oversize: {bytes: number; maxBytes: number} | null = null;
+
+      await siteArchiveImport(mockInstance, root, {
+        archiveName: 'big',
+        maxBytes: 1024, // tiny ceiling so the archive is over it
+        onOversize: (info) => {
+          oversize = info;
+        },
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      expect(oversize).to.not.be.null;
+      expect(oversize!.bytes).to.be.greaterThan(1024);
+      expect(oversize!.maxBytes).to.equal(1024);
+    });
+
+    it('does not invoke onOversize when the archive is within maxBytes', async () => {
+      const root = path.join(tempDir, 'site-data');
+      fs.mkdirSync(path.join(root, 'libraries', 'lib-a'), {recursive: true});
+      fs.writeFileSync(path.join(root, 'libraries', 'lib-a', 'library.xml'), '<library/>');
+
+      server.use(
+        http.all(
+          `${WEBDAV_BASE}/*`,
+          async ({request}) => new HttpResponse(null, {status: request.method === 'PUT' ? 201 : 204}),
+        ),
+        http.post(`${OCAPI_BASE}/jobs/sfcc-site-archive-import/executions`, () =>
+          HttpResponse.json({id: 'os-2', execution_status: 'finished', exit_status: {code: 'OK'}}),
+        ),
+        http.get(`${OCAPI_BASE}/jobs/sfcc-site-archive-import/executions/os-2`, () =>
+          HttpResponse.json({
+            id: 'os-2',
+            execution_status: 'finished',
+            exit_status: {code: 'OK'},
+            is_log_file_existing: false,
+          }),
+        ),
+      );
+
+      let called = false;
+
+      await siteArchiveImport(mockInstance, root, {
+        archiveName: 'small',
+        maxBytes: 50 * 1024 * 1024,
+        onOversize: () => {
+          called = true;
+        },
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      expect(called).to.be.false;
     });
   });
 

--- a/skills/b2c-cli/skills/b2c-site-import-export/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-site-import-export/SKILL.md
@@ -37,6 +37,26 @@ b2c job import ./my-site-data --show-log
 b2c job import existing-archive.zip --remote
 ```
 
+### Import Archives Larger Than the Instance Limit
+
+An instance rejects a single import archive above its size limit (typically 200 MB). Use `--split` on a directory import to import the data in multiple smaller parts:
+
+```bash
+# Split a large directory import into multiple archive parts
+b2c job import ./big-site-data --split
+
+# Tune the per-archive size limit (default 190mb; bare number is MiB)
+b2c job import ./big-site-data --split --max-size 150mb
+```
+
+How splitting works:
+
+- **Metadata/XML is imported first**, kept together in one archive when it fits (so internal references and dependency ordering resolve within a single import). If the XML alone is too large, it splits at top-level data-unit boundaries (`catalogs`, `libraries`, `sites`, `meta`, …) in dependency order — never splitting a single unit.
+- **Static assets** (files under a `static/` folder) are deferred into later archive parts, packed by compressed size. They attach to the catalogs/libraries created by the metadata import.
+- Parts import sequentially; the command stops on the first failure.
+
+If a single file, or a single data unit's XML, is larger than `--max-size` on its own, the command errors (a file is never split across archives). A normal directory import that exceeds the limit warns and recommends `--split`. `--split` cannot be combined with `--remote`, subset paths, or `--no-wait`.
+
 ## Export Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Adds multi-part site archive import to `b2c job import` so directories larger than the instance's single-archive size limit (typically 200 MB) can be imported directly — no more manually slicing archives with external tools like `zipsplit`.

This is a common problem customers hit with large site data, and a concrete current blocker for the new **"MarketStreet"** data set used for Storefront Next (SFNext), whose archive exceeds the import limit and is rejected outright.

Resolves **W-22899416**.

## What changed

`b2c job import <dir> --split` (with optional `--max-size`, default `190mb`) breaks a directory import into several smaller archives imported sequentially:

- **Metadata/XML first.** Order-sensitive XML (catalogs, libraries, sites, `meta`, …) is imported first, kept together in one archive when it fits so the import job resolves all internal references and dependency ordering within a single archive. If it overflows, it splits at top-level data-unit boundaries in dependency order, **never splitting an individual unit** (a catalog and its internal references always ride together).
- **Static assets after.** Files under `static/` folders are deferred into subsequent parts, packed by **compressed** size (already-compressed types like JPG/PNG/ZIP are measured as stored). They're order-independent and attach to the catalogs/libraries created by the metadata import.
- Parts import sequentially and stop on the first failure.
- A single file, or a single data unit's XML, that exceeds `--max-size` on its own errors clearly (a file is never split across archives).
- A normal (non-`--split`) directory import that exceeds the limit now **warns and recommends `--split`**, so users discover the flag exactly when they hit the wall.

Pure-JavaScript — no new dependencies (`zlib` is built-in; reuses existing `jszip`/`glob`).

### API

- **CLI:** new `--split` / `--max-size` flags on `job import`.
- **SDK:** new `siteArchiveImportSplit()` operation in `@salesforce/b2c-tooling-sdk`; `siteArchiveImport()` gains `maxBytes` + `onOversize` hooks (the SDK only bubbles the oversize signal — the consumer decides how to react).

## Docs

`docs/cli/jobs.md` and the `b2c-site-import-export` user skill both document the flag and the splitting behavior. Changeset included (`minor` for CLI + SDK, `patch` for agent-plugins).

