### PR TITLE
@W-22919546 fix(vs-extension): bundle vscode-html-languageservice in ISML scanner

### DIFF
--- a/.changeset/fix-isml-scanner-bundling.md
+++ b/.changeset/fix-isml-scanner-bundling.md
@@ -1,0 +1,5 @@
+---
+'b2c-vs-extension': patch
+---
+
+Fix the VS Code extension failing to activate when ISML support is enabled. The `src/isml/scanner.ts` module loaded `vscode-html-languageservice` via runtime `require()` calls that esbuild left unbundled. Because the VSIX is packaged with `vsce --no-dependencies`, the deep submodule paths could not be resolved at runtime and activation crashed silently — no "B2C DX" output channel, no instance selector, no commands. Switched to direct ESM imports so esbuild inlines the scanner code into the bundle.

--- a/packages/b2c-vs-extension/src/isml/scanner.ts
+++ b/packages/b2c-vs-extension/src/isml/scanner.ts
@@ -4,36 +4,12 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import {createRequire} from 'node:module';
-
-interface Scanner {
-  scan: () => number;
-  getTokenOffset: () => number;
-  getTokenLength: () => number;
-  getTokenText: () => string;
-}
-
-interface HtmlScannerModule {
-  createScanner: (input: string, initialOffset?: number, initialState?: number) => Scanner;
-}
-
-interface HtmlLanguageTypesModule {
-  TokenType: {
-    EOS: number;
-    StartTag: number;
-    StartTagClose: number;
-    StartTagSelfClose: number;
-    AttributeName: number;
-    AttributeValue: number;
-  };
-  ScannerState: {
-    WithinContent: number;
-  };
-}
-
-const require = createRequire(import.meta.url);
-const scannerModule = require('vscode-html-languageservice/lib/umd/parser/htmlScanner.js') as HtmlScannerModule;
-const typesModule = require('vscode-html-languageservice/lib/umd/htmlLanguageTypes.js') as HtmlLanguageTypesModule;
+// Direct ES imports so esbuild bundles the scanner code into the extension
+// bundle. The previous createRequire()-based deep-imports were left as runtime
+// requires by the bundler, which broke activation under `vsce --no-dependencies`
+// (no node_modules in the VSIX).
+import * as scannerModule from 'vscode-html-languageservice/lib/esm/parser/htmlScanner.js';
+import * as typesModule from 'vscode-html-languageservice/lib/esm/htmlLanguageTypes.js';
 
 export type IsmlScannerTokenType =
   | 'startTag'


### PR DESCRIPTION
## Summary
- Fixes a silent activation crash in the B2C DX VS Code extension introduced by the ISML support feature: `src/isml/scanner.ts` loaded `vscode-html-languageservice` via `createRequire()` + deep-path `require()`, which esbuild left unbundled. Under `vsce --no-dependencies` packaging the modules are not on disk, so `Module._resolveFilename` threw during activation — no "B2C DX" output channel, no instance selector, no commands worked.
- Switched the scanner to direct ESM imports (`vscode-html-languageservice/lib/esm/...`) so esbuild inlines the scanner code into `dist/extension.cjs`. The built bundle now contains **zero** `vscode-html-languageservice` references and the extension activates cleanly.

GUS: [W-22919546](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/a07EE00002brJebYAE/view)

## Why this slipped through
- PR builds typecheck and bundle without warnings; the failure only manifests at runtime under `--no-dependencies` packaging.
- The first activation event to fire is `onLanguage:isml` (which also activates `redhat.vscode-xml`); once the activation cache records a failure every subsequent event is short-circuited, so the extension appears completely dead in the UI.
- The original error is only visible in `~/Library/Application Support/Code/logs/<latest>/window1/exthost/exthost.log`:
  ```
  Activating extension Salesforce.b2c-vs-extension failed due to an error:
  Error: Cannot find module 'vscode-html-languageservice/lib/umd/parser/htmlScanner.js'
  ```

## Follow-up (not in this PR)
Add a build-time or activation-time regression check so that any future runtime `require()` of an unbundled npm package fails CI — either an esbuild plugin assertion or a smoke test that loads `dist/extension.cjs` in isolation.

## Test plan
- [x] `pnpm --filter b2c-vs-extension run typecheck:agent` passes
- [x] `pnpm --filter b2c-vs-extension run build` succeeds; `grep -c vscode-html-languageservice dist/extension.cjs` returns `0`
- [x] `pnpm --filter b2c-vs-extension run package` produces a working VSIX; installing it locally restores the "B2C DX" output channel and instance selector (verified by user with the same code in 0.9.1-diag.2.vsix)
- [ ] CI green