### PR TITLE
Remove the pilot note for SFNext

### DIFF
--- a/docs/guide/storefront-next.md
+++ b/docs/guide/storefront-next.md
@@ -4,11 +4,9 @@ description: Set up Storefront Next development environments using the B2C CLI t
 
 # Storefront Next
 
-::: warning Important
-Storefront Next is currently in a closed pilot. Access to Storefront Next is limited to pilot customers. Features and configuration may change.
-:::
-
 Set up Storefront Next development environments using the B2C CLI to create sandboxes, SLAS clients, MRT environments, and deploy.
+
+To learn more about Storefront Next, see the [Storefront Next](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-get-started.html) documentation.
 
 ## Prerequisites
 

--- a/docs/mcp/figma-tools-setup.md
+++ b/docs/mcp/figma-tools-setup.md
@@ -6,8 +6,6 @@ description: Prerequisites and setup for Figma-to-component tools (workflow orch
 
 Prerequisites and setup for using the Figma workflow tools: `sfnext_start_figma_workflow`, `sfnext_analyze_component`, and `sfnext_match_tokens_to_theme`.
 
-> **Note:** 🚧 This MCP tool is for Storefront Next. Storefront Next is part of a closed pilot and isn't available for general use.
-
 ## Overview
 
 The Figma-to-component workflow requires an **external Figma MCP server** to fetch design data from Figma. The b2c-dx-mcp server handles workflow orchestration, component analysis, and token mapping, but it needs the Figma MCP server to access Figma designs.

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -6,8 +6,6 @@ description: MCP Server for Salesforce B2C Commerce - AI-assisted development to
 
 The B2C DX MCP Server enables AI assistants (like Claude Code, Cursor, GitHub Copilot, and others) to help with B2C Commerce development tasks. It provides toolsets for **SCAPI**, **CARTRIDGES**, **MRT**, **PWAV3**, and **STOREFRONTNEXT** development.
 
-> **Note:** 🚧 The STOREFRONTNEXT MCP tool is for Storefront Next. Storefront Next is part of a closed pilot and isn't available for general use.
-
 ## Quick Start
 
 1. **Install** — set up the MCP server for your client. See the [Installation Guide](./installation) for Claude Code, Cursor, GitHub Copilot, and other clients.

--- a/docs/mcp/tools/sfnext-add-page-designer-decorator.md
+++ b/docs/mcp/tools/sfnext-add-page-designer-decorator.md
@@ -6,8 +6,6 @@ description: Add Page Designer decorators to React components for Storefront Nex
 
 Adds Page Designer decorators (`@Component`, `@AttributeDefinition`, `@RegionDefinition`) to React components to make them available in Page Designer for Storefront Next.
 
-> **Note:** 🚧 This MCP tool is for Storefront Next. Storefront Next is part of a closed pilot and isn't available for general use.
-
 ## Overview
 
 The `sfnext_add_page_designer_decorator` tool analyzes React components and generates Page Designer decorators that enable components to be used in Page Designer. It supports two modes:

--- a/docs/mcp/tools/sfnext-analyze-component.md
+++ b/docs/mcp/tools/sfnext-analyze-component.md
@@ -6,8 +6,6 @@ description: Analyze design and discovered components to recommend REUSE, EXTEND
 
 Analyzes design and discovered components to recommend a component generation strategy. Returns a REUSE, EXTEND, or CREATE action with confidence score, key differences, and suggested implementation approach.
 
-> **Note:** 🚧 This MCP tool is for Storefront Next. Storefront Next is part of a closed pilot and isn't available for general use.
-
 ## Overview
 
 The `sfnext_analyze_component` tool compares design React code (e.g., from Figma, design handoff, or other sources) against existing components discovered in the codebase. It analyzes differences across styling, structure, behavior, and props, then recommends the best approach:

--- a/docs/mcp/tools/sfnext-configure-theme.md
+++ b/docs/mcp/tools/sfnext-configure-theme.md
@@ -6,8 +6,6 @@ description: Get theming guidelines, guided questions, and WCAG color contrast v
 
 Guides theming changes (colors, fonts, visual styling) for Storefront Next and validates color combinations for WCAG accessibility.
 
-> **Note:** 🚧 This MCP tool is for Storefront Next. Storefront Next is part of a closed pilot and isn't available for general use.
-
 ## Overview
 
 The `sfnext_configure_theme` tool provides a structured workflow for applying theming to Storefront Next sites:

--- a/docs/mcp/tools/sfnext-get-guidelines.md
+++ b/docs/mcp/tools/sfnext-get-guidelines.md
@@ -6,8 +6,6 @@ description: Get Storefront Next development guidelines and best practices for R
 
 Returns critical architecture rules, coding standards, and best practices for building Storefront Next applications with React Server Components.
 
-> **Note:** 🚧 This MCP tool is for Storefront Next. Storefront Next is part of a closed pilot and isn't available for general use.
-
 ## Overview
 
 The `sfnext_get_guidelines` tool provides essential development guidance for Storefront Next. It:

--- a/docs/mcp/tools/sfnext-match-tokens-to-theme.md
+++ b/docs/mcp/tools/sfnext-match-tokens-to-theme.md
@@ -6,8 +6,6 @@ description: Match Figma design tokens to existing theme tokens in app.css with 
 
 Matches Figma design tokens (colors, spacing, radius, etc.) to your Storefront Next theme tokens in `app.css`. Helps you identify which design tokens match existing theme variables and suggests new token names for values that don't have matches.
 
-> **Note:** 🚧 This MCP tool is for Storefront Next. Storefront Next is part of a closed pilot and isn't available for general use.
-
 ## Overview
 
 The `sfnext_match_tokens_to_theme` tool helps you use theme tokens instead of hardcoded values in your components. After retrieving design tokens (from Figma, design handoff, or other sources), use this tool to match them against your Storefront Next theme.

--- a/docs/mcp/tools/sfnext-start-figma-workflow.md
+++ b/docs/mcp/tools/sfnext-start-figma-workflow.md
@@ -6,8 +6,6 @@ description: Workflow orchestrator for Figma-to-component conversion. Parses you
 
 Workflow orchestrator for converting Figma designs to Storefront Next components. Provide a Figma design URL to start the workflow, which extracts design data, analyzes your codebase, and produces component recommendations.
 
-> **Note:** 🚧 This MCP tool is for Storefront Next. Storefront Next is part of a closed pilot and isn't available for general use.
-
 ## Overview
 
 When you provide a Figma design URL, the workflow will:

--- a/docs/mcp/toolsets.md
+++ b/docs/mcp/toolsets.md
@@ -120,8 +120,6 @@ Salesforce Commerce API discovery and exploration.
 
 Storefront Next development tools for building modern storefronts.
 
-> **Note:** 🚧 This MCP tool is for Storefront Next. Storefront Next is part of a closed pilot and isn't available for general use.
-
 **Status:** 🚧 Preview — requires `--allow-non-ga-tools` flag.
 
 **Auto-enabled for:** Storefront Next projects (detected by `@salesforce/storefront-next*` dependencies, package name starting with `storefront-next`, or workspace packages with these indicators)


### PR DESCRIPTION
## Summary

Remove the pilot note of Storefront Next because it is now GA. Also, add a link to the Storefront Next doc.

## Testing

How was this tested?

## Dependencies

- [ ] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [ ] Tests pass (`pnpm test`)
- [ ] Code is formatted (`pnpm run format`)
