### PR TITLE
docs(skills): clarify CLI config auto-discovery and Custom API cartridge paths

### DIFF
--- a/.changeset/skills-config-discovery-blurb.md
+++ b/.changeset/skills-config-discovery-blurb.md
@@ -1,0 +1,9 @@
+---
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Skills now consistently document that the CLI auto-discovers configuration (instance, credentials, tenantId, etc.) from `dw.json`, `SFCC_*` env vars, `~/.mobify`, and `package.json` — flags like `--server`, `--client-id`, and `--client-secret` are usually unnecessary. Each instance-touching skill points agents at `b2c setup inspect` for resolved values and sources, and back to `b2c-config` for setup troubleshooting.
+
+The `b2c-config` skill has been broadened to be the fallback whenever CLI setup or authentication is unclear, with general configuration guidance (including the fact that `dw.json` keys accept both camelCase and kebab-case) and a richer troubleshooting section.
+
+The `b2c-custom-api-development` skill now describes Custom API cartridge-path lookup correctly: storefront `siteId` resolves through that site's cartridge path, while `siteId=Sites-Site` (the system-defined BM/organization site identifier) and an omitted `siteId` resolve through the Business Manager cartridge path. The skill shows how to manage paths with `b2c sites cartridges` and clarifies when `b2c code deploy --reload` is required (registration, contract, or cartridge-path changes) versus when a plain redeploy suffices (implementation-only edits to an already-registered endpoint).

--- a/skills/b2c-cli/skills/b2c-am/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-am/SKILL.md
@@ -14,8 +14,10 @@ Use the `b2c am` commands to manage Account Manager resources: API clients, user
 Account Manager commands work out of the box with no configuration. The CLI uses a built-in public client and opens a browser for login.
 
 - **Zero-config (browser login):** Default. Just run the commands -- the CLI opens a browser for login.
-- **Client credentials:** For CI/CD and automation. Pass `--client-id` and `--client-secret` (or set `SFCC_CLIENT_ID` and `SFCC_CLIENT_SECRET` env vars).
+- **Client credentials:** For CI/CD and automation. The CLI auto-discovers `clientId`/`clientSecret` from `SFCC_*` env vars, `dw.json` (in the current or a parent directory), `package.json`, or configuration plugins — **passing `--client-id`/`--client-secret` flags is usually unnecessary**.
 - **Force browser login (`--user-auth`):** When client credentials are configured but you need browser-based login (required for org and client management).
+
+> Run `b2c setup inspect` to confirm which credentials the CLI sees and where they came from. For precedence and troubleshooting, see the `b2c-cli:b2c-config` skill.
 
 ### Role Requirements
 

