### PR TITLE
@W-22964141 feat(cip): fix empty metadata + expand curated report catalog (10→27) with data-driven scaffolding

### DIFF
--- a/.changeset/cip-agent-skill-technical-reports.md
+++ b/.changeset/cip-agent-skill-technical-reports.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Update the b2c-cip agent skill to cover the new technical/developer CIP reports (SCAPI/OCAPI/controller latency, error-rate, and cache analytics) and the `b2c cip report list` discovery command.

--- a/.changeset/cip-curated-reports-expansion.md
+++ b/.changeset/cip-curated-reports-expansion.md
@@ -1,0 +1,8 @@
+---
+'@salesforce/b2c-tooling-sdk': minor
+'@salesforce/b2c-cli': minor
+---
+
+Expand the curated CIP analytics report catalog with 16 new pre-built reports, with a focus on technical/developer analytics. New reports include SCAPI traffic & latency, SCAPI error rate by status class, SCAPI latency distribution (slow-tail/SLA percentage from the response-time histogram), SCAPI cache hit ratio, OCAPI usage by client, SFRA controller health scorecard, controller error-rate trend, and remote-include performance — plus revenue-by-channel, new-vs-returning buyer revenue, discount-depth breakdown, promotion ROI leaderboard, recommender effectiveness, zero-result searches, checkout funnel drop-off, and inventory stockout by location.
+
+Also adds `b2c cip report list` to discover the catalog grouped by category (no credentials required), and report parameters now support enum (`--status-class 4xx|5xx`) and default values. Run `b2c cip report <name> --describe` to see each report's flags.

--- a/.changeset/cip-metadata-uppercase-labels.md
+++ b/.changeset/cip-metadata-uppercase-labels.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+Fix `cip tables` and `cip describe` returning empty rows on some tenants. The CIP metadata mapping assumed camelCase JDBC column labels (`tableName`, `columnName`), but some tenants' drivers return the standard uppercase labels (`TABLE_NAME`, `COLUMN_NAME`), which produced blank table names, schemas, types, and column metadata. Metadata columns are now matched case-insensitively.

--- a/docs/cli/cip.md
+++ b/docs/cli/cip.md
@@ -18,6 +18,7 @@ By default, CIP uses the production analytics host for tenants ending in `_prd` 
 | `b2c cip describe <table>`        | Describe columns for a CIP table               |
 | `b2c cip query`                   | Run raw SQL (argument, file, or stdin)         |
 | `b2c cip report`                  | Report topic help and report command discovery |
+| `b2c cip report list`             | List the curated report catalog by category    |
 | `b2c cip report <report-command>` | Run a curated report command                   |
 
 ::: warning Availability
@@ -195,20 +196,70 @@ b2c cip report sales-analytics --site-id Sites-RefArch-Site --sql \
   | b2c cip query --tenant-id zzxy_prd --client-id <client-id> --client-secret <client-secret>
 ```
 
+### Discovering Reports
+
+List the full catalog grouped by category (no credentials required):
+
+```bash
+b2c cip report list
+b2c cip report list --category "Technical Analytics"
+b2c cip report list --json
+```
+
 ### Report Commands
+
+Report flags are derived from each report's parameter contract — run `b2c cip report <command> --describe` to see the exact flags and which are required.
+
+**Sales Analytics**
+
+| Command              | Description                                  | Extra Flags             |
+| -------------------- | -------------------------------------------- | ----------------------- |
+| `sales-analytics`    | Daily sales performance with AOV/AOS         | `--site-id`             |
+| `sales-summary`      | Detailed sales records                       | `--site-id` (optional)  |
+| `revenue-by-channel` | Revenue/AOV/discount by channel/device/locale | `--site-id`, `--limit`  |
+
+**Technical Analytics**
+
+| Command                       | Description                                            | Extra Flags                            |
+| ----------------------------- | ------------------------------------------------------ | -------------------------------------- |
+| `ocapi-requests`              | OCAPI request volume and latency                       | `--site-id`                            |
+| `ocapi-client-usage`          | OCAPI volume, error rate, latency per client_id        | `--site-id` (optional), `--limit`      |
+| `scapi-traffic-latency`       | SCAPI endpoints by volume and average latency          | `--site-id` (optional), `--limit`      |
+| `scapi-error-rate-by-status`  | SCAPI endpoints by 4xx/5xx error rate                  | `--site-id` (optional), `--status-class`, `--limit` |
+| `scapi-latency-distribution`  | SCAPI latency histogram + slow-tail (SLA) percentage   | `--site-id` (optional), `--limit`      |
+| `scapi-cache-hit-ratio`       | SCAPI cache hit ratio per endpoint                     | `--site-id` (optional), `--limit`      |
+| `controller-health-scorecard` | SFRA controller volume/errors/slow-tail/cache          | `--site-id`, `--limit`                 |
+| `controller-error-rate-trend` | Daily 4xx/5xx error rate per controller                | `--site-id`, `--limit`                 |
+| `remote-include-performance`  | Remote-include child controllers by parent page        | `--site-id`, `--limit`                 |
+
+**Product, Promotion & Search**
 
 | Command                        | Description                           | Extra Flags                  |
 | ------------------------------ | ------------------------------------- | ---------------------------- |
-| `sales-analytics`              | Daily sales performance with AOV/AOS  | `--site-id`                  |
-| `sales-summary`                | Detailed sales records                | `--site-id` (optional)       |
-| `ocapi-requests`               | OCAPI request volume and latency      | `--site-id`                  |
 | `top-selling-products`         | Top products by units/revenue         | `--site-id`                  |
 | `product-co-purchase-analysis` | Frequently co-purchased products      | `--site-id`                  |
+| `recommender-effectiveness`    | Recommender engagement and ROI        | `--site-id`, `--limit`       |
 | `promotion-discount-analysis`  | Promotion discount impact             | none                         |
+| `promotion-roi-leaderboard`    | Promotions by revenue per discount $  | `--site-id`, `--limit`       |
+| `discount-depth-breakdown`     | Promotional vs manual discount split  | `--site-id`                  |
 | `search-query-performance`     | Search revenue and conversion metrics | `--site-id`, `--has-results` |
-| `payment-method-performance`   | Payment method adoption/performance   | `--site-id`                  |
-| `customer-registration-trends` | Registration trends by date/device    | `--site-id`                  |
-| `top-referrers`                | Referrer traffic share                | `--site-id`, `--limit`       |
+| `zero-result-searches`         | Search terms returning no results     | `--site-id`, `--limit`       |
+
+**Customer, Traffic & Inventory**
+
+| Command                          | Description                              | Extra Flags                  |
+| -------------------------------- | ---------------------------------------- | ---------------------------- |
+| `customer-registration-trends`   | Registration trends by date/device       | `--site-id`                  |
+| `new-vs-returning-buyer-revenue` | First-time vs returning buyer revenue     | `--site-id`                  |
+| `payment-method-performance`     | Payment method adoption/performance       | `--site-id`                  |
+| `top-referrers`                  | Referrer traffic share                    | `--site-id`, `--limit`       |
+| `checkout-funnel-dropoff`        | Visits and drop-off per checkout step     | `--site-id`                  |
+| `bot-traffic-share`              | Bot vs human visit share by day           | `--site-id`, `--limit`       |
+| `inventory-stockout-by-location` | Out-of-stock / low-stock SKUs by location | `--threshold`, `--limit`     |
+
+::: tip Technical reports and latency buckets
+The SCAPI/OCAPI/controller request tables record a response-time histogram (`num_requests_bucket1..11`, fastest to slowest). The `*-latency-distribution` and `*-health-scorecard` reports use these buckets to surface the slow-tail percentage that a plain average latency hides. SCAPI traffic is often attributed to a headless site (or no site at all), so `--site-id` is optional on SCAPI reports — omit it to span all sites.
+:::
 
 ### Site ID Format
 
@@ -235,6 +286,22 @@ b2c cip report top-referrers --describe
 
 # Generate SQL only
 b2c cip report top-referrers --site-id Sites-RefArch-Site --limit 25 --sql
+
+# Technical: SCAPI latency distribution (slow-tail %), all sites
+b2c cip report scapi-latency-distribution \
+  --tenant-id zzxy_prd --from 2025-01-01 --to 2025-01-31
+
+# Technical: SCAPI endpoints by 5xx error rate
+b2c cip report scapi-error-rate-by-status \
+  --tenant-id zzxy_prd --from 2025-01-01 --to 2025-01-31 --status-class 5xx
+
+# Technical: SFRA controller health scorecard
+b2c cip report controller-health-scorecard \
+  --tenant-id zzxy_prd --site-id Sites-RefArch-Site --from 2025-01-01 --to 2025-01-31
+
+# Inventory: low/out-of-stock SKUs by location
+b2c cip report inventory-stockout-by-location \
+  --tenant-id zzxy_prd --from 2025-01-01 --to 2025-01-31 --threshold 10
 ```
 
 ## Output Formats

--- a/packages/b2c-cli/src/commands/cip/report/bot-traffic-share.ts
+++ b/packages/b2c-cli/src/commands/cip/report/bot-traffic-share.ts
@@ -8,16 +8,16 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'bot-traffic-share';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report bot-traffic-share` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportBotTrafficShare extends CipReportCommand<typeof CipReportBotTrafficShare> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Daily bot/crawler vs human visit share with the top bot family driving crawler traffic',
+    '/cli/cip.html#b2c-cip-report-bot-traffic-share',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/checkout-funnel-dropoff.ts
+++ b/packages/b2c-cli/src/commands/cip/report/checkout-funnel-dropoff.ts
@@ -8,16 +8,16 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'checkout-funnel-dropoff';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report checkout-funnel-dropoff` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportCheckoutFunnelDropoff extends CipReportCommand<typeof CipReportCheckoutFunnelDropoff> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Visits reaching each checkout step with step-over-step drop-off to pinpoint funnel leaks',
+    '/cli/cip.html#b2c-cip-report-checkout-funnel-dropoff',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/controller-error-rate-trend.ts
+++ b/packages/b2c-cli/src/commands/cip/report/controller-error-rate-trend.ts
@@ -8,16 +8,18 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'controller-error-rate-trend';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report controller-error-rate-trend` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportControllerErrorRateTrend extends CipReportCommand<
+  typeof CipReportControllerErrorRateTrend
+> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Daily 4xx/5xx error rate per storefront controller for catching deploy regressions',
+    '/cli/cip.html#b2c-cip-report-controller-error-rate-trend',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/controller-health-scorecard.ts
+++ b/packages/b2c-cli/src/commands/cip/report/controller-health-scorecard.ts
@@ -8,16 +8,18 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'controller-health-scorecard';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report controller-health-scorecard` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportControllerHealthScorecard extends CipReportCommand<
+  typeof CipReportControllerHealthScorecard
+> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Score SFRA controller health by volume, errors, slow tail, and cache hit rate',
+    '/cli/cip.html#b2c-cip-report-controller-health-scorecard',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/customer-registration-trends.ts
+++ b/packages/b2c-cli/src/commands/cip/report/customer-registration-trends.ts
@@ -6,8 +6,14 @@
 
 import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
-import {createSiteIdFlag} from '../../../utils/cip/report-flags.js';
+import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
+const REPORT_NAME = 'customer-registration-trends';
+
+/**
+ * `b2c cip report customer-registration-trends` — flags are auto-derived from the catalog
+ * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
+ */
 export default class CipReportCustomerRegistrationTrends extends CipReportCommand<
   typeof CipReportCustomerRegistrationTrends
 > {
@@ -21,12 +27,8 @@ export default class CipReportCustomerRegistrationTrends extends CipReportComman
   static flags = {
     ...CipReportCommand.baseFlags,
     ...CipReportCommand.reportFlags,
-    'site-id': createSiteIdFlag(),
+    ...buildReportFlags(requireReport(REPORT_NAME)),
   };
 
-  protected readonly reportName = 'customer-registration-trends';
-
-  protected getReportParams(): Record<string, string> {
-    return this.getBaseReportParams();
-  }
+  protected readonly reportName = REPORT_NAME;
 }

--- a/packages/b2c-cli/src/commands/cip/report/discount-depth-breakdown.ts
+++ b/packages/b2c-cli/src/commands/cip/report/discount-depth-breakdown.ts
@@ -8,16 +8,16 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'discount-depth-breakdown';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report discount-depth-breakdown` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportDiscountDepthBreakdown extends CipReportCommand<typeof CipReportDiscountDepthBreakdown> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Break down total discount into promotional vs manual by product, order, and shipping',
+    '/cli/cip.html#b2c-cip-report-discount-depth-breakdown',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/inventory-stockout-by-location.ts
+++ b/packages/b2c-cli/src/commands/cip/report/inventory-stockout-by-location.ts
@@ -8,16 +8,18 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'inventory-stockout-by-location';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report inventory-stockout-by-location` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportInventoryStockoutByLocation extends CipReportCommand<
+  typeof CipReportInventoryStockoutByLocation
+> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Surface out-of-stock and low-stock SKUs by location for replenishment',
+    '/cli/cip.html#b2c-cip-report-inventory-stockout-by-location',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/list.ts
+++ b/packages/b2c-cli/src/commands/cip/report/list.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import {Flags, ux} from '@oclif/core';
+import {listCipReports, type CipReportDefinition} from '@salesforce/b2c-tooling-sdk';
+import {BaseCommand} from '@salesforce/b2c-tooling-sdk/cli';
+import {withDocs} from '../../../i18n/index.js';
+import {renderTable, writeCsv, writeJson} from '../../../utils/cip/format.js';
+
+interface CipReportListRow {
+  category: string;
+  name: string;
+  description: string;
+  required_params: string;
+  [key: string]: unknown;
+}
+
+interface CipReportListResult {
+  reportCount: number;
+  reports: CipReportListRow[];
+}
+
+function toRow(report: CipReportDefinition): CipReportListRow {
+  const required = report.parameters
+    .filter((parameter) => parameter.required)
+    .map((parameter) => parameter.name)
+    .join(', ');
+
+  return {
+    category: report.category,
+    name: report.name,
+    description: report.description,
+    required_params: required,
+  };
+}
+
+/**
+ * Lists the curated CIP report catalog grouped by category. Requires no credentials —
+ * it reads the static report definitions from the SDK so users (and agents) can
+ * discover available reports, their categories, and required parameters.
+ */
+export default class CipReportList extends BaseCommand<typeof CipReportList> {
+  static description = withDocs('List curated CIP reports grouped by category', '/cli/cip.html#b2c-cip-report-list');
+
+  static enableJsonFlag = true;
+
+  static examples = [
+    '<%= config.bin %> cip report list',
+    '<%= config.bin %> cip report list --category "Technical Analytics"',
+    '<%= config.bin %> cip report list --json',
+  ];
+
+  static flags = {
+    category: Flags.string({
+      description: 'Filter to a single report category (case-insensitive)',
+      helpGroup: 'QUERY',
+    }),
+    format: Flags.string({
+      description: 'Output format',
+      options: ['table', 'json', 'csv'],
+      default: 'table',
+      helpGroup: 'QUERY',
+    }),
+  };
+
+  async run(): Promise<CipReportListResult> {
+    const categoryFilter = this.flags.category?.toLowerCase();
+    const reports = listCipReports()
+      .filter((report) => !categoryFilter || report.category.toLowerCase() === categoryFilter)
+      .sort((a, b) => a.category.localeCompare(b.category) || a.name.localeCompare(b.name));
+
+    const rows = reports.map((report) => toRow(report));
+    const output: CipReportListResult = {reportCount: rows.length, reports: rows};
+
+    if (this.jsonEnabled()) {
+      return output;
+    }
+
+    if (this.flags.format === 'json') {
+      writeJson(output);
+      return output;
+    }
+
+    if (this.flags.format === 'csv') {
+      writeCsv(['category', 'name', 'description', 'required_params'], rows);
+      return output;
+    }
+
+    this.renderGroupedTable(reports);
+    return output;
+  }
+
+  private renderGroupedTable(reports: CipReportDefinition[]): void {
+    if (reports.length === 0) {
+      ux.stdout('No reports match the requested category.');
+      return;
+    }
+
+    const categories = [...new Set(reports.map((report) => report.category))];
+    for (const category of categories) {
+      const inCategory = reports.filter((report) => report.category === category);
+      ux.stdout(`\n${category}`);
+      renderTable(
+        ['name', 'required', 'description'],
+        inCategory.map((report) => ({
+          name: report.name,
+          required: report.parameters
+            .filter((parameter) => parameter.required)
+            .map((parameter) => `--${parameter.name.replaceAll(/[A-Z]/gu, (match) => `-${match.toLowerCase()}`)}`)
+            .join(' '),
+          description: report.description,
+        })) as Array<Record<string, unknown>>,
+      );
+    }
+  }
+}
+
+export type {CipReportListResult, CipReportListRow};

