### PR TITLE
fix(skills): correct value-definition element order in metadata skills

### DIFF
--- a/.changeset/fix-metadata-skill-value-definition-order.md
+++ b/.changeset/fix-metadata-skill-value-definition-order.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Fix `value-definition` element order in the b2c-metadata and b2c-site-import-export skills. The B2C `metadata.xsd` requires `<display>` to appear before `<value>` inside each `<value-definition>`; the skill examples had them reversed, which caused enum/set attribute imports to fail site-archive validation with `cvc-complex-type.2.4.d`. Examples now use the correct order and call out the requirement.

--- a/skills/b2c-cli/skills/b2c-site-import-export/references/METADATA-XML.md
+++ b/skills/b2c-cli/skills/b2c-site-import-export/references/METADATA-XML.md
@@ -58,20 +58,20 @@ For service configurations (HTTP services, credentials, profiles), see the `b2c:
                 <mandatory-flag>false</mandatory-flag>
                 <value-definitions>
                     <value-definition default="true">
-                        <value>pending</value>
                         <display xml:lang="x-default">Pending</display>
+                        <value>pending</value>
                     </value-definition>
                     <value-definition>
-                        <value>processing</value>
                         <display xml:lang="x-default">Processing</display>
+                        <value>processing</value>
                     </value-definition>
                     <value-definition>
-                        <value>shipped</value>
                         <display xml:lang="x-default">Shipped</display>
+                        <value>shipped</value>
                     </value-definition>
                     <value-definition>
-                        <value>delivered</value>
                         <display xml:lang="x-default">Delivered</display>
+                        <value>delivered</value>
                     </value-definition>
                 </value-definitions>
             </attribute-definition>

--- a/skills/b2c/skills/b2c-metadata/SKILL.md
+++ b/skills/b2c/skills/b2c-metadata/SKILL.md
@@ -94,7 +94,9 @@ Add custom attributes to existing system objects.
 
 ### Enum Value Definitions
 
-Enum types (`enum-of-string`, `enum-of-int`, `set-of-string`, `set-of-int`) require `value-definitions` with **value/display pairs**:
+Enum types (`enum-of-string`, `enum-of-int`, `set-of-string`, `set-of-int`) require `value-definitions` with **display/value pairs**:
+
+> **Element order matters.** Inside each `<value-definition>`, the `<display>` element must come **before** `<value>`. The `metadata.xsd` schema enforces this strict ordering — putting `<value>` first fails site import validation with `cvc-complex-type.2.4.d: Invalid content was found starting with element 'display'`.
 
 ```xml
 <attribute-definition attribute-id="warrantyType">
@@ -103,16 +105,16 @@ Enum types (`enum-of-string`, `enum-of-int`, `set-of-string`, `set-of-int`) requ
     <mandatory-flag>false</mandatory-flag>
     <value-definitions>
         <value-definition>
-            <value>none</value>
             <display xml:lang="x-default">No Warranty</display>
+            <value>none</value>
         </value-definition>
         <value-definition>
-            <value>limited</value>
             <display xml:lang="x-default">Limited Warranty</display>
+            <value>limited</value>
         </value-definition>
         <value-definition>
-            <value>full</value>
             <display xml:lang="x-default">Full Warranty</display>
+            <value>full</value>
         </value-definition>
     </value-definitions>
 </attribute-definition>
@@ -120,8 +122,8 @@ Enum types (`enum-of-string`, `enum-of-int`, `set-of-string`, `set-of-int`) requ
 
 | Element | Purpose |
 |---------|---------|
+| `<display>` | Human-readable label shown in Business Manager (must appear first) |
 | `<value>` | The stored/API value (use lowercase, no spaces) |
-| `<display>` | Human-readable label shown in Business Manager |
 
 ## Product Custom Attribute Example
 
@@ -145,16 +147,16 @@ Enum types (`enum-of-string`, `enum-of-int`, `set-of-string`, `set-of-int`) requ
                 <mandatory-flag>false</mandatory-flag>
                 <value-definitions>
                     <value-definition>
-                        <value>new</value>
                         <display xml:lang="x-default">New</display>
+                        <value>new</value>
                     </value-definition>
                     <value-definition>
-                        <value>refurbished</value>
                         <display xml:lang="x-default">Refurbished</display>
+                        <value>refurbished</value>
                     </value-definition>
                     <value-definition>
-                        <value>used</value>
                         <display xml:lang="x-default">Used</display>
+                        <value>used</value>
                     </value-definition>
                 </value-definitions>
             </attribute-definition>
@@ -174,12 +176,12 @@ Enum types (`enum-of-string`, `enum-of-int`, `set-of-string`, `set-of-int`) requ
                 <mandatory-flag>false</mandatory-flag>
                 <value-definitions>
                     <value-definition>
-                        <value>waterproof</value>
                         <display xml:lang="x-default">Waterproof</display>
+                        <value>waterproof</value>
                     </value-definition>
                     <value-definition>
-                        <value>recyclable</value>
                         <display xml:lang="x-default">Recyclable</display>
+                        <value>recyclable</value>
                     </value-definition>
                 </value-definitions>
             </attribute-definition>

--- a/skills/b2c/skills/b2c-metadata/references/SYSTEM-OBJECTS.md
+++ b/skills/b2c/skills/b2c-metadata/references/SYSTEM-OBJECTS.md
@@ -70,12 +70,12 @@ Placed orders.
             <type>enum-of-string</type>
             <value-definitions>
                 <value-definition>
-                    <value>pending</value>
                     <display xml:lang="x-default">Pending</display>
+                    <value>pending</value>
                 </value-definition>
                 <value-definition>
-                    <value>exported</value>
                     <display xml:lang="x-default">Exported</display>