--- a/skills/b2c-cli/skills/b2c-bm-users-roles/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-bm-users-roles/SKILL.md
@@ -13,6 +13,8 @@ For **Account Manager** user/role/client management (cross-instance, scoped to t
 
 ## Authentication
 
+The CLI auto-discovers the target instance and credentials from `SFCC_*` environment variables, `dw.json` in the current or parent directories, `~/.mobify`, `package.json`, and configuration plugins. **Flags like `--server`, `--client-id`, and `--client-secret` are usually unnecessary** — only pass them to override what's auto-detected. Run `b2c setup inspect` to see the resolved configuration and which source provided each value. For precedence and troubleshooting, see the `b2c-cli:b2c-config` skill.
+
 Most BM commands accept either client credentials or browser-based user auth. A handful require a *real BM user identity* and the CLI defaults those to user-auth automatically.
 
 | Command group | Default auth | Why |

--- a/skills/b2c-cli/skills/b2c-cap/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-cap/SKILL.md
@@ -9,6 +9,12 @@ Use the `b2c` CLI plugin to **validate, package, install, uninstall, list, and p
 
 > **Tip:** If `b2c` is not installed globally, use `npx @salesforce/b2c-cli` instead (e.g., `npx @salesforce/b2c-cli cap list`).
 
+## Configuration & Authentication
+
+The CLI auto-discovers the target instance and credentials from `SFCC_*` environment variables, `dw.json` in the current or parent directories, `~/.mobify`, `package.json`, and configuration plugins. **Flags like `--server`, `--client-id`, and `--client-secret` are usually unnecessary** — only pass them to override what's auto-detected.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (use `--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
+
 ## Examples
 
 ### List Installed Features

--- a/skills/b2c-cli/skills/b2c-cip/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-cip/SKILL.md
@@ -31,7 +31,9 @@ cip
 
 ## Configuration
 
-Values like `tenantId`, `clientId`, and `clientSecret` resolve from `dw.json` / `SFCC_*` env vars / the active instance. Examples below show minimal usage; add flags only to override configured values. If a required value is missing, the CLI emits an actionable error pointing at the flag, env var, and config key. See the `b2c-config` skill for precedence details.
+Values like `tenantId`, `clientId`, and `clientSecret` resolve from `dw.json` / `SFCC_*` env vars / the active instance / configuration plugins. Examples below show minimal usage; **add flags only to override configured values** — passing `--client-id`/`--client-secret`/`--tenant-id` is usually unnecessary. If a required value is missing, the CLI emits an actionable error pointing at the flag, env var, and config key.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (`--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
 
 Relevant overrides:
 

--- a/skills/b2c-cli/skills/b2c-code/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-code/SKILL.md
@@ -9,6 +9,12 @@ Use the `b2c` CLI to deploy, download, and manage code versions on Salesforce B2
 
 > **Tip:** If `b2c` is not installed globally, use `npx @salesforce/b2c-cli` instead (e.g., `npx @salesforce/b2c-cli code deploy`).
 
+## Configuration & Authentication
+
+The CLI auto-discovers the target instance and credentials from `SFCC_*` environment variables, `dw.json` in the current or parent directories, `~/.mobify`, `package.json`, and configuration plugins. **Flags like `--server`, `--client-id`, `--client-secret`, `--username`, and `--password` are usually unnecessary** — only pass them to override what's auto-detected.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (use `--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
+
 ## Examples
 
 ### Deploy Cartridges

--- a/skills/b2c-cli/skills/b2c-config/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: b2c-config
-description: Inspect and debug CLI configuration, instance connections, and authentication. Use this skill whenever the user needs to check which dw.json or credentials are active, manage multiple instance profiles, retrieve OAuth tokens for scripting, troubleshoot authentication failures or connection errors, or integrate with VS Code or other editors. Also use when environment variables override config or the wrong sandbox is being targeted -- even if they just say 'why is it connecting to the wrong instance' or 'get me an access token'.
+description: Inspect, configure, and troubleshoot the B2C CLI's setup, authentication, and instance connections. Use this skill as the **fallback whenever CLI setup, configuration, or authentication is unclear or failing** — including "command can't find my instance/credentials", auth errors (401/403, "client credentials required"), wrong sandbox being targeted, env var vs dw.json precedence, hostname mismatch warnings, missing tenantId/shortCode, OAuth scope errors, multi-instance switching, retrieving access tokens for scripts, and IDE/Prophet integration. Also use when the user needs to check what `dw.json` looks like, what fields it accepts (camelCase or kebab-case keys), or where the CLI is reading config from. Triggers include "why is the CLI connecting to the wrong instance", "auth keeps failing", "what config does the CLI see", "I need an OAuth token", "my dw.json isn't being picked up", or any general "how do I configure the CLI" question.
 ---
 
 # B2C Config Skill
@@ -8,6 +8,39 @@ description: Inspect and debug CLI configuration, instance connections, and auth
 The B2C CLI (`@salesforce/b2c-cli`) is a command-line tool for Salesforce B2C Commerce development. It provides commands organized by topic: `auth`, `code`, `webdav`, `sandbox`, `mrt`, `scapi`, `slas`, `ecdn`, `job`, `logs`, `sites`, `content`, `cip`, `setup`, and more. Use `b2c --help` or `b2c <topic> --help` for a full list.
 
 > **Tip:** If `b2c` is not installed globally, use `npx @salesforce/b2c-cli` instead (e.g., `npx @salesforce/b2c-cli setup inspect`).
+
+## How the CLI Discovers Configuration (read this first)
+
+The CLI **automatically detects** instance hostname, credentials, tenant ID, MRT API key, and other settings from multiple sources. **You usually do not need to pass `--server`, `--client-id`, `--client-secret`, `--username`, `--password`, `--tenant-id`, `--short-code`, or `--api-key` as flags** — the CLI picks them up from the environment or config files.
+
+Sources, in resolution order (highest priority first):
+
+1. **CLI flags and environment variables** — explicit values always win. Includes `.env` files in the current project directory (auto-loaded).
+2. **Plugin sources (high priority)** — custom configuration plugins (e.g., secret managers).
+3. **`dw.json`** — searched starting at the current directory and walking up the directory tree. Supports a single instance or a `configs[]` array with `active: true` / `-i <name>` selection.
+4. **`~/.mobify`** — home-directory file (MRT API key only).
+5. **Plugin sources (low priority)**.
+6. **`package.json`** under the `b2c` key — non-sensitive project defaults (e.g., `shortCode`, `clientId`, `mrtProject`). Sensitive fields like `clientSecret`/`password` are intentionally **not** allowed here.
+
+When in doubt, **always run `b2c setup inspect` first** — it shows the resolved value and the source for every field. This is the single most useful command for setup confusion.
+
+### `dw.json` Key Casing
+
+Field names in `dw.json` accept **both camelCase and kebab-case** — they're equivalent. For example:
+
+| Either form works |
+|---|
+| `clientId` ≡ `client-id` |
+| `clientSecret` ≡ `client-secret` |
+| `codeVersion` ≡ `code-version` |
+| `tenantId` ≡ `tenant-id` |
+| `shortCode` ≡ `short-code` ≡ `scapi-shortcode` |
+| `webdavHostname` ≡ `webdav-hostname` ≡ `webdav-server` ≡ `secureHostname` |
+| `certificatePassphrase` ≡ `certificate-passphrase` ≡ `passphrase` |
+
+Legacy aliases like `server` (for `hostname`) are also still supported. If a value isn't being picked up, casing is rarely the cause — check spelling, then run `b2c setup inspect` to see what the CLI actually parsed.
+
+For the full field reference, see the [Configuration guide](https://b2c-developer-tooling.dx.commercecloud.salesforce.com/guide/configuration.html) (or `docs/guide/configuration.md` in the repo).
 
 ## Authentication
 
@@ -201,27 +234,71 @@ Values are resolved with this priority (highest to lowest):
 
 When troubleshooting, check the source column to understand which configuration is taking precedence.
 
-## Common Issues
+## Troubleshooting
 
-### Missing Values
+**Always start with `b2c setup inspect`** — it shows resolved values and their sources. Add `--unmask` to see full secrets, `--json` for scripting. If a value isn't where you expect, the source column will tell you which file/env var/plugin won.
 
-If a value shows `-`, it means no source provided that configuration. Check:
+### Command says "credentials required" or "client-id is required"
 
-- Is the field spelled correctly in dw.json?
-- Is the environment variable set?
-- Does the plugin provide that value?
+- The CLI is not finding `clientId`/`clientSecret`. Run `b2c setup inspect` and check the OAuth section.
+- Confirm `dw.json` exists in the current directory or a parent (the CLI walks up from `cwd`).
+- Confirm `SFCC_CLIENT_ID`/`SFCC_CLIENT_SECRET` env vars are exported in *this* shell, not just defined elsewhere.
+- Credential groups are **atomic**: if `clientId` comes from one source and `clientSecret` from a lower-priority one, the lower-priority secret is discarded. Provide both from the same source, or use a higher-priority override.
 
-### Wrong Source Taking Precedence
+### Command targets the wrong instance
 
-If a value comes from an unexpected source:
+- `b2c setup inspect` will show the resolved hostname and its source.
+- For multi-instance `dw.json`, the `active: true` config is used by default. Override with `-i <name>` per-command, or change the default with `b2c setup instance set-active <name>`.
+- `SFCC_SERVER` (or any env var) overrides `dw.json`. Unset it if you want `dw.json` to win.
+- **Hostname mismatch protection:** if you pass `--server` (or `SFCC_SERVER`) that differs from the `dw.json` hostname, the CLI ignores **all** other values from `dw.json` to prevent mixing credentials across instances. Either match the hostname or pass full credentials explicitly.
 
-- Higher priority sources override lower ones
-- Credential groups (username+password, clientId+clientSecret) are atomic
-- Hostname mismatch protection may discard values
+### `dw.json` is not being picked up
 
-### Sensitive Values Masked
+- Check the `Sources` block from `b2c setup inspect` — if `DwJsonSource` isn't listed, the file wasn't found.
+- The CLI searches from the current working directory upward. Run from your project root, set `SFCC_PROJECT_DIRECTORY`, or pass `--config /path/to/dw.json`.
+- Ensure the file is valid JSON (a parse error silently skips it).
+- Field name casing doesn't matter — both `clientId` and `client-id` work. See "dw.json Key Casing" above.
 
-By default, passwords and secrets show partial values like `admi...REDACTED`. Use `--unmask` to see full values when debugging authentication issues.
+### 401/403 errors on SCAPI/OCAPI calls
+
+- Confirm the resolved `clientId`/`clientSecret` belong to the *target* instance (Account Manager scopes the API client per tenant).
+- Check OAuth scopes: required scopes vary by command (e.g., `sfcc.cdn-zones`, `sfcc.orders`). Pass `--auth-scope` or set `SFCC_OAUTH_SCOPES`.
+- For SCAPI commands, verify `tenantId` is correct — tenant IDs use underscores (`zzxy_001`), hostnames use hyphens (`zzxy-001`). The CLI normalizes between them, but a wrong tenant ID will produce 403s.
+
+### Missing `tenantId` / `shortCode`
+
+- These resolve from `dw.json`, `SFCC_TENANT_ID`/`SFCC_SHORTCODE`, or `package.json`. Run `b2c setup inspect` to see which source provided them.
+- For sandboxes, `tenantId` is derived from the hostname (replace `-` with `_`): `zzxy-001.dx...` → `zzxy_001`.
+
+### MRT commands say "API key required"
+
+- `MRT_API_KEY` (or `SFCC_MRT_API_KEY`) env var, or `~/.mobify` file (`{ "api_key": "..." }`).
+- When using `--cloud-origin <host>`, the CLI looks for `~/.mobify--<host>` instead of plain `~/.mobify`.
+
+### Sensitive values masked in `setup inspect`
+
+- By default secrets show as `admi...REDACTED`. Add `--unmask` to see full values when debugging.
+
+### Missing values
+
+- If a field shows `-`, no source provided it. Check spelling in `dw.json`, env var presence, and plugin output. Remember: `clientSecret`, `password`, and `mrtApiKey` cannot be set via `package.json` — use `dw.json` or env vars.
+
+### Wrong source taking precedence
+
+- Review the priority list in "How the CLI Discovers Configuration" above. Common surprise: env vars (or a `.env` file) override `dw.json`.
+
+### Still stuck
+
+Compare two outputs:
+
+```bash
+b2c setup inspect --unmask --json > expected.json   # in a known-good shell
+# ... run the failing command in the broken shell, then:
+b2c setup inspect --unmask --json > actual.json
+diff expected.json actual.json
+```
+
+The diff usually points directly at the missing or overridden field.
 
 ## Getting Admin OAuth Tokens
 

--- a/skills/b2c-cli/skills/b2c-content/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-content/SKILL.md
@@ -9,6 +9,12 @@ Use the `b2c` CLI to export, list, and validate Page Designer content from Sales
 
 > **Tip:** If `b2c` is not installed globally, use `npx @salesforce/b2c-cli` instead (e.g., `npx @salesforce/b2c-cli content export homepage`).
 
+## Configuration & Authentication
+
+The CLI auto-discovers the target instance and credentials from `SFCC_*` environment variables, `dw.json` in the current or parent directories, `~/.mobify`, `package.json`, and configuration plugins. **Flags like `--server`, `--client-id`, `--client-secret`, `--username`, and `--password` are usually unnecessary** — only pass them to override what's auto-detected.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (use `--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
+
 ## Examples
 
 ### Export Pages

--- a/skills/b2c-cli/skills/b2c-debug/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-debug/SKILL.md
@@ -9,6 +9,12 @@ Use the `b2c` CLI to debug server-side scripts on Salesforce B2C Commerce instan
 
 > **Tip:** If `b2c` is not installed globally, use `npx @salesforce/b2c-cli` instead (e.g., `npx @salesforce/b2c-cli debug cli`).
 
+## Configuration & Authentication
+
+The CLI auto-discovers the target instance and credentials from `SFCC_*` environment variables, `dw.json` in the current or parent directories, `~/.mobify`, `package.json`, and configuration plugins. **Flags like `--server`, `--username`, and `--password` are usually unnecessary** — only pass them to override what's auto-detected.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (use `--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
+
 ## Prerequisites
 
 - Basic Auth credentials (username/password) for a BM user with `WebDAV_Manage_Customization`

--- a/skills/b2c-cli/skills/b2c-docs/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-docs/SKILL.md
@@ -45,13 +45,13 @@ b2c docs read ProductMgr --json
 
 ### Download Documentation
 
-Download the latest Script API documentation from a B2C Commerce instance:
+Download the latest Script API documentation from a B2C Commerce instance. The CLI auto-discovers the target server and credentials from `dw.json`, `SFCC_*` env vars, and configuration plugins — `--server` is only needed to override. Run `b2c setup inspect` to confirm what the CLI sees; see the `b2c-cli:b2c-config` skill for troubleshooting.
 
 ```bash
-# Download to a directory
+# Download to a directory (uses configured instance)
 b2c docs download ./my-docs
 
-# Download with specific server
+# Override server explicitly
 b2c docs download ./docs --server sandbox.demandware.net
 
 # Keep the original archive

--- a/skills/b2c-cli/skills/b2c-ecdn/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-ecdn/SKILL.md
@@ -11,7 +11,9 @@ Use the `b2c` CLI plugin to manage eCDN (embedded Content Delivery Network) zone
 
 ## Configuration
 
-Values like `tenantId` resolve from `dw.json` / `SFCC_*` env vars / the active instance. Examples below show minimal usage; add flags only to override configured values. If a required value is missing, the CLI emits an actionable error pointing at the flag, env var, and config key. See the `b2c-config` skill for precedence details.
+Values like `tenantId`, `clientId`, and `clientSecret` resolve from `dw.json` / `SFCC_*` env vars / the active instance / configuration plugins. Examples below show minimal usage; **add flags only to override configured values** — passing `--client-id`/`--client-secret`/`--tenant-id` is usually unnecessary. If a required value is missing, the CLI emits an actionable error pointing at the flag, env var, and config key.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (`--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
 
 ## Prerequisites
 

--- a/skills/b2c-cli/skills/b2c-job/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-job/SKILL.md
@@ -11,6 +11,12 @@ Use the `b2c` CLI plugin to **run existing jobs** and import/export site archive
 
 > **Creating a new job?** If you need to write custom job step code (batch processing, scheduled tasks, data sync), use the `b2c:b2c-custom-job-steps` skill instead.
 
+## Configuration & Authentication
+
+The CLI auto-discovers the target instance and credentials from `SFCC_*` environment variables, `dw.json` in the current or parent directories, `~/.mobify`, `package.json`, and configuration plugins. **Flags like `--server`, `--client-id`, and `--client-secret` are usually unnecessary** — only pass them to override what's auto-detected.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (use `--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
+
 ## Examples
 
 ### Run a Job

--- a/skills/b2c-cli/skills/b2c-logs/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-logs/SKILL.md
@@ -9,6 +9,12 @@ Use the `b2c` CLI to retrieve and monitor log files on Salesforce B2C Commerce i
 
 > **Tip:** If `b2c` is not installed globally, use `npx @salesforce/b2c-cli` instead (e.g., `npx @salesforce/b2c-cli logs get`).
 
+## Configuration & Authentication
+
+The CLI auto-discovers the target instance and credentials from `SFCC_*` environment variables, `dw.json` in the current or parent directories, `~/.mobify`, `package.json`, and configuration plugins. **Flags like `--server`, `--client-id`, `--client-secret`, `--username`, and `--password` are usually unnecessary** — only pass them to override what's auto-detected.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (use `--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
+
 ## Agent-Friendly Log Retrieval
 
 The `logs get` command is optimized for coding agents:

--- a/skills/b2c-cli/skills/b2c-mrt/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-mrt/SKILL.md
@@ -9,6 +9,12 @@ Use the `b2c` CLI to manage Managed Runtime (MRT) projects, environments, bundle
 
 > **Tip:** If `b2c` is not installed globally, use `npx @salesforce/b2c-cli` instead (e.g., `npx @salesforce/b2c-cli mrt bundle deploy`).
 
+## Configuration & Authentication
+
+The CLI auto-discovers the MRT API key from `SFCC_MRT_API_KEY`, `~/.mobify`, `dw.json`, `package.json`, and configuration plugins. Project and environment defaults can come from `dw.json` (`mrtProject`, `mrtEnvironment`) or env vars. **Flags like `--api-key`, `-p`, and `-e` are usually unnecessary** when defaults are configured — only pass them to override.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (use `--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
+
 ## Command Structure
 
 ```

--- a/skills/b2c-cli/skills/b2c-sandbox/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-sandbox/SKILL.md
@@ -13,6 +13,12 @@ Use the `b2c` CLI plugin to manage Salesforce B2C Commerce On-demand sandboxes (
 
 > **Alias:** The `ods` prefix is still supported as a backward-compatible alias (e.g., `b2c ods list` works the same as `b2c sandbox list`).
 
+## Configuration & Authentication
+
+The CLI auto-discovers credentials from `SFCC_*` environment variables, `dw.json` in the current or parent directories, `~/.mobify`, `package.json`, and configuration plugins. **Flags like `--client-id` and `--client-secret` are usually unnecessary** — only pass them to override what's auto-detected. Use `--user-auth` only when you need browser-based login (e.g., no client secret, or interactive use).
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (use `--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
+
 ## Sandbox ID Formats
 
 Commands that operate on a specific sandbox accept two ID formats:

--- a/skills/b2c-cli/skills/b2c-scapi-custom/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-scapi-custom/SKILL.md
@@ -11,7 +11,9 @@ Use the `b2c` CLI plugin to manage SCAPI Custom API endpoints and check their re
 
 ## Configuration
 
-Values like `tenantId` and `shortCode` resolve from `dw.json` / `SFCC_*` env vars / the active instance. Examples below show minimal usage; add flags only to override configured values. If a required value is missing, the CLI emits an actionable error pointing at the flag, env var, and config key. See the `b2c-config` skill for precedence details.
+Values like `tenantId`, `shortCode`, `clientId`, and `clientSecret` resolve from `dw.json` / `SFCC_*` env vars / the active instance / configuration plugins. Examples below show minimal usage; **add flags only to override configured values** — passing `--client-id`/`--client-secret`/`--tenant-id`/`--short-code` is usually unnecessary. If a required value is missing, the CLI emits an actionable error pointing at the flag, env var, and config key.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (`--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
 
 ## Tenant ID vs. Organization ID
 

--- a/skills/b2c-cli/skills/b2c-scapi-schemas/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-scapi-schemas/SKILL.md
@@ -11,7 +11,9 @@ Use the `b2c` CLI plugin to browse and retrieve SCAPI OpenAPI schema specificati
 
 ## Configuration
 
-Values like `tenantId` and `shortCode` resolve from `dw.json` / `SFCC_*` env vars / the active instance. Examples below show minimal usage; add flags only to override configured values. If a required value is missing, the CLI emits an actionable error pointing at the flag, env var, and config key. See the `b2c-config` skill for precedence details.
+Values like `tenantId`, `shortCode`, `clientId`, and `clientSecret` resolve from `dw.json` / `SFCC_*` env vars / the active instance / configuration plugins. Examples below show minimal usage; **add flags only to override configured values** — passing `--client-id`/`--client-secret`/`--tenant-id`/`--short-code` is usually unnecessary. If a required value is missing, the CLI emits an actionable error pointing at the flag, env var, and config key.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (`--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
 
 ## Tenant ID vs. Organization ID
 

--- a/skills/b2c-cli/skills/b2c-site-import-export/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-site-import-export/SKILL.md
@@ -9,6 +9,12 @@ Use the `b2c` CLI plugin to import and export site archives on Salesforce B2C Co
 
 > **Tip:** If `b2c` is not installed globally, use `npx @salesforce/b2c-cli` instead (e.g., `npx @salesforce/b2c-cli job import`).
 
+## Configuration & Authentication
+
+The CLI auto-discovers the target instance and credentials from `SFCC_*` environment variables, `dw.json` in the current or parent directories, `~/.mobify`, `package.json`, and configuration plugins. **Flags like `--server`, `--client-id`, `--client-secret`, `--username`, and `--password` are usually unnecessary** — only pass them to override what's auto-detected.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (use `--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
+
 ## Import Commands
 
 ### Import Local Directory

--- a/skills/b2c-cli/skills/b2c-sites/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-sites/SKILL.md
@@ -9,6 +9,12 @@ Use the `b2c` CLI plugin to list and manage storefront sites on Salesforce B2C C
 
 > **Tip:** If `b2c` is not installed globally, use `npx @salesforce/b2c-cli` instead (e.g., `npx @salesforce/b2c-cli sites list`).
 
+## Configuration & Authentication
+
+The CLI auto-discovers the target instance and credentials from `SFCC_*` environment variables, `dw.json` in the current or parent directories, `~/.mobify`, `package.json`, and configuration plugins. **Flags like `--server`, `--client-id`, and `--client-secret` are usually unnecessary** — only pass them to override what's auto-detected.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (use `--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
+
 ## Commands
 
 ### `b2c sites list`

--- a/skills/b2c-cli/skills/b2c-slas/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-slas/SKILL.md
@@ -13,7 +13,9 @@ Use the `b2c` CLI plugin to manage SLAS (Shopper Login and API Access Service) A
 
 ## Configuration
 
-Values like `tenantId`, `shortCode`, `slasClientId`, and `slasClientSecret` resolve from `dw.json` / `SFCC_*` env vars / the active instance. Examples below show minimal usage; add flags only to override configured values. If a required value is missing, the CLI emits an actionable error pointing at the flag, env var, and config key. See the `b2c-config` skill for precedence details.
+Values like `tenantId`, `shortCode`, `slasClientId`, and `slasClientSecret` resolve from `dw.json` / `SFCC_*` env vars / the active instance / configuration plugins. Examples below show minimal usage; **add flags only to override configured values** — passing these as flags is usually unnecessary. If a required value is missing, the CLI emits an actionable error pointing at the flag, env var, and config key.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (`--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
 
 Relevant overrides:
 

--- a/skills/b2c-cli/skills/b2c-webdav/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-webdav/SKILL.md
@@ -9,6 +9,12 @@ Use the `b2c` CLI plugin to perform WebDAV file operations on Salesforce B2C Com
 
 > **Tip:** If `b2c` is not installed globally, use `npx @salesforce/b2c-cli` instead (e.g., `npx @salesforce/b2c-cli webdav ls`).
 
+## Configuration & Authentication
+
+The CLI auto-discovers the target instance and credentials from `SFCC_*` environment variables, `dw.json` in the current or parent directories, `~/.mobify`, `package.json`, and configuration plugins. **Flags like `--server`, `--client-id`, `--client-secret`, `--username`, and `--password` are usually unnecessary** — only pass them to override what's auto-detected.
+
+Run `b2c setup inspect` to see the resolved configuration and which source provided each value (use `--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
+
 ## WebDAV Roots
 
 The `--root` flag specifies the WebDAV directory:

--- a/skills/b2c/skills/b2c-custom-api-development/SKILL.md
+++ b/skills/b2c/skills/b2c-custom-api-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: b2c-custom-api-development
-description: Develop Custom SCAPI REST endpoints with api.json routes, schema.yaml definitions, and OAuth scope configuration. Use this skill whenever the user needs to create a custom API on the Commerce platform, define OpenAPI 3.0 schemas for request/response, structure the rest-apis cartridge folder, or debug endpoint registration and 404 issues. Also use when building headless commerce integrations -- even if they just say 'custom REST endpoint' or 'expose my script as an API'.
+description: Develop Custom SCAPI REST endpoints with api.json routes, schema.yaml definitions, and OAuth scope configuration. Use this skill whenever the user needs to create a custom API on the Commerce platform, define OpenAPI 3.0 schemas for request/response, structure the rest-apis cartridge folder, or debug endpoint registration and 404 issues. Also use when building headless commerce integrations, choosing between Shopper (`ShopperToken`) and Admin (`AmOAuth2`) APIs, or troubleshooting why a Custom API endpoint isn't appearing or returning 404 in `b2c scapi custom status` — even if they just say 'custom REST endpoint', 'expose my script as an API', or 'my admin custom API isn't registering'.
 ---
 
 # Custom API Development Skill
@@ -82,6 +82,40 @@ security:
 - Custom scopes must start with `c_`, max 25 chars
 - Custom parameters must have `c_` prefix
 
+### Cartridge path requirements (where the platform looks up your `rest-apis/` folder)
+
+| Call shape | Cartridge path searched |
+|---|---|
+| Shopper API (`ShopperToken`) — always site-scoped | The **storefront site's** cartridge path (the site that issued the SLAS token) |
+| Admin API (`AmOAuth2`) with `siteId=<storefront-site>` | That **storefront site's** cartridge path |
+| Admin API (`AmOAuth2`) with `siteId=Sites-Site` (the special BM/organization site) | The **Business Manager** cartridge path |
+| Admin API (`AmOAuth2`) with `siteId` omitted | The **Business Manager** cartridge path |
+
+Admin APIs can be invoked in either site or organization context — the `siteId` parameter is optional, and one special value addresses the org context explicitly:
+
+- Passing a real storefront site ID (e.g. `siteId=RefArch`) runs the call in that site's context and resolves the cartridge against that site's cartridge path.
+- Passing `siteId=Sites-Site` is the literal way to invoke the Admin API against the **Business Manager / organization site**. `Sites-Site` is not a real storefront — it's the system-defined site that represents BM/org-level operations. The platform resolves the cartridge through the BM cartridge path.
+- Omitting `siteId` entirely is equivalent to org context and also resolves through the BM cartridge path.
+
+The BM cartridge path is the common gotcha: if your Admin API is intended for org-level operations (called with `siteId=Sites-Site` or with `siteId` omitted), the cartridge containing `rest-apis/` **must** be on the BM cartridge path. A typical symptom is "registers fine when called with a storefront `siteId` but 404s in org context," or never appears in `b2c scapi custom status` for the org context.
+
+Manage cartridge paths with the CLI (no BM clicks needed):
+
+```bash
+# Inspect the current BM cartridge path
+b2c sites cartridges list --bm
+
+# Add a cartridge to BM for org-context Admin APIs
+b2c sites cartridges add my_admin_api_cartridge --bm --position first
+
+# Add a cartridge to a storefront site (for Shopper APIs or site-scoped Admin APIs)
+b2c sites cartridges add my_api_cartridge --site-id RefArch --position first
+```
+
+After updating any cartridge path, re-activate the code version (`b2c code deploy --reload` or `b2c code activate <version>`) so the platform re-registers the endpoints.
+
+To set the BM cartridge path manually in Business Manager: **Administration > Sites > Manage Sites > Business Manager (link in the header) > Settings > Cartridges**.
+
 See [Contract Reference](references/CONTRACT.md) for full schema examples and Shopper vs Admin API differences.
 
 ## Component 2: Implementation (script.js)
@@ -126,14 +160,18 @@ See [Implementation Reference](references/IMPLEMENTATION.md) for caching, remote
 2. Define contract (schema.yaml) with endpoints and security
 3. Implement logic (script.js) with exported functions
 4. Create mapping (api.json) binding endpoints to implementation
-5. Deploy and activate to register endpoints
+5. Deploy and **activate** the code version (`--reload`) to register endpoints — required on first registration and any contract (`schema.yaml` / `api.json`) change
 6. Check registration status and test
+7. For subsequent edits to `script.js` of an already-registered endpoint, redeploy without `--reload` — re-activation isn't needed for implementation-only changes
 
 ### Deployment
 
 ```bash
-# Deploy and activate to register endpoints
+# Deploy and activate to (re-)register endpoints
 b2c code deploy ./my-cartridge --reload
+
+# Deploy without re-activation (fine for implementation-only edits to already-registered endpoints)
+b2c code deploy ./my-cartridge
 
 # Check registration status
 b2c scapi custom status --tenant-id zzpq_013
@@ -141,6 +179,20 @@ b2c scapi custom status --tenant-id zzpq_013
 # Show failed registrations with error reasons
 b2c scapi custom status --tenant-id zzpq_013 --status not_registered --columns apiName,endpointPath,errorReason
 ```
+
+#### When you need to re-activate the code version (`--reload`)
+
+Custom API endpoint registration is rebuilt on **code-version activation**, not on every file upload. That means:
+
+| Change | Re-activation required? |
+|---|---|
+| New endpoint, new API, or first-time registration | Yes |
+| Edits to `schema.yaml` (paths, params, security, scopes, request/response shapes) | Yes |
+| Edits to `api.json` (endpoint → implementation mapping) | Yes |
+| Adding/removing the cartridge from a site or BM cartridge path | Yes |
+| Edits to `script.js` (or any implementation/library code) for an **already-registered** endpoint | **No** — the new code is picked up live; just deploy without `--reload` |
+
+So during normal iteration on the *implementation* of an endpoint that's already registered, you can deploy repeatedly without paying the re-activation cost. Reach for `--reload` (or `b2c code activate <version>`) only when the *contract* changes or when an endpoint isn't registering yet.
 
 ## Authentication Setup
 
@@ -174,7 +226,9 @@ See [Testing Reference](references/TESTING.md) for curl examples and authenticat
 
 ### Registration Issues
 
-- **Endpoint not appearing:** Verify cartridge is in site's cartridge path, re-activate code version
+- **Shopper-API endpoint not appearing:** verify the cartridge is on the **site's** cartridge path (`b2c sites cartridges list --site-id <site>`), then re-activate the code version.
+- **Admin-API endpoint called with a storefront `siteId`:** verify the cartridge is on **that site's** cartridge path.
+- **Admin-API endpoint called with `siteId=Sites-Site` (or with `siteId` omitted) returns 404 / never registers:** the cartridge must be on the **Business Manager cartridge path**. Check with `b2c sites cartridges list --bm` and add it via `b2c sites cartridges add <cartridge> --bm --position first`. Re-activate the code version after. See [Cartridge path requirements](#cartridge-path-requirements-where-the-platform-looks-up-your-rest-apis-folder) above.
 - **Check logs:** Use `b2c logs get` or filter Log Center with `CustomApiRegistry`
 
 ## Related Skills

--- a/skills/b2c/skills/b2c-custom-api-development/references/CONTRACT.md
+++ b/skills/b2c/skills/b2c-custom-api-development/references/CONTRACT.md
@@ -9,14 +9,14 @@ info:
   title: My Custom API
 components:
   securitySchemes:
-    ShopperToken:                     # For Shopper APIs (requires siteId)
+    ShopperToken:                     # For Shopper APIs — always site-scoped (requires siteId)
       type: oauth2
       flows:
         clientCredentials:
           tokenUrl: https://{shortCode}.api.commercecloud.salesforce.com/shopper/auth/v1/organizations/{organizationId}/oauth2/token
           scopes:
             c_my_scope: Description of my scope
-    AmOAuth2:                         # For Admin APIs (no siteId)
+    AmOAuth2:                         # For Admin APIs — siteId optional (site or org context)
       type: oauth2
       flows:
         clientCredentials:
@@ -75,10 +75,24 @@ security:
 | Aspect | Shopper API | Admin API |
 |--------|-------------|-----------|
 | Security Scheme | `ShopperToken` | `AmOAuth2` |
-| `siteId` Parameter | Required | Must omit |
+| `siteId` Parameter | Required (always site-scoped) | Optional — see "Admin API call contexts" below |
 | Max Runtime | 10 seconds | 60 seconds |
 | Max Request Body | 5 MiB | 20 MB |
 | Activity Type | STOREFRONT | BUSINESS_MANAGER |
+
+### Admin API call contexts
+
+Unlike Shopper APIs, Admin APIs (`AmOAuth2`) can be invoked in either a storefront site context or the Business Manager / organization context. The `siteId` parameter selects which:
+
+| Context | `siteId` value | Cartridge path used to resolve `rest-apis/` |
+|---|---|---|
+| Storefront site context | A real site ID (e.g. `RefArch`) | That **site's** cartridge path |
+| Organization / Business Manager context | The literal value `Sites-Site` | The **Business Manager** cartridge path |
+| Organization / Business Manager context | `siteId` omitted | The **Business Manager** cartridge path |
+
+`Sites-Site` is not a real storefront — it's the system-defined site identifier the platform uses for BM / org-level operations. Passing `siteId=Sites-Site` is the explicit way to invoke an Admin Custom API against the BM context; omitting `siteId` resolves the same way.
+
+If you want the same Admin API to work in both contexts, declare `siteId` as an *optional* parameter (drop `required: true`). The cartridge containing your `rest-apis/` folder must be on whichever cartridge path corresponds to how the caller invokes it — the storefront site's path for storefront-`siteId` calls, and the BM cartridge path for `Sites-Site` / omitted-`siteId` calls.
 
 ## Path Parameter Example
 


### PR DESCRIPTION
## Summary

- Add a uniform **Configuration & Authentication** blurb to every instance-touching b2c-cli skill so agents stop passing `--server`/`--client-id`/`--client-secret`/`--username`/`--password` when the CLI already auto-discovers them. Each skill now points at `b2c setup inspect` and back to `b2c-config` for troubleshooting.
- Broaden the **`b2c-config`** skill to be the fallback whenever setup or auth is unclear:
  - New "How the CLI Discovers Configuration" section listing the six sources and their priority order.
  - "dw.json Key Casing" note: keys accept both camelCase and kebab-case (e.g. `clientId` ≡ `client-id`).
  - Expanded troubleshooting (missing credentials, wrong instance, hostname mismatch, 401/403, missing tenantId, MRT API key, etc.).
- Fix the **`b2c-custom-api-development`** skill:
  - Correct cartridge-path lookup: storefront `siteId` → that site's path; `siteId=Sites-Site` (system-defined BM site identifier) or omitted `siteId` → Business Manager cartridge path. Show management via `b2c sites cartridges --bm`.
  - Add a `--reload` rule of thumb: required for first-time registration, contract (`schema.yaml`/`api.json`) changes, and cartridge-path changes; not required for implementation-only edits to an already-registered endpoint.
  - Tightened description to stay trigger-focused.

## Test plan

- [ ] Spot-check a few updated skills render cleanly in the agent skill viewer (no broken markdown / list formatting).
- [ ] Verify the `Sites-Site` description matches platform behavior (storefront `siteId` → site path; `Sites-Site` or omitted → BM path).
- [ ] Confirm changeset `@salesforce/b2c-agent-plugins: patch` is the correct package and bump level for skill-only doc changes.