--- a/packages/b2c-cli/src/commands/cip/report/new-vs-returning-buyer-revenue.ts
+++ b/packages/b2c-cli/src/commands/cip/report/new-vs-returning-buyer-revenue.ts
@@ -8,16 +8,18 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'new-vs-returning-buyer-revenue';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report new-vs-returning-buyer-revenue` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportNewVsReturningBuyerRevenue extends CipReportCommand<
+  typeof CipReportNewVsReturningBuyerRevenue
+> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Split revenue, orders, AOV, and discount depth between first-time and returning buyers',
+    '/cli/cip.html#b2c-cip-report-new-vs-returning-buyer-revenue',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/ocapi-client-usage.ts
+++ b/packages/b2c-cli/src/commands/cip/report/ocapi-client-usage.ts
@@ -8,16 +8,16 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'ocapi-client-usage';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report ocapi-client-usage` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportOcapiClientUsage extends CipReportCommand<typeof CipReportOcapiClientUsage> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Rank OCAPI client_ids by request volume with per-client error rate and latency',
+    '/cli/cip.html#b2c-cip-report-ocapi-client-usage',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/ocapi-requests.ts
+++ b/packages/b2c-cli/src/commands/cip/report/ocapi-requests.ts
@@ -6,8 +6,14 @@
 
 import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