+                    <value>exported</value>
                 </value-definition>
             </value-definitions>
         </attribute-definition>
@@ -131,16 +131,16 @@ Customer profiles (registered customers).
             <type>enum-of-string</type>
             <value-definitions>
                 <value-definition>
-                    <value>email</value>
                     <display xml:lang="x-default">Email</display>
+                    <value>email</value>
                 </value-definition>
                 <value-definition>
-                    <value>phone</value>
                     <display xml:lang="x-default">Phone</display>
+                    <value>phone</value>
                 </value-definition>
                 <value-definition>
-                    <value>sms</value>
                     <display xml:lang="x-default">SMS</display>
+                    <value>sms</value>
                 </value-definition>
             </value-definitions>
         </attribute-definition>
@@ -160,12 +160,12 @@ Customer address book entries.
             <type>enum-of-string</type>
             <value-definitions>
                 <value-definition>
-                    <value>residential</value>
                     <display xml:lang="x-default">Residential</display>
+                    <value>residential</value>
                 </value-definition>
                 <value-definition>
-                    <value>commercial</value>
                     <display xml:lang="x-default">Commercial</display>
+                    <value>commercial</value>
                 </value-definition>
             </value-definitions>
         </attribute-definition>

--- a/skills/b2c/skills/b2c-metadata/references/XML-EXAMPLES.md
+++ b/skills/b2c/skills/b2c-metadata/references/XML-EXAMPLES.md
@@ -62,16 +62,16 @@ b2c docs schema --list
                 <mandatory-flag>false</mandatory-flag>
                 <value-definitions>
                     <value-definition>
-                        <value>none</value>
                         <display xml:lang="x-default">No Warranty</display>
+                        <value>none</value>
                     </value-definition>
                     <value-definition default="true">
-                        <value>standard</value>
                         <display xml:lang="x-default">Standard Warranty</display>
+                        <value>standard</value>
                     </value-definition>
                     <value-definition>
-                        <value>extended</value>
                         <display xml:lang="x-default">Extended Warranty</display>
+                        <value>extended</value>
                     </value-definition>
                 </value-definitions>
             </attribute-definition>
@@ -99,16 +99,16 @@ b2c docs schema --list
                 <mandatory-flag>false</mandatory-flag>
                 <value-definitions>
                     <value-definition>
-                        <value>energy-star</value>
                         <display xml:lang="x-default">Energy Star</display>
+                        <value>energy-star</value>
                     </value-definition>
                     <value-definition>
-                        <value>ul-listed</value>
                         <display xml:lang="x-default">UL Listed</display>
+                        <value>ul-listed</value>
                     </value-definition>
                     <value-definition>
-                        <value>fda-approved</value>
                         <display xml:lang="x-default">FDA Approved</display>
+                        <value>fda-approved</value>
                     </value-definition>
                 </value-definitions>
             </attribute-definition>
@@ -154,16 +154,16 @@ b2c docs schema --list
                 <type>enum-of-string</type>
                 <value-definitions>
                     <value-definition default="true">
-                        <value>pending</value>
                         <display xml:lang="x-default">Pending</display>
+                        <value>pending</value>
                     </value-definition>
                     <value-definition>
-                        <value>synced</value>
                         <display xml:lang="x-default">Synced</display>
+                        <value>synced</value>
                     </value-definition>
                     <value-definition>
-                        <value>failed</value>
                         <display xml:lang="x-default">Failed</display>
+                        <value>failed</value>
                     </value-definition>
                 </value-definitions>
             </attribute-definition>
@@ -230,16 +230,16 @@ b2c docs schema --list
                 <type>set-of-string</type>
                 <value-definitions>
                     <value-definition>
-                        <value>promotions</value>
                         <display xml:lang="x-default">Promotions</display>
+                        <value>promotions</value>
                     </value-definition>
                     <value-definition>
-                        <value>new-arrivals</value>
                         <display xml:lang="x-default">New Arrivals</display>
+                        <value>new-arrivals</value>
                     </value-definition>
                     <value-definition>
-                        <value>tips</value>
                         <display xml:lang="x-default">Tips & Tricks</display>
+                        <value>tips</value>
                     </value-definition>
                 </value-definitions>
             </attribute-definition>


### PR DESCRIPTION
## What

The B2C `metadata.xsd` schema requires `<display>` to appear **before** `<value>` inside each `<value-definition>`. The `b2c-metadata` and `b2c-site-import-export` skills had every enum/set example with the elements reversed (`<value>` first).

## Why

Following the skills' examples produces metadata XML that **fails site-archive import validation**:

```
ERROR ... cvc-complex-type.2.4.d: Invalid content was found starting with
element 'display'. No child element is expected at this point.
```

This was discovered while building a real `OrganizationPreferences` metadata archive and importing it via `b2c job import` — the import was rejected on every enum/set attribute until the element order was corrected, after which it imported cleanly.

## Changes

- Reordered `<display>`/`<value>` in all `value-definition` examples across:
  - `skills/b2c/skills/b2c-metadata/SKILL.md`
  - `skills/b2c/skills/b2c-metadata/references/XML-EXAMPLES.md`
  - `skills/b2c/skills/b2c-metadata/references/SYSTEM-OBJECTS.md`
  - `skills/b2c-cli/skills/b2c-site-import-export/references/METADATA-XML.md`
- Added an explicit "Element order matters" note in `SKILL.md` documenting the schema requirement, and reordered the element reference table to match.

## Verification

- Confirmed against live `metadata.xsd` (sandbox `zzpq-013`): a value-first archive fails validation; the display-first version imports successfully.
- `grep` confirms zero remaining value-before-display occurrences across the skill sources.

Changeset: `@salesforce/b2c-agent-plugins` (patch).