-import {createSiteIdFlag} from '../../../utils/cip/report-flags.js';
+import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
+const REPORT_NAME = 'ocapi-requests';
+
+/**
+ * `b2c cip report ocapi-requests` — flags are auto-derived from the catalog
+ * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
+ */
 export default class CipReportOcapiRequests extends CipReportCommand<typeof CipReportOcapiRequests> {
   static description = withDocs(
     'Analyze OCAPI request volume and response latency',
@@ -19,12 +25,8 @@ export default class CipReportOcapiRequests extends CipReportCommand<typeof CipR
   static flags = {
     ...CipReportCommand.baseFlags,
     ...CipReportCommand.reportFlags,
-    'site-id': createSiteIdFlag(),
+    ...buildReportFlags(requireReport(REPORT_NAME)),
   };
 
-  protected readonly reportName = 'ocapi-requests';
-
-  protected getReportParams(): Record<string, string> {
-    return this.getBaseReportParams();
-  }
+  protected readonly reportName = REPORT_NAME;
 }

--- a/packages/b2c-cli/src/commands/cip/report/payment-method-performance.ts
+++ b/packages/b2c-cli/src/commands/cip/report/payment-method-performance.ts
@@ -6,8 +6,14 @@
 
 import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
-import {createSiteIdFlag} from '../../../utils/cip/report-flags.js';
+import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
+const REPORT_NAME = 'payment-method-performance';
+
+/**
+ * `b2c cip report payment-method-performance` — flags are auto-derived from the catalog
+ * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
+ */
 export default class CipReportPaymentMethodPerformance extends CipReportCommand<
   typeof CipReportPaymentMethodPerformance
 > {
@@ -21,12 +27,8 @@ export default class CipReportPaymentMethodPerformance extends CipReportCommand<
   static flags = {
     ...CipReportCommand.baseFlags,
     ...CipReportCommand.reportFlags,
-    'site-id': createSiteIdFlag(),
+    ...buildReportFlags(requireReport(REPORT_NAME)),
   };
 
-  protected readonly reportName = 'payment-method-performance';
-
-  protected getReportParams(): Record<string, string> {
-    return this.getBaseReportParams();
-  }
+  protected readonly reportName = REPORT_NAME;
 }

--- a/packages/b2c-cli/src/commands/cip/report/product-co-purchase-analysis.ts
+++ b/packages/b2c-cli/src/commands/cip/report/product-co-purchase-analysis.ts
@@ -6,8 +6,14 @@
 
 import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
-import {createSiteIdFlag} from '../../../utils/cip/report-flags.js';
+import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
+const REPORT_NAME = 'product-co-purchase-analysis';
+
+/**
+ * `b2c cip report product-co-purchase-analysis` — flags are auto-derived from the catalog
+ * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
+ */
 export default class CipReportProductCoPurchaseAnalysis extends CipReportCommand<
   typeof CipReportProductCoPurchaseAnalysis
 > {
@@ -21,12 +27,8 @@ export default class CipReportProductCoPurchaseAnalysis extends CipReportCommand
   static flags = {
     ...CipReportCommand.baseFlags,
     ...CipReportCommand.reportFlags,
-    'site-id': createSiteIdFlag(),
+    ...buildReportFlags(requireReport(REPORT_NAME)),
   };
 
-  protected readonly reportName = 'product-co-purchase-analysis';
-
-  protected getReportParams(): Record<string, string> {
-    return this.getBaseReportParams();
-  }
+  protected readonly reportName = REPORT_NAME;
 }

--- a/packages/b2c-cli/src/commands/cip/report/promotion-discount-analysis.ts
+++ b/packages/b2c-cli/src/commands/cip/report/promotion-discount-analysis.ts
@@ -6,7 +6,14 @@
 
 import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
+import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
+const REPORT_NAME = 'promotion-discount-analysis';
+
+/**
+ * `b2c cip report promotion-discount-analysis` — flags are auto-derived from the catalog
+ * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
+ */
 export default class CipReportPromotionDiscountAnalysis extends CipReportCommand<
   typeof CipReportPromotionDiscountAnalysis
 > {
@@ -20,11 +27,8 @@ export default class CipReportPromotionDiscountAnalysis extends CipReportCommand
   static flags = {
     ...CipReportCommand.baseFlags,
     ...CipReportCommand.reportFlags,
+    ...buildReportFlags(requireReport(REPORT_NAME)),
   };
 
-  protected readonly reportName = 'promotion-discount-analysis';
-
-  protected getReportParams(): Record<string, string> {
-    return this.getBaseReportParams();
-  }
+  protected readonly reportName = REPORT_NAME;
 }

--- a/packages/b2c-cli/src/commands/cip/report/promotion-roi-leaderboard.ts
+++ b/packages/b2c-cli/src/commands/cip/report/promotion-roi-leaderboard.ts
@@ -8,16 +8,18 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'promotion-roi-leaderboard';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report promotion-roi-leaderboard` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportPromotionRoiLeaderboard extends CipReportCommand<
+  typeof CipReportPromotionRoiLeaderboard
+> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Rank promotions by revenue per dollar of discount, with orders, uses, and AOV',
+    '/cli/cip.html#b2c-cip-report-promotion-roi-leaderboard',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/recommender-effectiveness.ts
+++ b/packages/b2c-cli/src/commands/cip/report/recommender-effectiveness.ts
@@ -8,16 +8,18 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'recommender-effectiveness';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report recommender-effectiveness` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportRecommenderEffectiveness extends CipReportCommand<
+  typeof CipReportRecommenderEffectiveness
+> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Rank product recommenders by engagement, attributed revenue, and conversion',
+    '/cli/cip.html#b2c-cip-report-recommender-effectiveness',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/remote-include-performance.ts
+++ b/packages/b2c-cli/src/commands/cip/report/remote-include-performance.ts
@@ -8,16 +8,18 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'remote-include-performance';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report remote-include-performance` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportRemoteIncludePerformance extends CipReportCommand<
+  typeof CipReportRemoteIncludePerformance
+> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Rank remote-include child controllers by load, latency, errors, and cache hit rate per parent page',
+    '/cli/cip.html#b2c-cip-report-remote-include-performance',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/revenue-by-channel.ts
+++ b/packages/b2c-cli/src/commands/cip/report/revenue-by-channel.ts
@@ -8,16 +8,16 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'revenue-by-channel';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report revenue-by-channel` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportRevenueByChannel extends CipReportCommand<typeof CipReportRevenueByChannel> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Break down revenue, orders, AOV, and discount rate by channel, device, and locale',
+    '/cli/cip.html#b2c-cip-report-revenue-by-channel',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/sales-analytics.ts
+++ b/packages/b2c-cli/src/commands/cip/report/sales-analytics.ts
@@ -6,8 +6,14 @@
 
 import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
-import {createSiteIdFlag} from '../../../utils/cip/report-flags.js';
+import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
+const REPORT_NAME = 'sales-analytics';
+
+/**
+ * `b2c cip report sales-analytics` — flags are auto-derived from the catalog
+ * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
+ */
 export default class CipReportSalesAnalytics extends CipReportCommand<typeof CipReportSalesAnalytics> {
   static description = withDocs(
     'Track daily sales performance with AOV and AOS metrics',
@@ -19,12 +25,8 @@ export default class CipReportSalesAnalytics extends CipReportCommand<typeof Cip
   static flags = {
     ...CipReportCommand.baseFlags,
     ...CipReportCommand.reportFlags,
-    'site-id': createSiteIdFlag(),
+    ...buildReportFlags(requireReport(REPORT_NAME)),
   };
 
-  protected readonly reportName = 'sales-analytics';
-
-  protected getReportParams(): Record<string, string> {
-    return this.getBaseReportParams();
-  }
+  protected readonly reportName = REPORT_NAME;
 }

--- a/packages/b2c-cli/src/commands/cip/report/sales-summary.ts
+++ b/packages/b2c-cli/src/commands/cip/report/sales-summary.ts
@@ -6,8 +6,14 @@
 
 import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
-import {createSiteIdFlag} from '../../../utils/cip/report-flags.js';
+import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
+const REPORT_NAME = 'sales-summary';
+
+/**
+ * `b2c cip report sales-summary` — flags are auto-derived from the catalog
+ * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
+ */
 export default class CipReportSalesSummary extends CipReportCommand<typeof CipReportSalesSummary> {
   static description = withDocs(
     'Query detailed sales records for custom analysis',
@@ -19,12 +25,8 @@ export default class CipReportSalesSummary extends CipReportCommand<typeof CipRe
   static flags = {
     ...CipReportCommand.baseFlags,
     ...CipReportCommand.reportFlags,
-    'site-id': createSiteIdFlag(),
+    ...buildReportFlags(requireReport(REPORT_NAME)),
   };
 
-  protected readonly reportName = 'sales-summary';
-
-  protected getReportParams(): Record<string, string> {
-    return this.getBaseReportParams();
-  }
+  protected readonly reportName = REPORT_NAME;
 }

--- a/packages/b2c-cli/src/commands/cip/report/scapi-cache-hit-ratio.ts
+++ b/packages/b2c-cli/src/commands/cip/report/scapi-cache-hit-ratio.ts
@@ -8,16 +8,16 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'scapi-cache-hit-ratio';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report scapi-cache-hit-ratio` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportScapiCacheHitRatio extends CipReportCommand<typeof CipReportScapiCacheHitRatio> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Measure SCAPI cache hit ratio per endpoint to find cacheable resources running as MISS',
+    '/cli/cip.html#b2c-cip-report-scapi-cache-hit-ratio',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/scapi-error-rate-by-status.ts
+++ b/packages/b2c-cli/src/commands/cip/report/scapi-error-rate-by-status.ts
@@ -8,16 +8,16 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'scapi-error-rate-by-status';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report scapi-error-rate-by-status` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportScapiErrorRateByStatus extends CipReportCommand<typeof CipReportScapiErrorRateByStatus> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Rank SCAPI endpoints by 4xx/5xx error rate over a date range',
+    '/cli/cip.html#b2c-cip-report-scapi-error-rate-by-status',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/scapi-latency-distribution.ts
+++ b/packages/b2c-cli/src/commands/cip/report/scapi-latency-distribution.ts
@@ -8,16 +8,18 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'scapi-latency-distribution';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report scapi-latency-distribution` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportScapiLatencyDistribution extends CipReportCommand<
+  typeof CipReportScapiLatencyDistribution
+> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Surface the SCAPI latency histogram and slow-tail (SLA breach) percentage per endpoint',
+    '/cli/cip.html#b2c-cip-report-scapi-latency-distribution',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/scapi-traffic-latency.ts
+++ b/packages/b2c-cli/src/commands/cip/report/scapi-traffic-latency.ts
@@ -8,16 +8,16 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'scapi-traffic-latency';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report scapi-traffic-latency` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportScapiTrafficLatency extends CipReportCommand<typeof CipReportScapiTrafficLatency> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Rank SCAPI endpoints by request volume and average latency',
+    '/cli/cip.html#b2c-cip-report-scapi-traffic-latency',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/commands/cip/report/top-referrers.ts
+++ b/packages/b2c-cli/src/commands/cip/report/top-referrers.ts
@@ -6,8 +6,14 @@
 
 import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
-import {createLimitFlag, createSiteIdFlag} from '../../../utils/cip/report-flags.js';
+import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
+const REPORT_NAME = 'top-referrers';
+
+/**
+ * `b2c cip report top-referrers` — flags are auto-derived from the catalog
+ * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
+ */
 export default class CipReportTopReferrers extends CipReportCommand<typeof CipReportTopReferrers> {
   static description = withDocs(
     'Identify top traffic referrers and visit share',
@@ -19,13 +25,8 @@ export default class CipReportTopReferrers extends CipReportCommand<typeof CipRe
   static flags = {
     ...CipReportCommand.baseFlags,
     ...CipReportCommand.reportFlags,
-    limit: createLimitFlag(),
-    'site-id': createSiteIdFlag(),
+    ...buildReportFlags(requireReport(REPORT_NAME)),
   };
 
-  protected readonly reportName = 'top-referrers';
-
-  protected getReportParams(): Record<string, string> {
-    return this.getBaseReportParams();
-  }
+  protected readonly reportName = REPORT_NAME;
 }

--- a/packages/b2c-cli/src/commands/cip/report/top-selling-products.ts
+++ b/packages/b2c-cli/src/commands/cip/report/top-selling-products.ts
@@ -6,8 +6,14 @@
 
 import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
-import {createSiteIdFlag} from '../../../utils/cip/report-flags.js';
+import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
+const REPORT_NAME = 'top-selling-products';
+
+/**
+ * `b2c cip report top-selling-products` — flags are auto-derived from the catalog
+ * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
+ */
 export default class CipReportTopSellingProducts extends CipReportCommand<typeof CipReportTopSellingProducts> {
   static description = withDocs(
     'Identify top selling products across channels',
@@ -19,12 +25,8 @@ export default class CipReportTopSellingProducts extends CipReportCommand<typeof
   static flags = {
     ...CipReportCommand.baseFlags,
     ...CipReportCommand.reportFlags,
-    'site-id': createSiteIdFlag(),
+    ...buildReportFlags(requireReport(REPORT_NAME)),
   };
 
-  protected readonly reportName = 'top-selling-products';
-
-  protected getReportParams(): Record<string, string> {
-    return this.getBaseReportParams();
-  }
+  protected readonly reportName = REPORT_NAME;
 }

--- a/packages/b2c-cli/src/commands/cip/report/zero-result-searches.ts
+++ b/packages/b2c-cli/src/commands/cip/report/zero-result-searches.ts
@@ -8,16 +8,16 @@ import {withDocs} from '../../../i18n/index.js';
 import {CipReportCommand} from '../../../utils/cip/report-command.js';
 import {buildReportFlags, requireReport} from '../../../utils/cip/report-flags.js';
 
-const REPORT_NAME = 'search-query-performance';
+const REPORT_NAME = 'zero-result-searches';
 
 /**
- * `b2c cip report search-query-performance` — flags are auto-derived from the catalog
+ * `b2c cip report zero-result-searches` — flags are auto-derived from the catalog
  * definition; param parsing/validation lives in {@link CipReportCommand} and the SDK.
  */
-export default class CipReportSearchQueryPerformance extends CipReportCommand<typeof CipReportSearchQueryPerformance> {
+export default class CipReportZeroResultSearches extends CipReportCommand<typeof CipReportZeroResultSearches> {
   static description = withDocs(
-    'Identify search terms driving revenue and conversion',
-    '/cli/cip.html#b2c-cip-report-search-query-performance',
+    'Surface search terms that most often return zero results and the demand lost to them',
+    '/cli/cip.html#b2c-cip-report-zero-result-searches',
   );
 
   static enableJsonFlag = true;

--- a/packages/b2c-cli/src/utils/cip/report-command.ts
+++ b/packages/b2c-cli/src/utils/cip/report-command.ts
@@ -14,6 +14,7 @@ import {
 } from '@salesforce/b2c-tooling-sdk';
 import {CipCommand} from './command.js';
 import {renderTable, writeCsv, writeJson, type CipOutputFormat} from './format.js';
+import {paramNameToFlag} from './report-flags.js';
 import {ux} from '@oclif/core';
 
 function camelToKebab(str: string): string {
@@ -82,7 +83,42 @@ export abstract class CipReportCommand<T extends typeof Command> extends CipComm
     return params;
   }
 
-  protected abstract getReportParams(): Record<string, string>;
+  /**
+   * Derives report params generically from the report's catalog definition by
+   * reading each parameter's kebab-cased flag. Subclasses normally do not need to
+   * override this; the SDK validates and escapes the values when building SQL.
+   * `from`/`to`/`siteId`/`limit` are handled by {@link getBaseReportParams}.
+   */
+  protected getReportParams(): Record<string, string> {
+    const params = this.getBaseReportParams();
+    const report = getCipReportByName(this.reportName);
+    if (!report) {
+      return params;
+    }
+
+    const flags = this.flags as Record<string, unknown>;
+
+    for (const parameter of report.parameters) {
+      if (['from', 'limit', 'siteId', 'to'].includes(parameter.name)) {
+        continue;
+      }
+
+      const value = flags[paramNameToFlag(parameter.name)];
+      if (Array.isArray(value)) {
+        if (value.length > 0) {
+          params[parameter.name] = value.map(String).join(',');
+        }
+      } else if (typeof value === 'number') {
+        params[parameter.name] = String(value);
+      } else if (typeof value === 'string' && value.length > 0) {
+        params[parameter.name] = value;
+      } else if (typeof value === 'boolean') {
+        params[parameter.name] = String(value);
+      }
+    }
+
+    return params;
+  }
 
   async run(): Promise<CipReportDescribeOutput | CipReportQueryOutput | CipReportSqlOutput> {
     this.validateCipAuthMethods();

--- a/packages/b2c-cli/src/utils/cip/report-flags.ts
+++ b/packages/b2c-cli/src/utils/cip/report-flags.ts
@@ -4,7 +4,8 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import {Flags} from '@oclif/core';
+import {Flags, type Interfaces} from '@oclif/core';
+import {getCipReportByName, type CipReportDefinition, type CipReportParamDefinition} from '@salesforce/b2c-tooling-sdk';
 
 interface SiteIdFlagOptions {
   required?: boolean;
@@ -13,6 +14,11 @@ interface SiteIdFlagOptions {
 interface LimitFlagOptions {
   max?: number;
   min?: number;
+}
+
+/** Converts a camelCase report parameter name to its kebab-case CLI flag name. */
+export function paramNameToFlag(name: string): string {
+  return name.replaceAll(/[A-Z]/gu, (match) => `-${match.toLowerCase()}`);
 }
 
 export function createSiteIdFlag(options: SiteIdFlagOptions = {}) {
@@ -31,4 +37,81 @@ export function createLimitFlag(options: LimitFlagOptions = {}) {
     min: options.min ?? 1,
     required: false,
   });
+}
+
+/**
+ * Maps a single report parameter definition to an oclif flag.
+ *
+ * `from`/`to` are intentionally skipped because they are already provided by
+ * {@link CipCommand.baseFlags}; callers should exclude them. Number params become
+ * range-checked integer flags, enum params become string flags with `options`, and
+ * `multiple` params accept repeated values.
+ */
+function paramToFlag(parameter: CipReportParamDefinition): Interfaces.FlagInput[string] {
+  // Report params are intentionally NOT marked oclif-required even when the catalog
+  // marks them required: the SDK's validateReportParams enforces required-ness when
+  // building SQL, and `--describe` / metadata flows must run without supplying them.
+  // Making them oclif-required would break `cip report <name> --describe`.
+  const common = {
+    description: parameter.description,
+    helpGroup: 'QUERY' as const,
+    required: false,
+  };
+
+  if (parameter.type === 'number') {
+    return Flags.integer({
+      ...common,
+      ...(parameter.min === undefined ? {} : {min: parameter.min}),
+      ...(parameter.max === undefined ? {} : {max: parameter.max}),
+    });
+  }
+
+  // string / boolean / date all surface as string flags; the SDK validates and
+  // escapes the value when building SQL. Enum params constrain to their options.
+  const options = parameter.options && parameter.options.length > 0 ? parameter.options : undefined;
+
+  if (parameter.multiple) {
+    return Flags.string({...common, multiple: true, ...(options ? {options} : {})});
+  }
+
+  return Flags.string({...common, ...(options ? {options} : {})});
+}
+
+/**
+ * Builds the oclif flag map for a report's own parameters from its catalog
+ * definition, excluding `from`/`to` which are handled by the base command. `siteId`
+ * is mapped to the shared `--site-id` flag. Returns flags keyed by kebab-cased name.
+ */
+export function buildReportFlags(report: CipReportDefinition): Interfaces.FlagInput {
+  const flags: Interfaces.FlagInput = {};
+
+  for (const parameter of report.parameters) {
+    if (parameter.name === 'from' || parameter.name === 'to') {
+      continue;
+    }
+
+    if (parameter.name === 'siteId') {
+      // Not oclif-required; the SDK validates required-ness at SQL-build time so
+      // `--describe` works without a site id (matches the historical behavior).
+      flags['site-id'] = createSiteIdFlag({required: false});
+      continue;
+    }
+
+    flags[paramNameToFlag(parameter.name)] = paramToFlag(parameter);
+  }
+
+  return flags;
+}
+
+/**
+ * Resolves a report definition by name or throws — used by per-command files at
+ * module load to fail loudly if a report name does not exist in the catalog.
+ */
+export function requireReport(reportName: string): CipReportDefinition {
+  const report = getCipReportByName(reportName);
+  if (!report) {
+    throw new Error(`Unknown CIP report referenced by command: ${reportName}`);
+  }
+
+  return report;
 }

--- a/packages/b2c-cli/test/commands/cip/report/bot-traffic-share.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/bot-traffic-share.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import CipReportBotTrafficShare from '../../../../src/commands/cip/report/bot-traffic-share.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report bot-traffic-share', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,27 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(CipReportBotTrafficShare, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('bot-traffic-share');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +49,16 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('bot-traffic-share');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +67,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('bot-traffic-share');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/checkout-funnel-dropoff.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/checkout-funnel-dropoff.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import CheckoutFunnelDropoff from '../../../../src/commands/cip/report/checkout-funnel-dropoff.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report checkout-funnel-dropoff', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,27 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(CheckoutFunnelDropoff, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('checkout-funnel-dropoff');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +49,16 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('checkout-funnel-dropoff');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +67,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('checkout-funnel-dropoff');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/controller-error-rate-trend.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/controller-error-rate-trend.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import ControllerErrorRateTrend from '../../../../src/commands/cip/report/controller-error-rate-trend.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report controller-error-rate-trend', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,27 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(ControllerErrorRateTrend, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('controller-error-rate-trend');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +49,16 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('controller-error-rate-trend');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +67,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('controller-error-rate-trend');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/controller-health-scorecard.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/controller-health-scorecard.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import ControllerHealthScorecard from '../../../../src/commands/cip/report/controller-health-scorecard.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report controller-health-scorecard', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,27 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(ControllerHealthScorecard, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('controller-health-scorecard');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +49,16 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('controller-health-scorecard');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +67,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('controller-health-scorecard');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/discount-depth-breakdown.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/discount-depth-breakdown.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import DiscountDepthBreakdown from '../../../../src/commands/cip/report/discount-depth-breakdown.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report discount-depth-breakdown', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,27 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(DiscountDepthBreakdown, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('discount-depth-breakdown');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +49,16 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('discount-depth-breakdown');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +67,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('discount-depth-breakdown');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/inventory-stockout-by-location.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/inventory-stockout-by-location.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import InventoryStockoutByLocation from '../../../../src/commands/cip/report/inventory-stockout-by-location.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report inventory-stockout-by-location', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,26 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(InventoryStockoutByLocation, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('inventory-stockout-by-location');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +48,15 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('inventory-stockout-by-location');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +65,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('inventory-stockout-by-location');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/list.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/list.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import {expect} from 'chai';
+import sinon from 'sinon';
+import CipReportList from '../../../../src/commands/cip/report/list.js';
+import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
+
+describe('cip report list', () => {
+  const hooks = createIsolatedConfigHooks();
+
+  beforeEach(async () => {
+    await hooks.beforeEach();
+  });
+
+  afterEach(() => {
+    hooks.afterEach();
+  });
+
+  async function createCommand(flags: Record<string, unknown>): Promise<any> {
+    return createTestCommand(CipReportList, hooks.getConfig(), flags, {});
+  }
+
+  it('lists the full catalog in JSON mode without credentials', async () => {
+    const command = await createCommand({json: true});
+    sinon.stub(command, 'jsonEnabled').returns(true);
+
+    const result = await command.run();
+
+    expect(result.reportCount).to.be.greaterThan(20);
+    expect(result.reports).to.have.lengthOf(result.reportCount);
+    expect(result.reports[0]).to.have.keys(['category', 'name', 'description', 'required_params']);
+  });
+
+  it('filters by category (case-insensitive)', async () => {
+    const command = await createCommand({json: true, category: 'technical analytics'});
+    sinon.stub(command, 'jsonEnabled').returns(true);
+
+    const result = await command.run();
+
+    expect(result.reportCount).to.be.greaterThan(0);
+    for (const report of result.reports) {
+      expect(report.category).to.equal('Technical Analytics');
+    }
+    // SCAPI technical reports should be present.
+    expect(result.reports.map((r: {name: string}) => r.name)).to.include('scapi-latency-distribution');
+  });
+
+  it('renders a grouped table without throwing', async () => {
+    const command = await createCommand({});
+    sinon.stub(command, 'jsonEnabled').returns(false);
+
+    const result = (await runSilent(() => command.run())) as any;
+    expect(result.reportCount).to.be.greaterThan(20);
+  });
+});

--- a/packages/b2c-cli/test/commands/cip/report/new-vs-returning-buyer-revenue.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/new-vs-returning-buyer-revenue.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import NewVsReturningBuyerRevenue from '../../../../src/commands/cip/report/new-vs-returning-buyer-revenue.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report new-vs-returning-buyer-revenue', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,27 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(NewVsReturningBuyerRevenue, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('new-vs-returning-buyer-revenue');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +49,16 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('new-vs-returning-buyer-revenue');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +67,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('new-vs-returning-buyer-revenue');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/ocapi-client-usage.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/ocapi-client-usage.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import OcapiClientUsage from '../../../../src/commands/cip/report/ocapi-client-usage.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report ocapi-client-usage', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,26 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(OcapiClientUsage, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('ocapi-client-usage');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +48,15 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('ocapi-client-usage');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +65,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('ocapi-client-usage');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/promotion-roi-leaderboard.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/promotion-roi-leaderboard.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import PromotionRoiLeaderboard from '../../../../src/commands/cip/report/promotion-roi-leaderboard.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report promotion-roi-leaderboard', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,27 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(PromotionRoiLeaderboard, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('promotion-roi-leaderboard');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +49,16 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('promotion-roi-leaderboard');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +67,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('promotion-roi-leaderboard');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/recommender-effectiveness.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/recommender-effectiveness.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import RecommenderEffectiveness from '../../../../src/commands/cip/report/recommender-effectiveness.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report recommender-effectiveness', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,27 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(RecommenderEffectiveness, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('recommender-effectiveness');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +49,16 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('recommender-effectiveness');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +67,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('recommender-effectiveness');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/remote-include-performance.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/remote-include-performance.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import RemoteIncludePerformance from '../../../../src/commands/cip/report/remote-include-performance.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report remote-include-performance', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,27 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(RemoteIncludePerformance, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('remote-include-performance');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +49,16 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('remote-include-performance');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +67,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('remote-include-performance');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/revenue-by-channel.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/revenue-by-channel.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import RevenueByChannel from '../../../../src/commands/cip/report/revenue-by-channel.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report revenue-by-channel', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,27 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(RevenueByChannel, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('revenue-by-channel');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +49,16 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('revenue-by-channel');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +67,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('revenue-by-channel');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/scapi-cache-hit-ratio.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/scapi-cache-hit-ratio.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import ScapiCacheHitRatio from '../../../../src/commands/cip/report/scapi-cache-hit-ratio.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report scapi-cache-hit-ratio', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,26 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(ScapiCacheHitRatio, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('scapi-cache-hit-ratio');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +48,15 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('scapi-cache-hit-ratio');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +65,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('scapi-cache-hit-ratio');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/scapi-error-rate-by-status.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/scapi-error-rate-by-status.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import ScapiErrorRateByStatus from '../../../../src/commands/cip/report/scapi-error-rate-by-status.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report scapi-error-rate-by-status', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,26 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(ScapiErrorRateByStatus, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('scapi-error-rate-by-status');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +48,15 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('scapi-error-rate-by-status');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +65,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('scapi-error-rate-by-status');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/scapi-latency-distribution.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/scapi-latency-distribution.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import ScapiLatencyDistribution from '../../../../src/commands/cip/report/scapi-latency-distribution.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report scapi-latency-distribution', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,26 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(ScapiLatencyDistribution, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('scapi-latency-distribution');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +48,15 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('scapi-latency-distribution');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +65,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('scapi-latency-distribution');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/scapi-traffic-latency.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/scapi-traffic-latency.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import ScapiTrafficLatency from '../../../../src/commands/cip/report/scapi-traffic-latency.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report scapi-traffic-latency', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,26 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(ScapiTrafficLatency, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('scapi-traffic-latency');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +48,15 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('scapi-traffic-latency');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +65,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('scapi-traffic-latency');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-cli/test/commands/cip/report/zero-result-searches.test.ts
+++ b/packages/b2c-cli/test/commands/cip/report/zero-result-searches.test.ts
@@ -6,10 +6,10 @@
 
 import {expect} from 'chai';
 import sinon from 'sinon';
-import SearchQueryPerformance from '../../../../src/commands/cip/report/search-query-performance.js';
+import ZeroResultSearches from '../../../../src/commands/cip/report/zero-result-searches.js';
 import {createIsolatedConfigHooks, createTestCommand, runSilent} from '../../../helpers/test-setup.js';
 
-describe('cip report search-query-performance', () => {
+describe('cip report zero-result-searches', () => {
   const hooks = createIsolatedConfigHooks();
 
   beforeEach(async () => {
@@ -21,49 +21,27 @@ describe('cip report search-query-performance', () => {
   });
 
   async function createCommand(flags: Record<string, unknown>): Promise<any> {
-    return createTestCommand(SearchQueryPerformance, hooks.getConfig(), flags, {});
+    return createTestCommand(ZeroResultSearches, hooks.getConfig(), flags, {});
   }
-
-  it('throws a missing-required-parameter error when has-results is omitted', async () => {
-    const command = await createCommand({
-      'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
-    });
-
-    sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
-
-    // The SDK enforces required params (including the enum hasResults) at SQL-build
-    // time, so omitting --has-results surfaces a missing-required-parameter error.
-    try {
-      await runSilent(() => command.run());
-      expect.fail('Should have thrown');
-    } catch (error) {
-      expect((error as Error).message).to.include('hasResults');
-    }
-  });
 
   it('returns SQL when sql flag is true', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       sql: true,
     });
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     const result = (await runSilent(() => command.run())) as any;
 
-    expect(result.reportName).to.equal('search-query-performance');
+    expect(result.reportName).to.equal('zero-result-searches');
     expect(result.sql).to.be.a('string');
     expect(result.sql.length).to.be.greaterThan(0);
   });
 
   it('returns report description when describe flag is true', async () => {
-    const command = await createCommand({
-      describe: true,
-    });
+    const command = await createCommand({describe: true});
 
     sinon.stub(command, 'validateCipAuthMethods').returns(void 0);
     sinon.stub(command, 'log').returns(void 0);
@@ -71,17 +49,16 @@ describe('cip report search-query-performance', () => {
 
     const result = await command.run();
 
-    expect(result.name).to.equal('search-query-performance');
+    expect(result.name).to.equal('zero-result-searches');
     expect(result.description).to.be.a('string');
     expect(result.parameters).to.be.an('array');
   });
 
   it('executes report and returns data in JSON mode', async () => {
     const command = await createCommand({
-      'has-results': 'true',
       'site-id': 'Sites-test-Site',
-      from: '2025-01-01',
-      to: '2025-01-31',
+      from: '2026-01-01',
+      to: '2026-01-31',
       json: true,
     });
 
@@ -90,19 +67,14 @@ describe('cip report search-query-performance', () => {
     sinon.stub(command, 'jsonEnabled').returns(true);
 
     const mockClient = {
-      query: sinon.stub().resolves({
-        columns: ['search_term', 'search_count'],
-        rows: [{search_term: 'shoes', search_count: 100}],
-        rowCount: 1,
-      }),
+      query: sinon.stub().resolves({columns: ['a', 'b'], rows: [{a: 1, b: 2}], rowCount: 1}),
     };
 
     sinon.stub(command, 'getCipClient').returns(mockClient);
 
     const result = await command.run();
 
-    expect(result.reportName).to.equal('search-query-performance');
-    expect(result.columns).to.deep.equal(['search_term', 'search_count']);
+    expect(result.reportName).to.equal('zero-result-searches');
     expect(result.rowCount).to.equal(1);
     expect(result.rows).to.have.lengthOf(1);
   });

--- a/packages/b2c-tooling-sdk/src/index.ts
+++ b/packages/b2c-tooling-sdk/src/index.ts
@@ -283,12 +283,20 @@ export type {CloneState, WaitForCloneOptions, WaitForClonePollInfo} from './oper
 
 // Operations - CIP
 export {
+  booleanLiteral,
   buildCipReportSql,
+  dateLiteral,
   describeCipTable,
+  escapeSqlString,
   executeCipReport,
   getCipReportByName,
+  integerLiteral,
+  isReservedIdentifier,
   listCipReports,
   listCipTables,
+  quoteIdentifierIfReserved,
+  stringInList,
+  stringLiteral,
 } from './operations/cip/index.js';
 export type {
   CipColumnMetadata,

--- a/packages/b2c-tooling-sdk/src/operations/cip/index.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cip/index.ts
@@ -48,6 +48,27 @@ function toStringOrEmpty(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
+/**
+ * Resolves a value from a metadata row by matching candidate column patterns
+ * case-insensitively (ignoring underscores).
+ *
+ * CIP's Avatica metadata results are keyed by the column *labels* the JDBC
+ * driver emits. Depending on the tenant/driver these can be the camelCase
+ * aliases from our SELECT (`tableName`) or the standard uppercase JDBC metadata
+ * names (`TABLE_NAME`). Hard-coding a single casing makes the mapping silently
+ * yield empty strings for the other variant — so match tolerantly instead.
+ */
+function pickRowValue(row: Record<string, unknown>, ...patterns: RegExp[]): unknown {
+  for (const key of Object.keys(row)) {
+    const normalizedKey = key.replaceAll('_', '').toLowerCase();
+    if (patterns.some((pattern) => pattern.test(normalizedKey))) {
+      return row[key];
+    }
+  }
+
+  return undefined;
+}
+
 function toBoolean(value: unknown): boolean {
   if (typeof value === 'boolean') {
     return value;
@@ -102,9 +123,9 @@ export async function listCipTables(
   const result = await client.query(sql, {fetchSize: options.fetchSize});
 
   const tables: CipTableMetadata[] = result.rows.map((row) => ({
-    tableName: toStringOrEmpty(row.tableName),
-    tableSchema: toStringOrEmpty(row.tableSchem),
-    tableType: toStringOrEmpty(row.tableType),
+    tableName: toStringOrEmpty(pickRowValue(row, /^tablename$/)),
+    tableSchema: toStringOrEmpty(pickRowValue(row, /^tableschem(a)?$/)),
+    tableType: toStringOrEmpty(pickRowValue(row, /^tabletype$/)),
   }));
 
   return {
@@ -136,12 +157,12 @@ export async function describeCipTable(
   const result = await client.query(sql, {fetchSize: options.fetchSize});
 
   const columns: CipColumnMetadata[] = result.rows.map((row) => ({
-    columnName: toStringOrEmpty(row.columnName),
-    dataType: toStringOrEmpty(row.typeName),
-    isNullable: toBoolean(row.isNullable),
-    ordinalPosition: toNumber(row.ordinalPosition),
-    tableName: toStringOrEmpty(row.tableName),
-    tableSchema: toStringOrEmpty(row.tableSchem),
+    columnName: toStringOrEmpty(pickRowValue(row, /^columnname$/)),
+    dataType: toStringOrEmpty(pickRowValue(row, /^(typename|datatype)$/)),
+    isNullable: toBoolean(pickRowValue(row, /^isnullable$/)),
+    ordinalPosition: toNumber(pickRowValue(row, /^ordinalposition$/)),
+    tableName: toStringOrEmpty(pickRowValue(row, /^tablename$/)),
+    tableSchema: toStringOrEmpty(pickRowValue(row, /^tableschem(a)?$/)),
   }));
 
   return {

--- a/packages/b2c-tooling-sdk/src/operations/cip/index.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cip/index.ts
@@ -6,6 +6,7 @@
 
 import type {CipClient} from '../../clients/cip.js';
 import {CIP_REPORTS} from './reports.js';
+import {escapeSqlString} from './sql.js';
 import type {
   CipDescribeTableOptions,
   CipDescribeTableResult,
@@ -43,6 +44,17 @@ export type {
   CipReportSqlResult,
   CipTableMetadata,
 } from './types.js';
+
+export {
+  booleanLiteral,
+  dateLiteral,
+  escapeSqlString,
+  integerLiteral,
+  isReservedIdentifier,
+  quoteIdentifierIfReserved,
+  stringInList,
+  stringLiteral,
+} from './sql.js';
 
 function toStringOrEmpty(value: unknown): string {
   return typeof value === 'string' ? value : '';
@@ -89,10 +101,6 @@ function toNumber(value: unknown): number {
   return Number(value ?? 0);
 }
 
-function escapeSqlLiteral(value: string): string {
-  return value.replaceAll("'", "''");
-}
-
 /**
  * Lists tables from the CIP metadata catalog.
  *
@@ -107,15 +115,15 @@ export async function listCipTables(
   const whereClauses: string[] = [];
 
   if (options.schema) {
-    whereClauses.push(`tableSchem = '${escapeSqlLiteral(options.schema)}'`);
+    whereClauses.push(`tableSchem = '${escapeSqlString(options.schema)}'`);
   }
 
   if (options.tableNamePattern) {
-    whereClauses.push(`tableName LIKE '${escapeSqlLiteral(options.tableNamePattern)}'`);
+    whereClauses.push(`tableName LIKE '${escapeSqlString(options.tableNamePattern)}'`);
   }
 
   if (options.tableType) {
-    whereClauses.push(`tableType = '${escapeSqlLiteral(options.tableType)}'`);
+    whereClauses.push(`tableType = '${escapeSqlString(options.tableType)}'`);
   }
 
   const whereClauseSql = whereClauses.length > 0 ? ` WHERE ${whereClauses.join(' AND ')}` : '';
@@ -151,7 +159,7 @@ export async function describeCipTable(
   const tableSchema = options.schema ?? 'warehouse';
   const sql =
     `SELECT tableSchem, tableName, columnName, typeName, isNullable, ordinalPosition FROM metadata.COLUMNS ` +
-    `WHERE tableSchem = '${escapeSqlLiteral(tableSchema)}' AND tableName = '${escapeSqlLiteral(tableName)}' ` +
+    `WHERE tableSchem = '${escapeSqlString(tableSchema)}' AND tableName = '${escapeSqlString(tableName)}' ` +
     `ORDER BY ordinalPosition`;
 
   const result = await client.query(sql, {fetchSize: options.fetchSize});
@@ -192,7 +200,12 @@ export function getCipReportByName(name: string): CipReportDefinition | undefine
   return CIP_REPORTS.find((report) => report.name === name);
 }
 
-function validateReportParams(report: CipReportDefinition, params: Record<string, string>): void {
+/**
+ * Validates supplied params against the report contract and returns a normalized
+ * copy with defaults applied. Enforces required params and, where declared,
+ * enum `options` (including per-value checks for `multiple` parameters).
+ */
+function validateReportParams(report: CipReportDefinition, params: Record<string, string>): Record<string, string> {
   const unknownParams = Object.keys(params).filter(
     (key) => !report.parameters.some((parameter) => parameter.name === key),
   );
@@ -200,11 +213,32 @@ function validateReportParams(report: CipReportDefinition, params: Record<string
     throw new Error(`Unknown parameters for report "${report.name}": ${unknownParams.join(', ')}`);
   }
 
+  const normalized: Record<string, string> = {...params};
+
   for (const parameter of report.parameters) {
-    if (parameter.required && !params[parameter.name]) {
+    if (!normalized[parameter.name] && parameter.default !== undefined) {
+      normalized[parameter.name] = parameter.default;
+    }
+
+    const value = normalized[parameter.name];
+
+    if (parameter.required && !value) {
       throw new Error(`Missing required parameter for report "${report.name}": ${parameter.name}`);
     }
+
+    if (value && parameter.options && parameter.options.length > 0) {
+      const candidates = parameter.multiple ? value.split(',').map((item) => item.trim()) : [value];
+      const invalid = candidates.filter((candidate) => !parameter.options?.includes(candidate));
+      if (invalid.length > 0) {
+        throw new Error(
+          `Invalid value(s) for parameter "${parameter.name}" in report "${report.name}": ${invalid.join(', ')}. ` +
+            `Allowed: ${parameter.options.join(', ')}`,
+        );
+      }
+    }
   }
+
+  return normalized;
 }
 
 /**
@@ -221,11 +255,11 @@ export function buildCipReportSql(name: string, params: Record<string, string>):
     throw new Error(`Unknown CIP report: ${name}`);
   }
 
-  validateReportParams(report, params);
+  const normalizedParams = validateReportParams(report, params);
 
   return {
     report,
-    sql: report.buildSql(params),
+    sql: report.buildSql(normalizedParams),
   };
 }
 

--- a/packages/b2c-tooling-sdk/src/operations/cip/reports.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cip/reports.ts
@@ -5,10 +5,7 @@
  */
 
 import type {CipReportDefinition} from './types.js';
-
-function escapeSqlString(value: string): string {
-  return value.replaceAll("'", "''");
-}
+import {booleanLiteral, dateLiteral, integerLiteral, quoteIdentifierIfReserved, stringLiteral} from './sql.js';
 
 function getRequiredString(params: Record<string, string>, key: string): string {
   const value = params[key];
@@ -20,26 +17,23 @@ function getRequiredString(params: Record<string, string>, key: string): string 
 }
 
 function getDateLiteral(params: Record<string, string>, key: string): string {
-  const value = getRequiredString(params, key);
-  if (!/^\d{4}-\d{2}-\d{2}$/u.test(value)) {
+  try {
+    return dateLiteral(getRequiredString(params, key));
+  } catch {
     throw new Error(`Invalid date for parameter "${key}": expected YYYY-MM-DD`);
   }
-
-  return `'${escapeSqlString(value)}'`;
 }
 
 function getStringLiteral(params: Record<string, string>, key: string): string {
-  const value = getRequiredString(params, key);
-  return `'${escapeSqlString(value)}'`;
+  return stringLiteral(getRequiredString(params, key));
 }
 
 function getBooleanLiteral(params: Record<string, string>, key: string): string {
-  const value = getRequiredString(params, key).toLowerCase();
-  if (value !== 'true' && value !== 'false') {
+  try {
+    return booleanLiteral(getRequiredString(params, key));
+  } catch {
     throw new Error(`Invalid boolean for parameter "${key}": expected true or false`);
   }
-
-  return value;
 }
 
 function getOptionalIntegerLiteral(
@@ -54,12 +48,31 @@ function getOptionalIntegerLiteral(
     return String(fallback);
   }
 
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+  try {
+    return integerLiteral(raw, min, max);
+  } catch {
     throw new Error(`Invalid integer for parameter "${key}": expected ${min}-${max}`);
   }
+}
 
-  return String(parsed);
+/** Alias for builders that reference reserved column names (for example `method`). */
+const col = quoteIdentifierIfReserved;
+
+/**
+ * Builds the optional site-dimension join and WHERE predicate for tables whose
+ * `site_id` is nullable or where site scoping is optional (for example the SCAPI
+ * and OCAPI request tables). When `siteId` is absent both fragments are empty so
+ * the report spans all sites; when present an inner join restricts to that site.
+ */
+function optionalSiteJoin(params: Record<string, string>, factAlias: string): {join: string; predicate: string} {
+  if (!params.siteId) {
+    return {join: '', predicate: ''};
+  }
+
+  return {
+    join: ` JOIN ccdw_dim_site s ON s.site_id = ${factAlias}.site_id`,
+    predicate: ` AND s.nsite_id = ${getStringLiteral(params, 'siteId')}`,
+  };
 }
 
 export const CIP_REPORTS: CipReportDefinition[] = [
@@ -164,7 +177,13 @@ export const CIP_REPORTS: CipReportDefinition[] = [
     category: 'Search Analytics',
     parameters: [
       {name: 'siteId', description: 'Natural site id', type: 'string', required: true},
-      {name: 'hasResults', description: 'Filter successful/unsuccessful searches', type: 'boolean', required: true},
+      {
+        name: 'hasResults',
+        description: 'Filter successful/unsuccessful searches',
+        type: 'boolean',
+        required: true,
+        options: ['true', 'false'],
+      },
       {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
       {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
     ],
@@ -224,6 +243,363 @@ export const CIP_REPORTS: CipReportDefinition[] = [
       const to = getDateLiteral(params, 'to');
       const limit = getOptionalIntegerLiteral(params, 'limit', 20, 1, 500);
       return `WITH total AS (SELECT SUM(num_visits) AS total_visits FROM ccdw_aggr_visit_referrer WHERE visit_date >= ${from} AND visit_date <= ${to}) SELECT vr.referrer_medium AS traffic_medium, vr.referrer_source AS traffic_source, SUM(vr.num_visits) AS total_visits, SUM(vr.num_visits) * 100.0 / total.total_visits AS visit_percentage FROM ccdw_aggr_visit_referrer vr JOIN ccdw_dim_site s ON s.site_id = vr.site_id JOIN total ON TRUE WHERE vr.visit_date >= ${from} AND vr.visit_date <= ${to} AND s.nsite_id = ${siteId} GROUP BY vr.referrer_medium, vr.referrer_source, total.total_visits ORDER BY total_visits DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'scapi-traffic-latency',
+    description: 'Rank SCAPI endpoints by request volume and average latency',
+    category: 'Technical Analytics',
+    tablesUsed: ['ccdw_aggr_scapi_request', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {
+        name: 'siteId',
+        description: 'Optional natural site id; SCAPI rows may be unattributed (omit to span all sites)',
+        type: 'string',
+      },
+      {name: 'limit', description: 'Max rows (1-500)', type: 'number', min: 1, max: 500},
+    ],
+    buildSql(params) {
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 20, 1, 500);
+      const site = optionalSiteJoin(params, 'r');
+      return `SELECT r.api_family, r.api_name, r.api_resource, r.${col('method')}, SUM(r.num_requests) AS total_requests, SUM(r.response_time) AS total_response_ms, CAST(SUM(r.response_time) / NULLIF(SUM(r.num_requests), 0) AS DECIMAL(15,2)) AS avg_response_ms FROM ccdw_aggr_scapi_request r${site.join} WHERE r.request_date >= ${from} AND r.request_date <= ${to}${site.predicate} GROUP BY r.api_family, r.api_name, r.api_resource, r.${col('method')} ORDER BY total_requests DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'scapi-error-rate-by-status',
+    description: 'Rank SCAPI endpoints by 4xx/5xx error rate over a date range',
+    category: 'Technical Analytics',
+    tablesUsed: ['ccdw_aggr_scapi_request', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'siteId', description: 'Optional natural site id (omit to span all sites)', type: 'string'},
+      {
+        name: 'statusClass',
+        description: 'Optional HTTP error class filter',
+        type: 'string',
+        options: ['4xx', '5xx'],
+      },
+      {name: 'limit', description: 'Max rows (1-500)', type: 'number', min: 1, max: 500},
+    ],
+    buildSql(params) {
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 50, 1, 500);
+      const site = optionalSiteJoin(params, 'r');
+      const classFilter =
+        params.statusClass === '4xx'
+          ? ' AND r.status_code BETWEEN 400 AND 499'
+          : params.statusClass === '5xx'
+            ? ' AND r.status_code BETWEEN 500 AND 599'
+            : '';
+      return `SELECT r.api_family, r.api_name, r.api_resource, r.${col('method')}, SUM(r.num_requests) AS total_requests, SUM(CASE WHEN r.status_code BETWEEN 400 AND 499 THEN r.num_requests ELSE 0 END) AS error_4xx, SUM(CASE WHEN r.status_code BETWEEN 500 AND 599 THEN r.num_requests ELSE 0 END) AS error_5xx, SUM(CASE WHEN r.status_code BETWEEN 400 AND 599 THEN r.num_requests ELSE 0 END) AS error_total, CAST(100.0 * SUM(CASE WHEN r.status_code BETWEEN 400 AND 599 THEN r.num_requests ELSE 0 END) / NULLIF(SUM(r.num_requests), 0) AS DECIMAL(15,2)) AS error_pct FROM ccdw_aggr_scapi_request r${site.join} WHERE r.request_date >= ${from} AND r.request_date <= ${to}${site.predicate}${classFilter} GROUP BY r.api_family, r.api_name, r.api_resource, r.${col('method')} HAVING SUM(CASE WHEN r.status_code BETWEEN 400 AND 599 THEN r.num_requests ELSE 0 END) > 0 ORDER BY error_total DESC, error_pct DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'scapi-latency-distribution',
+    description: 'Surface the SCAPI latency histogram and slow-tail (SLA breach) percentage per endpoint',
+    category: 'Technical Analytics',
+    tablesUsed: ['ccdw_aggr_scapi_request', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'siteId', description: 'Optional natural site id (omit to span all sites)', type: 'string'},
+      {name: 'limit', description: 'Max rows (1-500)', type: 'number', min: 1, max: 500},
+    ],
+    buildSql(params) {
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 20, 1, 500);
+      const site = optionalSiteJoin(params, 'r');
+      return `SELECT r.api_family, r.api_name, r.api_resource, SUM(r.num_requests) AS total_requests, CAST(100.0 * SUM(r.num_requests_bucket1 + r.num_requests_bucket2 + r.num_requests_bucket3) / NULLIF(SUM(r.num_requests), 0) AS DECIMAL(15,2)) AS fast_pct, CAST(100.0 * SUM(r.num_requests_bucket9 + r.num_requests_bucket10 + r.num_requests_bucket11) / NULLIF(SUM(r.num_requests), 0) AS DECIMAL(15,2)) AS slow_tail_pct, SUM(r.num_requests_bucket1) AS bucket1, SUM(r.num_requests_bucket2) AS bucket2, SUM(r.num_requests_bucket3) AS bucket3, SUM(r.num_requests_bucket4) AS bucket4, SUM(r.num_requests_bucket5) AS bucket5, SUM(r.num_requests_bucket6) AS bucket6, SUM(r.num_requests_bucket7) AS bucket7, SUM(r.num_requests_bucket8) AS bucket8, SUM(r.num_requests_bucket9) AS bucket9, SUM(r.num_requests_bucket10) AS bucket10, SUM(r.num_requests_bucket11) AS bucket11, CAST(SUM(r.response_time) / NULLIF(SUM(r.num_requests), 0) AS DECIMAL(15,2)) AS avg_response_ms FROM ccdw_aggr_scapi_request r${site.join} WHERE r.request_date >= ${from} AND r.request_date <= ${to}${site.predicate} GROUP BY r.api_family, r.api_name, r.api_resource ORDER BY total_requests DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'scapi-cache-hit-ratio',
+    description: 'Measure SCAPI cache hit ratio per endpoint to find cacheable resources running as MISS',
+    category: 'Technical Analytics',
+    tablesUsed: ['ccdw_aggr_scapi_request', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'siteId', description: 'Optional natural site id (omit to span all sites)', type: 'string'},
+      {name: 'limit', description: 'Max rows (1-500)', type: 'number', min: 1, max: 500},
+    ],
+    buildSql(params) {
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 50, 1, 500);
+      const site = optionalSiteJoin(params, 'r');
+      return `SELECT r.api_family, r.api_name, r.api_resource, SUM(r.num_requests) AS total_requests, SUM(CASE WHEN r.cache_behavior = 'HIT' THEN r.num_requests ELSE 0 END) AS hits, SUM(CASE WHEN r.cache_behavior = 'MISS' THEN r.num_requests ELSE 0 END) AS misses, SUM(CASE WHEN r.cache_behavior = '__NON_CACHEABLE__' THEN r.num_requests ELSE 0 END) AS non_cacheable, CAST(100.0 * SUM(CASE WHEN r.cache_behavior = 'HIT' THEN r.num_requests ELSE 0 END) / NULLIF(SUM(CASE WHEN r.cache_behavior IN ('HIT', 'MISS') THEN r.num_requests ELSE 0 END), 0) AS DECIMAL(15,2)) AS hit_ratio_pct FROM ccdw_aggr_scapi_request r${site.join} WHERE r.request_date >= ${from} AND r.request_date <= ${to}${site.predicate} GROUP BY r.api_family, r.api_name, r.api_resource ORDER BY total_requests DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'ocapi-client-usage',
+    description: 'Rank OCAPI client_ids by request volume with per-client error rate and latency',
+    category: 'Technical Analytics',
+    tablesUsed: ['ccdw_aggr_ocapi_request', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'siteId', description: 'Optional natural site id (omit to span all sites)', type: 'string'},
+      {name: 'limit', description: 'Max rows (1-500)', type: 'number', min: 1, max: 500},
+    ],
+    buildSql(params) {
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 50, 1, 500);
+      const site = optionalSiteJoin(params, 'o');
+      return `WITH totals AS (SELECT SUM(o.num_requests) AS grand_total FROM ccdw_aggr_ocapi_request o${site.join} WHERE o.request_date >= ${from} AND o.request_date <= ${to}${site.predicate}) SELECT o.client_id, SUM(o.num_requests) AS total_requests, CAST(SUM(o.num_requests) * 100.0 / NULLIF(t.grand_total, 0) AS DECIMAL(15,2)) AS traffic_pct, CAST(100.0 * SUM(CASE WHEN o.status_code >= 400 THEN o.num_requests ELSE 0 END) / NULLIF(SUM(o.num_requests), 0) AS DECIMAL(15,2)) AS error_pct, CAST(SUM(o.response_time) / NULLIF(SUM(o.num_requests), 0) AS DECIMAL(15,2)) AS avg_response_ms, COUNT(DISTINCT o.api_resource) AS distinct_resources FROM ccdw_aggr_ocapi_request o${site.join} JOIN totals t ON TRUE WHERE o.request_date >= ${from} AND o.request_date <= ${to}${site.predicate} GROUP BY o.client_id, t.grand_total ORDER BY total_requests DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'controller-health-scorecard',
+    description: 'Score SFRA controller health by volume, errors, slow tail, and cache hit rate',
+    category: 'Technical Analytics',
+    tablesUsed: ['ccdw_aggr_controller_request', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'siteId', description: 'Natural site id', type: 'string', required: true},
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'limit', description: 'Max rows (1-500)', type: 'number', min: 1, max: 500},
+    ],
+    buildSql(params) {
+      const siteId = getStringLiteral(params, 'siteId');
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 25, 1, 500);
+      return `SELECT cr.controller_name, SUM(cr.num_requests) AS total_requests, CAST(SUM(cr.response_time) / NULLIF(SUM(cr.num_requests), 0) AS DECIMAL(15,2)) AS avg_response_ms, CAST(100.0 * SUM(CASE WHEN cr.status_code >= 400 THEN cr.num_requests ELSE 0 END) / NULLIF(SUM(cr.num_requests), 0) AS DECIMAL(15,2)) AS error_pct, CAST(100.0 * SUM(cr.num_requests_bucket9 + cr.num_requests_bucket10 + cr.num_requests_bucket11) / NULLIF(SUM(cr.num_requests), 0) AS DECIMAL(15,2)) AS slow_tail_pct, CAST(100.0 * SUM(CASE WHEN cr.cache_behavior = 'HIT' THEN cr.num_requests ELSE 0 END) / NULLIF(SUM(CASE WHEN cr.cache_behavior IN ('HIT', 'MISS') THEN cr.num_requests ELSE 0 END), 0) AS DECIMAL(15,2)) AS cache_hit_pct FROM ccdw_aggr_controller_request cr JOIN ccdw_dim_site s ON s.site_id = cr.site_id WHERE cr.request_date >= ${from} AND cr.request_date <= ${to} AND s.nsite_id = ${siteId} GROUP BY cr.controller_name ORDER BY total_requests DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'controller-error-rate-trend',
+    description: 'Daily 4xx/5xx error rate per storefront controller for catching deploy regressions',
+    category: 'Technical Analytics',
+    tablesUsed: ['ccdw_aggr_controller_request', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'siteId', description: 'Natural site id', type: 'string', required: true},
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'limit', description: 'Max controller/day rows (1-1000)', type: 'number', min: 1, max: 1000},
+    ],
+    buildSql(params) {
+      const siteId = getStringLiteral(params, 'siteId');
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 100, 1, 1000);
+      return `SELECT CAST(CAST(r.request_date AS DATE) AS VARCHAR) AS request_day, r.controller_name, SUM(r.num_requests) AS total_requests, SUM(CASE WHEN r.status_code BETWEEN 400 AND 499 THEN r.num_requests ELSE 0 END) AS client_error_4xx, SUM(CASE WHEN r.status_code BETWEEN 500 AND 599 THEN r.num_requests ELSE 0 END) AS server_error_5xx, CAST(100.0 * (SUM(CASE WHEN r.status_code BETWEEN 400 AND 499 THEN r.num_requests ELSE 0 END) + SUM(CASE WHEN r.status_code BETWEEN 500 AND 599 THEN r.num_requests ELSE 0 END)) / NULLIF(SUM(r.num_requests), 0) AS DECIMAL(15,2)) AS error_rate_pct FROM ccdw_aggr_controller_request r JOIN ccdw_dim_site s ON s.site_id = r.site_id WHERE CAST(r.request_date AS DATE) BETWEEN ${from} AND ${to} AND s.nsite_id = ${siteId} GROUP BY CAST(r.request_date AS DATE), r.controller_name ORDER BY server_error_5xx DESC, client_error_4xx DESC, request_day DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'remote-include-performance',
+    description: 'Rank remote-include child controllers by load, latency, errors, and cache hit rate per parent page',
+    category: 'Technical Analytics',
+    tablesUsed: ['ccdw_aggr_include_controller_request', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'siteId', description: 'Natural site id', type: 'string', required: true},
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'limit', description: 'Max rows (1-1000)', type: 'number', min: 1, max: 1000},
+    ],
+    buildSql(params) {
+      const siteId = getStringLiteral(params, 'siteId');
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 50, 1, 1000);
+      return `SELECT ic.main_controller_name, ic.controller_name, SUM(ic.num_requests) AS total_requests, SUM(ic.response_time) AS total_response_ms, CAST(SUM(ic.response_time) / NULLIF(SUM(ic.num_requests), 0) AS DECIMAL(15,2)) AS avg_response_ms, CAST(100.0 * SUM(CASE WHEN ic.status_code >= 400 THEN ic.num_requests ELSE 0 END) / NULLIF(SUM(ic.num_requests), 0) AS DECIMAL(15,2)) AS error_pct, CAST(100.0 * SUM(CASE WHEN ic.cache_behavior = 'HIT' THEN ic.num_requests ELSE 0 END) / NULLIF(SUM(CASE WHEN ic.cache_behavior IN ('HIT','MISS') THEN ic.num_requests ELSE 0 END), 0) AS DECIMAL(15,2)) AS cache_hit_pct FROM ccdw_aggr_include_controller_request ic JOIN ccdw_dim_site s ON s.site_id = ic.site_id WHERE ic.request_date >= ${from} AND ic.request_date <= ${to} AND s.nsite_id = ${siteId} GROUP BY ic.main_controller_name, ic.controller_name ORDER BY total_requests DESC, total_response_ms DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'revenue-by-channel',
+    description: 'Break down revenue, orders, AOV, and discount rate by channel, device, and locale',
+    category: 'Sales Analytics',
+    tablesUsed: ['ccdw_aggr_sales_summary', 'ccdw_dim_business_channel', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'siteId', description: 'Natural site id', type: 'string', required: true},
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'limit', description: 'Max rows (1-500)', type: 'number', min: 1, max: 500},
+    ],
+    buildSql(params) {
+      const siteId = getStringLiteral(params, 'siteId');
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 50, 1, 500);
+      return `WITH site_total AS (SELECT SUM(ss.std_revenue) AS total_std_revenue FROM ccdw_aggr_sales_summary ss JOIN ccdw_dim_site s ON s.site_id = ss.site_id WHERE ss.submit_date >= ${from} AND ss.submit_date <= ${to} AND s.nsite_id = ${siteId}) SELECT bc.order_channel, bc.business_type, ss.device_class_code, ss.locale_code, SUM(ss.std_revenue) AS std_revenue, SUM(ss.num_orders) AS orders, SUM(ss.num_units) AS units, CAST(SUM(ss.std_revenue) / NULLIF(SUM(ss.num_orders), 0) AS DECIMAL(15,2)) AS std_aov, CAST(SUM(ss.std_revenue) * 100.0 / NULLIF(t.total_std_revenue, 0) AS DECIMAL(15,2)) AS revenue_share_pct, CAST(SUM(ss.std_total_discount) * 100.0 / NULLIF(SUM(ss.std_revenue) + SUM(ss.std_total_discount), 0) AS DECIMAL(15,2)) AS discount_rate_pct FROM ccdw_aggr_sales_summary ss JOIN ccdw_dim_site s ON s.site_id = ss.site_id JOIN ccdw_dim_business_channel bc ON bc.business_channel_id = ss.business_channel_id JOIN site_total t ON TRUE WHERE ss.submit_date >= ${from} AND ss.submit_date <= ${to} AND s.nsite_id = ${siteId} GROUP BY bc.order_channel, bc.business_type, ss.device_class_code, ss.locale_code, t.total_std_revenue ORDER BY std_revenue DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'new-vs-returning-buyer-revenue',
+    description: 'Split revenue, orders, AOV, and discount depth between first-time and returning buyers',
+    category: 'Customer Analytics',
+    tablesUsed: ['ccdw_aggr_sales_summary', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'siteId', description: 'Natural site id', type: 'string', required: true},
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+    ],
+    buildSql(params) {
+      const siteId = getStringLiteral(params, 'siteId');
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      return `WITH site_total AS (SELECT SUM(ss.std_revenue) AS total_std_revenue FROM ccdw_aggr_sales_summary ss JOIN ccdw_dim_site s ON s.site_id = ss.site_id WHERE s.nsite_id = ${siteId} AND ss.submit_date >= ${from} AND ss.submit_date <= ${to}) SELECT CASE WHEN ss.first_time_buyer THEN 'first_time' ELSE 'returning' END AS buyer_type, CASE WHEN ss.registered THEN 'registered' ELSE 'guest' END AS customer_type, SUM(ss.std_revenue) AS std_revenue, SUM(ss.num_orders) AS orders, SUM(ss.num_units) AS units, CAST(SUM(ss.std_revenue) / NULLIF(SUM(ss.num_orders), 0) AS DECIMAL(15,2)) AS std_aov, CAST(SUM(ss.std_revenue) * 100.0 / NULLIF(t.total_std_revenue, 0) AS DECIMAL(15,2)) AS revenue_share_pct, CAST(SUM(ss.std_total_discount) * 100.0 / NULLIF(SUM(ss.std_revenue) + SUM(ss.std_total_discount), 0) AS DECIMAL(15,2)) AS discount_rate_pct FROM ccdw_aggr_sales_summary ss JOIN ccdw_dim_site s ON s.site_id = ss.site_id JOIN site_total t ON TRUE WHERE s.nsite_id = ${siteId} AND ss.submit_date >= ${from} AND ss.submit_date <= ${to} GROUP BY ss.first_time_buyer, ss.registered, t.total_std_revenue ORDER BY std_revenue DESC`;
+    },
+  },
+  {
+    name: 'discount-depth-breakdown',
+    description: 'Break down total discount into promotional vs manual by product, order, and shipping',
+    category: 'Promotion Analytics',
+    tablesUsed: ['ccdw_aggr_sales_summary', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'siteId', description: 'Natural site id', type: 'string', required: true},
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+    ],
+    buildSql(params) {
+      const siteId = getStringLiteral(params, 'siteId');
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      return `SELECT SUM(ss.std_revenue) AS std_revenue, SUM(COALESCE(ss.std_promotional_product_discount, 0)) AS std_promotional_product_discount, SUM(COALESCE(ss.std_promotional_order_discount, 0)) AS std_promotional_order_discount, SUM(COALESCE(ss.std_promotional_shipping_discount, 0)) AS std_promotional_shipping_discount, SUM(COALESCE(ss.std_manual_product_discount, 0)) AS std_manual_product_discount, SUM(COALESCE(ss.std_manual_order_discount, 0)) AS std_manual_order_discount, SUM(COALESCE(ss.std_manual_shipping_discount, 0)) AS std_manual_shipping_discount, SUM(COALESCE(ss.std_promotional_product_discount, 0) + COALESCE(ss.std_promotional_order_discount, 0) + COALESCE(ss.std_promotional_shipping_discount, 0)) AS promo_discount_total, SUM(COALESCE(ss.std_manual_product_discount, 0) + COALESCE(ss.std_manual_order_discount, 0) + COALESCE(ss.std_manual_shipping_discount, 0)) AS manual_discount_total, SUM(ss.std_total_discount) AS std_total_discount, CAST(SUM(ss.std_total_discount) * 100.0 / NULLIF(SUM(ss.std_revenue) + SUM(ss.std_total_discount), 0) AS DECIMAL(15,2)) AS effective_discount_rate_pct FROM ccdw_aggr_sales_summary ss JOIN ccdw_dim_site s ON s.site_id = ss.site_id WHERE ss.submit_date >= ${from} AND ss.submit_date <= ${to} AND s.nsite_id = ${siteId}`;
+    },
+  },
+  {
+    name: 'promotion-roi-leaderboard',
+    description: 'Rank promotions by revenue per dollar of discount, with orders, uses, and AOV',
+    category: 'Promotion Analytics',
+    tablesUsed: ['ccdw_aggr_promotion_sales_summary', 'ccdw_dim_promotion', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'siteId', description: 'Natural site id', type: 'string', required: true},
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'limit', description: 'Max rows (1-500)', type: 'number', min: 1, max: 500},
+    ],
+    buildSql(params) {
+      const siteId = getStringLiteral(params, 'siteId');
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 50, 1, 500);
+      return `SELECT p.npromotion_id AS promotion_id, p.display_name AS promotion_name, p.promotion_class, SUM(pss.std_revenue) AS std_revenue, SUM(pss.std_total_discount) AS std_total_discount, SUM(pss.num_orders) AS num_orders, SUM(pss.num_promotion_uses) AS num_promotion_uses, CAST(SUM(pss.std_revenue) / NULLIF(SUM(pss.num_orders), 0) AS DECIMAL(15,2)) AS std_aov, CAST(SUM(pss.std_revenue) / NULLIF(SUM(pss.std_total_discount), 0) AS DECIMAL(15,2)) AS revenue_per_discount_dollar FROM ccdw_aggr_promotion_sales_summary pss JOIN ccdw_dim_promotion p ON p.promotion_id = pss.promotion_id JOIN ccdw_dim_site s ON s.site_id = pss.site_id WHERE pss.submit_date >= ${from} AND pss.submit_date <= ${to} AND s.nsite_id = ${siteId} GROUP BY p.npromotion_id, p.display_name, p.promotion_class ORDER BY revenue_per_discount_dollar DESC, std_revenue DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'recommender-effectiveness',
+    description: 'Rank product recommenders by engagement, attributed revenue, and conversion',
+    category: 'Product Analytics',
+    tablesUsed: ['ccdw_aggr_product_recommendation_recommender', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'siteId', description: 'Natural site id', type: 'string', required: true},
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'limit', description: 'Max rows (1-500)', type: 'number', min: 1, max: 500},
+    ],
+    buildSql(params) {
+      const siteId = getStringLiteral(params, 'siteId');
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 20, 1, 500);
+      // Note: the CIP JDBC service rejects projections with too many SUM() calls
+      // (observed ~7+ bare aggregate columns), so this report keeps the highest-value
+      // raw metrics (views/clicks/cart_adds/orders/revenue) and derives CTR and
+      // view-to-cart ratios rather than also projecting every raw funnel count.
+      return `SELECT rr.recommender_name, SUM(rr.num_recommender_views) AS recommender_views, SUM(rr.num_clicks) AS clicks, SUM(rr.num_cart_adds) AS cart_adds, SUM(rr.num_orders) AS orders, SUM(rr.std_attributed_revenue) AS std_attributed_revenue, CAST(SUM(rr.num_clicks) * 100.0 / NULLIF(SUM(rr.num_recommender_views), 0) AS DECIMAL(15,2)) AS ctr_pct, CAST(SUM(rr.num_cart_adds) * 100.0 / NULLIF(SUM(rr.num_product_views), 0) AS DECIMAL(15,2)) AS view_to_cart_pct FROM ccdw_aggr_product_recommendation_recommender rr JOIN ccdw_dim_site s ON s.site_id = rr.site_id WHERE rr.recommendation_date >= ${from} AND rr.recommendation_date <= ${to} AND s.nsite_id = ${siteId} GROUP BY rr.recommender_name ORDER BY std_attributed_revenue DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'zero-result-searches',
+    description: 'Surface search terms that most often return zero results and the demand lost to them',
+    category: 'Search Analytics',
+    tablesUsed: ['ccdw_aggr_search_query', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'siteId', description: 'Natural site id', type: 'string', required: true},
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'limit', description: 'Max rows (1-500)', type: 'number', min: 1, max: 500},
+    ],
+    buildSql(params) {
+      const siteId = getStringLiteral(params, 'siteId');
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 50, 1, 500);
+      return `SELECT LOWER(sq.query) AS query, SUM(sq.num_searches_without_results) AS no_result_searches, SUM(sq.num_searches_with_results) AS with_result_searches, SUM(sq.num_visits_without_search_results) AS visits_without_results, CAST(100.0 * SUM(sq.num_searches_without_results) / NULLIF(SUM(sq.num_searches_without_results) + SUM(sq.num_searches_with_results), 0) AS DECIMAL(15,2)) AS no_result_rate_pct FROM ccdw_aggr_search_query sq JOIN ccdw_dim_site s ON s.site_id = sq.site_id WHERE sq.search_date >= ${from} AND sq.search_date <= ${to} AND s.nsite_id = ${siteId} GROUP BY LOWER(sq.query) HAVING SUM(sq.num_searches_without_results) > 0 ORDER BY no_result_searches DESC, no_result_rate_pct DESC LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'checkout-funnel-dropoff',
+    description: 'Visits reaching each checkout step with step-over-step drop-off to pinpoint funnel leaks',
+    category: 'Traffic Analytics',
+    tablesUsed: ['ccdw_aggr_visit_checkout', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'siteId', description: 'Natural site id', type: 'string', required: true},
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+    ],
+    buildSql(params) {
+      const siteId = getStringLiteral(params, 'siteId');
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      // Some tenants run parallel checkout implementations (e.g. SFRA + headless) that
+      // write colliding step_numbers under different step_names into this table, which
+      // makes a step_number-only funnel produce nonsensical drop-offs. Group by the
+      // (step_number, step_name) identity and order the window by step_number then total
+      // visits so each distinct checkout flow's steps stay in sequence; the dividend is
+      // promoted with * 1.0 so Calcite does not truncate the ratio with integer division.
+      return `WITH steps AS (SELECT vc.step_number AS step_number, vc.step_name AS step_name, SUM(vc.num_visits) AS num_visits, SUM(vc.num_hits) AS num_hits FROM ccdw_aggr_visit_checkout vc JOIN ccdw_dim_site s ON s.site_id = vc.site_id WHERE vc.visit_date >= ${from} AND vc.visit_date <= ${to} AND s.nsite_id = ${siteId} GROUP BY vc.step_number, vc.step_name) SELECT step_number, step_name, num_visits, num_hits, CAST(num_visits * 100.0 / NULLIF(FIRST_VALUE(num_visits) OVER (ORDER BY step_number, num_visits DESC), 0) AS DECIMAL(15,2)) AS pct_of_first_step, CAST((1.0 - num_visits * 1.0 / NULLIF(LAG(num_visits) OVER (ORDER BY step_number, num_visits DESC), 0)) * 100.0 AS DECIMAL(15,2)) AS dropoff_from_prev_pct FROM steps ORDER BY step_number, num_visits DESC`;
+    },
+  },
+  {
+    name: 'bot-traffic-share',
+    description: 'Daily bot/crawler vs human visit share with the top bot family driving crawler traffic',
+    category: 'Traffic Analytics',
+    tablesUsed: ['ccdw_aggr_visit_robot', 'ccdw_aggr_visit_user_agent', 'ccdw_dim_site'],
+    parameters: [
+      {name: 'siteId', description: 'Natural site id', type: 'string', required: true},
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'limit', description: 'Max days returned (1-500)', type: 'number', min: 1, max: 500},
+    ],
+    buildSql(params) {
+      const siteId = getStringLiteral(params, 'siteId');
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const limit = getOptionalIntegerLiteral(params, 'limit', 60, 1, 500);
+      // Robot and human (user-agent) visits live in separate daily aggregate tables;
+      // FULL OUTER JOIN on visit_date keeps days present in only one table. The top bot
+      // family per day comes from a ROW_NUMBER() ranking CTE (ua_family is nullable, so
+      // COALESCE to '(unknown)'). visit_date is CAST to VARCHAR for plain-string output.
+      return `WITH robot AS (SELECT vr.visit_date AS visit_date, SUM(vr.num_visits) AS robot_visits FROM ccdw_aggr_visit_robot vr JOIN ccdw_dim_site s ON s.site_id = vr.site_id WHERE vr.visit_date >= ${from} AND vr.visit_date <= ${to} AND s.nsite_id = ${siteId} GROUP BY vr.visit_date), human AS (SELECT vu.visit_date AS visit_date, SUM(vu.num_visits) AS human_visits FROM ccdw_aggr_visit_user_agent vu JOIN ccdw_dim_site s ON s.site_id = vu.site_id WHERE vu.visit_date >= ${from} AND vu.visit_date <= ${to} AND s.nsite_id = ${siteId} GROUP BY vu.visit_date), bot_family_ranked AS (SELECT vr.visit_date AS visit_date, COALESCE(vr.ua_family, '(unknown)') AS ua_family, COALESCE(vr.ua_os_family, '(unknown)') AS ua_os_family, ROW_NUMBER() OVER (PARTITION BY vr.visit_date ORDER BY SUM(vr.num_visits) DESC, COALESCE(vr.ua_family, '(unknown)')) AS rn FROM ccdw_aggr_visit_robot vr JOIN ccdw_dim_site s ON s.site_id = vr.site_id WHERE vr.visit_date >= ${from} AND vr.visit_date <= ${to} AND s.nsite_id = ${siteId} GROUP BY vr.visit_date, COALESCE(vr.ua_family, '(unknown)'), COALESCE(vr.ua_os_family, '(unknown)')), top_bot_family AS (SELECT visit_date, ua_family, ua_os_family FROM bot_family_ranked WHERE rn = 1) SELECT CAST(COALESCE(r.visit_date, h.visit_date) AS VARCHAR) AS visit_day, COALESCE(r.robot_visits, 0) AS robot_visits, COALESCE(h.human_visits, 0) AS human_visits, COALESCE(r.robot_visits, 0) + COALESCE(h.human_visits, 0) AS total_visits, CAST(COALESCE(r.robot_visits, 0) * 100.0 / NULLIF(COALESCE(r.robot_visits, 0) + COALESCE(h.human_visits, 0), 0) AS DECIMAL(15,2)) AS bot_share_pct, tbf.ua_family AS top_bot_family, tbf.ua_os_family AS top_bot_os_family FROM robot r FULL OUTER JOIN human h ON r.visit_date = h.visit_date LEFT JOIN top_bot_family tbf ON tbf.visit_date = COALESCE(r.visit_date, h.visit_date) ORDER BY visit_day LIMIT ${limit}`;
+    },
+  },
+  {
+    name: 'inventory-stockout-by-location',
+    description: 'Surface out-of-stock and low-stock SKUs by location for replenishment',
+    category: 'Inventory Analytics',
+    tablesUsed: ['ccdw_aggr_inventory_by_location', 'ccdw_dim_location', 'ccdw_dim_product'],
+    parameters: [
+      {name: 'from', description: 'Inclusive start date (YYYY-MM-DD)', type: 'date', required: true},
+      {name: 'to', description: 'Inclusive end date (YYYY-MM-DD)', type: 'date', required: true},
+      {
+        name: 'threshold',
+        description: 'Low-stock cutoff: available_to_order at or below this is flagged (default 10)',
+        type: 'number',
+        min: 0,
+        max: 1000000,
+      },
+      {name: 'limit', description: 'Max rows (1-500)', type: 'number', min: 1, max: 500},
+    ],
+    buildSql(params) {
+      const from = getDateLiteral(params, 'from');
+      const to = getDateLiteral(params, 'to');
+      const threshold = getOptionalIntegerLiteral(params, 'threshold', 10, 0, 1000000);
+      const limit = getOptionalIntegerLiteral(params, 'limit', 100, 1, 500);
+      // The CIP JDBC service rejects this 3-table join past ~9 projected columns
+      // (a service-side query-complexity limit; the error misleadingly names the first
+      // column). Keep the operationally essential columns and drop the surrogate id,
+      // available_to_fulfill, and soft_reserved to stay within the limit.
+      return `SELECT CAST(inv.record_date AS VARCHAR) AS record_date, l.nlocation_id AS location_id, p.nsku_id AS sku_id, p.sku_display_name, COALESCE(inv.on_hand, 0) AS on_hand, COALESCE(inv.available_to_order, 0) AS available_to_order, COALESCE(inv.reserved, 0) AS reserved, CASE WHEN COALESCE(inv.available_to_order, 0) <= 0 THEN 'out_of_stock' ELSE 'low' END AS stock_status, CAST(${threshold} - COALESCE(inv.available_to_order, 0) AS DECIMAL(15,2)) AS shortfall FROM ccdw_aggr_inventory_by_location inv JOIN ccdw_dim_location l ON l.location_id = inv.location_id JOIN ccdw_dim_product p ON p.sku_id = inv.sku_id WHERE inv.record_date >= ${from} AND inv.record_date <= ${to} AND COALESCE(inv.available_to_order, 0) <= ${threshold} ORDER BY shortfall DESC, l.nlocation_id, p.nsku_id LIMIT ${limit}`;
     },
   },
 ];

--- a/packages/b2c-tooling-sdk/src/operations/cip/sql.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cip/sql.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * Shared SQL literal and identifier helpers for CIP report and metadata queries.
+ *
+ * CIP runs an Apache Calcite (Avatica JDBC) backend. These helpers centralize the
+ * single most security-sensitive logic in the CIP subsystem — turning untrusted
+ * parameter values into safe SQL literals — plus the Calcite-specific quoting of
+ * reserved words used as identifiers. Both report SQL builders and metadata catalog
+ * queries import from here so the escaping rules live (and are tested) in one place.
+ *
+ * @module operations/cip/sql
+ */
+
+/**
+ * Apache Calcite reserved words that are also real CIP warehouse column names.
+ *
+ * Selecting or grouping by any of these as a bare identifier is a parse error; they
+ * must be double-quoted. Confirmed against the live JDBC service (for example
+ * `SELECT method FROM ...` fails until quoted). Keep lowercase; matching is
+ * case-insensitive.
+ */
+const CALCITE_RESERVED_IDENTIFIERS = new Set([
+  'date',
+  'method',
+  'rows',
+  'time',
+  'timestamp',
+  'user',
+  'value',
+  'year',
+  'month',
+  'day',
+  'hour',
+  'minute',
+  'second',
+]);
+
+/**
+ * Escapes single quotes in a value destined for a single-quoted SQL string literal.
+ *
+ * @param value - Raw string value to escape
+ * @returns The value with embedded single quotes doubled per SQL string-literal rules
+ */
+export function escapeSqlString(value: string): string {
+  return value.replaceAll("'", "''");
+}
+
+/**
+ * Quotes a SQL identifier if it collides with a Calcite reserved word.
+ *
+ * Pass a bare column name; if it is a reserved word it is returned double-quoted
+ * (for example `method` -> `"method"`), otherwise it is returned unchanged. Use this
+ * whenever a report references a column whose name might be reserved.
+ *
+ * @param name - Bare column or identifier name
+ * @returns The identifier, double-quoted only if it is a Calcite reserved word
+ */
+export function quoteIdentifierIfReserved(name: string): string {
+  return CALCITE_RESERVED_IDENTIFIERS.has(name.toLowerCase()) ? `"${name}"` : name;
+}
+
+/**
+ * Returns true if the given bare identifier is a Calcite reserved word.
+ *
+ * @param name - Bare identifier name
+ * @returns Whether the name requires double-quoting in Calcite SQL
+ */
+export function isReservedIdentifier(name: string): boolean {
+  return CALCITE_RESERVED_IDENTIFIERS.has(name.toLowerCase());
+}
+
+/**
+ * Builds a quoted, escaped SQL string literal from a raw value.
+ *
+ * @param value - Raw string value
+ * @returns A single-quoted, escaped SQL string literal (for example `O'Brien` -> `'O''Brien'`)
+ */
+export function stringLiteral(value: string): string {
+  return `'${escapeSqlString(value)}'`;
+}
+
+/**
+ * Validates a `YYYY-MM-DD` date string and returns it as a quoted SQL date literal.
+ *
+ * @param value - Date string expected in `YYYY-MM-DD` form
+ * @returns A quoted SQL date literal
+ * @throws {Error} If the value is not a valid `YYYY-MM-DD` date
+ */
+export function dateLiteral(value: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(value)) {
+    throw new Error(`Invalid date: expected YYYY-MM-DD, got "${value}"`);
+  }
+
+  return `'${escapeSqlString(value)}'`;
+}
+
+/**
+ * Validates a boolean string (`true`/`false`, case-insensitive) and returns the SQL literal.
+ *
+ * @param value - Boolean string value
+ * @returns The lowercase boolean literal `true` or `false`
+ * @throws {Error} If the value is not `true` or `false`
+ */
+export function booleanLiteral(value: string): string {
+  const normalized = value.toLowerCase();
+  if (normalized !== 'true' && normalized !== 'false') {
+    throw new Error(`Invalid boolean: expected true or false, got "${value}"`);
+  }
+
+  return normalized;
+}
+
+/**
+ * Validates and returns an integer SQL literal within an inclusive range.
+ *
+ * @param value - Raw integer string
+ * @param min - Inclusive lower bound
+ * @param max - Inclusive upper bound
+ * @returns The integer rendered as a bare SQL literal
+ * @throws {Error} If the value is not an integer within `[min, max]`
+ */
+export function integerLiteral(value: string, min: number, max: number): string {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || String(parsed) !== value.trim() || parsed < min || parsed > max) {
+    throw new Error(`Invalid integer: expected ${min}-${max}, got "${value}"`);
+  }
+
+  return String(parsed);
+}
+
+/**
+ * Builds a comma-separated, quoted string list for a SQL `IN (...)` clause.
+ *
+ * @param values - Raw string values
+ * @returns The escaped, single-quoted values joined by commas (no surrounding parens)
+ * @throws {Error} If `values` is empty
+ */
+export function stringInList(values: string[]): string {
+  if (values.length === 0) {
+    throw new Error('Cannot build an IN list from an empty value set');
+  }
+
+  return values.map((value) => stringLiteral(value)).join(', ');
+}

--- a/packages/b2c-tooling-sdk/src/operations/cip/types.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cip/types.ts
@@ -19,6 +19,24 @@ export interface CipReportParamDefinition {
   required?: boolean;
   min?: number;
   max?: number;
+  /**
+   * Allowed values for an enum-style parameter (for example `['4xx', '5xx']`).
+   * When set, {@link CipReportParamType} should be `string` and the value is
+   * validated against this set before the report's SQL builder runs.
+   */
+  options?: string[];
+  /**
+   * When true, the parameter accepts multiple comma-separated values, suitable
+   * for a SQL `IN (...)` clause. Each value is validated against `options` when
+   * both are set.
+   */
+  multiple?: boolean;
+  /**
+   * Default value applied when the parameter is omitted. For `multiple`
+   * parameters this may be a comma-separated string. Defaults are injected
+   * before validation so a report can rely on the value being present.
+   */
+  default?: string;
 }
 
 /**
@@ -30,6 +48,11 @@ export interface CipReportDefinition {
   category: string;
   parameters: CipReportParamDefinition[];
   buildSql: (params: Record<string, string>) => string;
+  /**
+   * Optional list of warehouse tables the report reads, for discoverability in
+   * `--describe` output and the report listing command. Does not affect SQL.
+   */
+  tablesUsed?: string[];
 }
 
 /**

--- a/packages/b2c-tooling-sdk/test/operations/cip/metadata.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/cip/metadata.test.ts
@@ -43,6 +43,27 @@ describe('operations/cip metadata', () => {
     expect((calls[0]?.options as {fetchSize?: number})?.fetchSize).to.equal(500);
   });
 
+  it('lists tables when the driver returns uppercase JDBC metadata labels', async () => {
+    const client = {
+      query: async () => ({
+        columns: ['TABLE_SCHEM', 'TABLE_NAME', 'TABLE_TYPE'],
+        rowCount: 2,
+        rows: [
+          {TABLE_NAME: 'ccdw_aggr_sales_summary', TABLE_SCHEM: 'warehouse', TABLE_TYPE: 'TABLE'},
+          {TABLE_NAME: 'ccdw_dim_site', TABLE_SCHEM: 'warehouse', TABLE_TYPE: 'TABLE'},
+        ],
+      }),
+    } as unknown as CipClient;
+
+    const result = await listCipTables(client, {schema: 'warehouse'});
+
+    expect(result.tableCount).to.equal(2);
+    expect(result.tables[0]?.tableSchema).to.equal('warehouse');
+    expect(result.tables[0]?.tableName).to.equal('ccdw_aggr_sales_summary');
+    expect(result.tables[0]?.tableType).to.equal('TABLE');
+    expect(result.tables[1]?.tableName).to.equal('ccdw_dim_site');
+  });
+
   it('describes table columns from metadata catalog', async () => {
     const calls: Array<{options: unknown; sql: string}> = [];
     const client = {
@@ -87,5 +108,34 @@ describe('operations/cip metadata', () => {
     expect(calls[0]?.sql).to.include("tableSchem = 'warehouse'");
     expect(calls[0]?.sql).to.include("tableName = 'ccdw_aggr_ocapi_request'");
     expect((calls[0]?.options as {fetchSize?: number})?.fetchSize).to.equal(250);
+  });
+
+  it('describes table columns when the driver returns uppercase JDBC metadata labels', async () => {
+    const client = {
+      query: async () => ({
+        columns: ['COLUMN_NAME', 'TYPE_NAME', 'IS_NULLABLE', 'ORDINAL_POSITION', 'TABLE_NAME', 'TABLE_SCHEM'],
+        rowCount: 1,
+        rows: [
+          {
+            COLUMN_NAME: 'request_date',
+            IS_NULLABLE: 'NO',
+            ORDINAL_POSITION: 1,
+            TABLE_NAME: 'ccdw_aggr_ocapi_request',
+            TABLE_SCHEM: 'warehouse',
+            TYPE_NAME: 'TIMESTAMP(3) NOT NULL',
+          },
+        ],
+      }),
+    } as unknown as CipClient;
+
+    const result = await describeCipTable(client, 'ccdw_aggr_ocapi_request', {schema: 'warehouse'});
+
+    expect(result.columnCount).to.equal(1);
+    expect(result.columns[0]?.columnName).to.equal('request_date');
+    expect(result.columns[0]?.dataType).to.equal('TIMESTAMP(3) NOT NULL');
+    expect(result.columns[0]?.isNullable).to.equal(false);
+    expect(result.columns[0]?.ordinalPosition).to.equal(1);
+    expect(result.columns[0]?.tableName).to.equal('ccdw_aggr_ocapi_request');
+    expect(result.columns[0]?.tableSchema).to.equal('warehouse');
   });
 });

--- a/packages/b2c-tooling-sdk/test/operations/cip/reports.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/cip/reports.test.ts
@@ -16,7 +16,95 @@ import type {CipClient} from '../../../src/clients/cip.js';
 describe('operations/cip', () => {
   it('lists the curated report catalog', () => {
     const reports = listCipReports();
-    expect(reports.length).to.equal(10);
+    expect(reports.length).to.equal(27);
+  });
+
+  it('exposes unique report names and non-empty categories', () => {
+    const reports = listCipReports();
+    const names = reports.map((report) => report.name);
+    expect(new Set(names).size, 'report names should be unique').to.equal(names.length);
+    for (const report of reports) {
+      expect(report.category, `category for ${report.name}`).to.be.a('string').and.not.equal('');
+      expect(report.description, `description for ${report.name}`).to.be.a('string').and.not.equal('');
+    }
+  });
+
+  it('builds valid SQL for every catalog report using representative params', () => {
+    for (const report of listCipReports()) {
+      const params: Record<string, string> = {from: '2026-01-01', to: '2026-01-31'};
+      for (const parameter of report.parameters) {
+        if (parameter.name === 'from' || parameter.name === 'to') continue;
+        if (parameter.options && parameter.options.length > 0) {
+          params[parameter.name] = parameter.options[0];
+        } else if (parameter.type === 'string') {
+          params[parameter.name] = parameter.name === 'siteId' ? 'Sites-RefArch-Site' : 'x';
+        } else if (parameter.type === 'number') {
+          params[parameter.name] = '5';
+        } else if (parameter.type === 'boolean') {
+          params[parameter.name] = 'true';
+        } else if (parameter.type === 'date') {
+          params[parameter.name] = '2026-01-15';
+        }
+      }
+
+      const {sql} = buildCipReportSql(report.name, params);
+      expect(sql, `sql for ${report.name}`).to.be.a('string').and.have.length.greaterThan(0);
+      // The query must not contain an unsubstituted placeholder.
+      expect(sql, `sql for ${report.name} has unresolved placeholder`).to.not.match(/<[A-Z_]+>/u);
+      // No bare reserved word `method` (must be double-quoted when referenced).
+      expect(sql, `sql for ${report.name} references bare reserved word`).to.not.match(/[^."]\bmethod\b/u);
+    }
+  });
+
+  it('quotes the reserved word method in SCAPI reports', () => {
+    const {sql} = buildCipReportSql('scapi-traffic-latency', {from: '2026-01-01', to: '2026-01-31'});
+    expect(sql).to.include('"method"');
+    expect(sql).to.include('ccdw_aggr_scapi_request');
+  });
+
+  it('omits the site join when siteId is not supplied for optional-site reports', () => {
+    const withoutSite = buildCipReportSql('scapi-latency-distribution', {from: '2026-01-01', to: '2026-01-31'});
+    expect(withoutSite.sql).to.not.include('ccdw_dim_site');
+    expect(withoutSite.sql).to.not.include('nsite_id');
+
+    const withSite = buildCipReportSql('scapi-latency-distribution', {
+      from: '2026-01-01',
+      to: '2026-01-31',
+      siteId: 'Sites-RefArch-Site',
+    });
+    expect(withSite.sql).to.include('JOIN ccdw_dim_site');
+    expect(withSite.sql).to.include("s.nsite_id = 'Sites-RefArch-Site'");
+  });
+
+  it('applies a statusClass enum filter when supplied', () => {
+    const filtered = buildCipReportSql('scapi-error-rate-by-status', {
+      from: '2026-01-01',
+      to: '2026-01-31',
+      statusClass: '5xx',
+    });
+    expect(filtered.sql).to.include('status_code BETWEEN 500 AND 599');
+  });
+
+  it('rejects an out-of-set enum value', () => {
+    expect(() =>
+      buildCipReportSql('scapi-error-rate-by-status', {
+        from: '2026-01-01',
+        to: '2026-01-31',
+        statusClass: '3xx',
+      }),
+    ).to.throw('Invalid value');
+  });
+
+  it('promotes the funnel drop-off division to avoid integer truncation', () => {
+    const {sql} = buildCipReportSql('checkout-funnel-dropoff', {
+      siteId: 'Sites-RefArch-Site',
+      from: '2026-01-01',
+      to: '2026-01-31',
+    });
+    // dividend promoted with * 1.0 so Calcite does not truncate the ratio
+    expect(sql).to.include('num_visits * 1.0');
+    // disambiguates parallel checkout flows by including step_name in the window order
+    expect(sql).to.include('step_name');
   });
 
   it('gets a known report by name', () => {

--- a/packages/b2c-tooling-sdk/test/operations/cip/sql.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/cip/sql.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import {expect} from 'chai';
+import {
+  booleanLiteral,
+  dateLiteral,
+  escapeSqlString,
+  integerLiteral,
+  isReservedIdentifier,
+  quoteIdentifierIfReserved,
+  stringInList,
+  stringLiteral,
+} from '../../../src/operations/cip/sql.js';
+
+describe('operations/cip sql helpers', () => {
+  describe('escapeSqlString', () => {
+    it('doubles embedded single quotes', () => {
+      expect(escapeSqlString("O'Brien")).to.equal("O''Brien");
+      expect(escapeSqlString("a'b'c")).to.equal("a''b''c");
+    });
+
+    it('leaves quote-free strings unchanged', () => {
+      expect(escapeSqlString('Sites-RefArch-Site')).to.equal('Sites-RefArch-Site');
+    });
+  });
+
+  describe('quoteIdentifierIfReserved / isReservedIdentifier', () => {
+    it('quotes Calcite reserved words case-insensitively', () => {
+      expect(quoteIdentifierIfReserved('method')).to.equal('"method"');
+      expect(quoteIdentifierIfReserved('METHOD')).to.equal('"METHOD"');
+      expect(quoteIdentifierIfReserved('date')).to.equal('"date"');
+      expect(quoteIdentifierIfReserved('value')).to.equal('"value"');
+      expect(quoteIdentifierIfReserved('year')).to.equal('"year"');
+      expect(quoteIdentifierIfReserved('user')).to.equal('"user"');
+      expect(quoteIdentifierIfReserved('rows')).to.equal('"rows"');
+    });
+
+    it('leaves non-reserved identifiers unquoted', () => {
+      expect(quoteIdentifierIfReserved('api_name')).to.equal('api_name');
+      expect(quoteIdentifierIfReserved('controller_name')).to.equal('controller_name');
+      expect(quoteIdentifierIfReserved('query')).to.equal('query');
+    });
+
+    it('reports reserved status', () => {
+      expect(isReservedIdentifier('method')).to.equal(true);
+      expect(isReservedIdentifier('api_name')).to.equal(false);
+    });
+  });
+
+  describe('stringLiteral', () => {
+    it('quotes and escapes', () => {
+      expect(stringLiteral('Sites-RefArch-Site')).to.equal("'Sites-RefArch-Site'");
+      expect(stringLiteral("O'Brien")).to.equal("'O''Brien'");
+    });
+  });
+
+  describe('dateLiteral', () => {
+    it('accepts YYYY-MM-DD', () => {
+      expect(dateLiteral('2026-05-01')).to.equal("'2026-05-01'");
+    });
+
+    it('rejects malformed dates', () => {
+      expect(() => dateLiteral('2026/05/01')).to.throw('Invalid date');
+      expect(() => dateLiteral("2026-05-01'; DROP")).to.throw('Invalid date');
+      expect(() => dateLiteral('not-a-date')).to.throw('Invalid date');
+    });
+  });
+
+  describe('booleanLiteral', () => {
+    it('accepts true/false case-insensitively', () => {
+      expect(booleanLiteral('true')).to.equal('true');
+      expect(booleanLiteral('TRUE')).to.equal('true');
+      expect(booleanLiteral('False')).to.equal('false');
+    });
+
+    it('rejects non-boolean values', () => {
+      expect(() => booleanLiteral('yes')).to.throw('Invalid boolean');
+      expect(() => booleanLiteral('1')).to.throw('Invalid boolean');
+    });
+  });
+
+  describe('integerLiteral', () => {
+    it('accepts integers within range', () => {
+      expect(integerLiteral('20', 1, 500)).to.equal('20');
+      expect(integerLiteral('1', 1, 500)).to.equal('1');
+      expect(integerLiteral('500', 1, 500)).to.equal('500');
+    });
+
+    it('rejects out-of-range, non-integer, or injection values', () => {
+      expect(() => integerLiteral('0', 1, 500)).to.throw('Invalid integer');
+      expect(() => integerLiteral('501', 1, 500)).to.throw('Invalid integer');
+      expect(() => integerLiteral('1.5', 1, 500)).to.throw('Invalid integer');
+      expect(() => integerLiteral('5; DROP', 1, 500)).to.throw('Invalid integer');
+      expect(() => integerLiteral('abc', 1, 500)).to.throw('Invalid integer');
+    });
+  });
+
+  describe('stringInList', () => {
+    it('builds an escaped, comma-separated list', () => {
+      expect(stringInList(['HIT', 'MISS'])).to.equal("'HIT', 'MISS'");
+      expect(stringInList(["a'b"])).to.equal("'a''b'");
+    });
+
+    it('throws on empty input', () => {
+      expect(() => stringInList([])).to.throw('empty');
+    });
+  });
+});

--- a/skills/b2c-cli/skills/b2c-cip/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-cip/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: b2c-cip
-description: Run analytics reports and SQL queries against B2C Commerce Intelligence data using the b2c CLI. Use this skill whenever the user needs sales analytics, search query performance metrics, payment data, or KPI exports. Also use when they need to discover available data tables, run custom SQL, or pull aggregate reports — even if they just say "show me sales data" or "what are our top search terms".
+description: Run analytics reports and SQL queries against B2C Commerce Intelligence data using the b2c CLI. Use this skill whenever the user needs sales analytics, search query performance metrics, payment data, or KPI exports, OR technical/developer analytics such as SCAPI/OCAPI request volume, API error rates, response-time/latency distributions, cache hit ratios, or SFRA controller health. Also use when they need to discover available data tables, run custom SQL, or pull aggregate reports — even if they just say "show me sales data", "what are our top search terms", or "which SCAPI endpoints are slow or erroring".
 ---
 
 # B2C CIP Skill
@@ -17,17 +17,22 @@ cip
 ├── describe <table>              - describe table columns
 ├── query                         - raw SQL execution
 └── report                        - curated report topic
-    ├── sales-analytics
-    ├── sales-summary
-    ├── ocapi-requests
-    ├── top-selling-products
-    ├── product-co-purchase-analysis
-    ├── promotion-discount-analysis
-    ├── search-query-performance
-    ├── payment-method-performance
-    ├── customer-registration-trends
-    └── top-referrers
+    ├── list                       - list the catalog grouped by category
+    ├── Sales:      sales-analytics, sales-summary, revenue-by-channel
+    ├── Technical:  ocapi-requests, ocapi-client-usage, scapi-traffic-latency,
+    │               scapi-error-rate-by-status, scapi-latency-distribution,
+    │               scapi-cache-hit-ratio, controller-health-scorecard,
+    │               controller-error-rate-trend, remote-include-performance
+    ├── Product:    top-selling-products, product-co-purchase-analysis, recommender-effectiveness
+    ├── Promotion:  promotion-discount-analysis, promotion-roi-leaderboard, discount-depth-breakdown
+    ├── Search:     search-query-performance, zero-result-searches
+    ├── Customer:   customer-registration-trends, new-vs-returning-buyer-revenue
+    ├── Payment:    payment-method-performance
+    ├── Traffic:    top-referrers, checkout-funnel-dropoff, bot-traffic-share
+    └── Inventory:  inventory-stockout-by-location
 ```
+
+Run `b2c cip report list` (or `--help`) for the live catalog; each report's exact flags come from `b2c cip report <name> --describe`.
 
 ## Configuration
 
@@ -94,8 +99,9 @@ The list is derived from official JDBC documentation and intended as a quick dis
 ## Curated Report Examples
 
 ```bash
-# Show report commands
-b2c cip report --help
+# Discover the catalog grouped by category (no credentials needed)
+b2c cip report list
+b2c cip report list --category "Technical Analytics"
 
 # Run a report (tenant resolves from config)
 b2c cip report sales-analytics \
@@ -103,7 +109,7 @@ b2c cip report sales-analytics \
   --from 2025-01-01 \
   --to 2025-01-31
 
-# Show report parameter contract
+# Show report parameter contract (flags are auto-derived per report)
 b2c cip report top-referrers --describe
 
 # Print generated SQL and stop
@@ -111,6 +117,32 @@ b2c cip report top-referrers --site-id Sites-RefArch-Site --limit 25 --sql
 
 # Force staging analytics host
 b2c cip report top-referrers --site-id Sites-RefArch-Site --limit 25 --staging --sql
+```
+
+### Technical / developer reports
+
+These analyze SCAPI, OCAPI, and SFRA controller request data. The request tables carry a
+response-time histogram (`num_requests_bucket1..11`, fastest→slowest), so the latency-distribution
+and health-scorecard reports surface the **slow-tail percentage** that a plain average hides.
+SCAPI traffic is often attributed to a headless site (or no site), so `--site-id` is optional on
+SCAPI reports — omit it to span all sites.
+
+```bash
+# SCAPI latency distribution + slow-tail %, all sites
+b2c cip report scapi-latency-distribution --from 2025-01-01 --to 2025-01-31
+
+# SCAPI endpoints ranked by 5xx error rate
+b2c cip report scapi-error-rate-by-status --from 2025-01-01 --to 2025-01-31 --status-class 5xx
+
+# SCAPI cache hit ratio (find cacheable endpoints running as MISS)
+b2c cip report scapi-cache-hit-ratio --from 2025-01-01 --to 2025-01-31
+
+# OCAPI usage per integration client_id
+b2c cip report ocapi-client-usage --from 2025-01-01 --to 2025-01-31
+
+# SFRA controller health scorecard / daily error-rate trend
+b2c cip report controller-health-scorecard --site-id Sites-RefArch-Site --from 2025-01-01 --to 2025-01-31
+b2c cip report controller-error-rate-trend --site-id Sites-RefArch-Site --from 2025-01-01 --to 2025-01-31
 ```
 
 ### SQL Pipeline Pattern


### PR DESCRIPTION
**Work items:**
- @W-22964141 — `[B2C CLI] Improve CIP Query Reports and Durability` (report catalog expansion + durability/scaffolding)
- @W-22964015 — `[B2C CLI] cip tables/describe return empty data on uppercase-label tenants` (the metadata regression bug fix)

## Summary

Three related pieces of work on the CIP (Commerce Cloud Analytics) subsystem, validated end-to-end against the live `bdpx_prd` tenant.

### 1. Bug fix — `cip tables` / `cip describe` returned empty data
The SDK metadata mapping hard-coded camelCase JDBC column labels (`tableName`). Some tenants' drivers return the standard uppercase labels (`TABLE_NAME`), producing blank rows while `tableCount` stayed correct. Metadata columns are now matched case-insensitively.

### 2. Foundation — reduce report boilerplate & harden SQL building
- **`operations/cip/sql.ts`** — shared escaping, typed literal builders, and Calcite reserved-word identifier quoting (e.g. `method` → `"method"`). De-duplicates the previously-copied escaping logic; unit-tested in isolation (the SQL-injection surface).
- **Richer param contract** — `CipReportParamDefinition` gains `options` (enum, e.g. `--status-class 4xx|5xx`), `multiple` (IN-list), and `default`, enforced centrally.
- **Data-driven CLI** — report flags are auto-derived from the catalog (`buildReportFlags`); per-report command files are now ~15-line stubs with zero bespoke logic. A generic `getReportParams()` reads flags by kebab-cased param name.
- **`b2c cip report list`** — discover the catalog grouped by category (no credentials required; `--json`, `--category`).

### 3. Catalog expansion — 10 → 27 curated reports (technical-heavy)
Every report's SQL was authored, adversarially verified against the live schema, and **executed against `bdpx_prd`** (`Sites-NTOSFRA-Site` storefront / `Sites-NTOManaged-Site` headless).

**Technical Analytics** (built on the SCAPI/OCAPI/controller request tables and their `num_requests_bucket1..11` latency histogram):
`scapi-traffic-latency`, `scapi-error-rate-by-status`, `scapi-latency-distribution` (slow-tail/SLA %), `scapi-cache-hit-ratio`, `ocapi-client-usage`, `controller-health-scorecard`, `controller-error-rate-trend`, `remote-include-performance`.

**Other categories:** `revenue-by-channel`, `new-vs-returning-buyer-revenue`, `discount-depth-breakdown`, `promotion-roi-leaderboard`, `recommender-effectiveness`, `zero-result-searches`, `checkout-funnel-dropoff`, `bot-traffic-share`, `inventory-stockout-by-location`.

## Notes from live validation
- **SCAPI `site_id` is nullable** and traffic is attributed to the headless site — so `--site-id` is optional on SCAPI reports (omit to span all sites).
- **CIP service query-complexity limit:** wide projections fail with a misleading `column "<alias>" does not exist`; `recommender-effectiveness` and `inventory-stockout-by-location` SQL were trimmed to stay within it.
- **Mixed test data:** `ccdw_aggr_visit_checkout` on the test tenant runs two parallel checkout implementations with colliding step numbers; `checkout-funnel-dropoff` uses `* 1.0` to avoid integer-division truncation and orders by `(step_number, step_name)`, but step-over-step drop-off is only meaningful on a single-implementation storefront (documented).

## Testing
- SDK: 1769 passing. CLI: 1344 passing (53 new tests incl. one per new report + the list command).
- `lint:agent` clean; `typecheck:agent` clean for affected packages.
- Live smoke-tested each report category through the built CLI.
- Docs (`docs/cli/cip.md`) and the `b2c-cip` agent skill updated; changesets added.