### PR TITLE
feat(mcp): deprecate Storefront Next sfnext_* tools

### DIFF
--- a/.changeset/deprecate-storefront-next-mcp-tools.md
+++ b/.changeset/deprecate-storefront-next-mcp-tools.md
@@ -1,0 +1,8 @@
+---
+'@salesforce/b2c-dx-mcp': minor
+'@salesforce/b2c-dx-docs': patch
+---
+
+Deprecate the Storefront Next MCP tools (`sfnext_*`) in favor of the `storefront-next` and `storefront-next-figma` agent-skills plugins. These tools are not compatible with the Storefront Next 1.0 GA release and will be removed in a future release.
+
+The six `sfnext_*` tools have moved to a new `STOREFRONTNEXT_DEPRECATED` toolset that is never auto-enabled by project detection and is excluded from `--toolsets all`. To keep using them, request the toolset explicitly: `--toolsets STOREFRONTNEXT_DEPRECATED --allow-non-ga-tools`. Storefront Next projects still auto-enable the `STOREFRONTNEXT` toolset (MRT bundle push, SCAPI discovery/scaffolding, and diagnostics). Migrate to the agent-skills plugins — see the Agent Skills guide for installation.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -160,7 +160,7 @@ const referenceSidebar = [
         ],
       },
       {
-        text: 'Storefront Next',
+        text: 'Storefront Next (deprecated)',
         collapsed: true,
         items: [
           {text: 'sfnext_get_guidelines', link: '/mcp/tools/sfnext-get-guidelines'},

--- a/docs/mcp/configuration.md
+++ b/docs/mcp/configuration.md
@@ -114,6 +114,8 @@ Override auto-discovery with `--toolsets` or `SFCC_TOOLSETS`:
 
 **Available toolsets:** `CARTRIDGES`, `MRT`, `PWAV3`, `SCAPI`, `STOREFRONTNEXT`, `all`
 
+**Deprecated toolset:** `STOREFRONTNEXT_DEPRECATED` holds the legacy `sfnext_*` tools, which are not compatible with the Storefront Next 1.0 GA release and are superseded by the [`storefront-next`/`storefront-next-figma` agent-skills plugins](../guide/agent-skills). It is **never auto-enabled** and **not included in `all`** — request it explicitly with `--toolsets STOREFRONTNEXT_DEPRECATED --allow-non-ga-tools`. See [Toolsets](./toolsets#storefrontnext-deprecated).
+
 With auto-discovery, the `SCAPI` toolset is always included. When using `--toolsets` or `--tools`, only the specified toolsets/tools are enabled.
 
 ### Individual Tool Selection

--- a/docs/mcp/figma-tools-setup.md
+++ b/docs/mcp/figma-tools-setup.md
@@ -4,6 +4,10 @@ description: Prerequisites and setup for Figma-to-component tools (workflow orch
 
 # Figma-to-Component Tools Setup
 
+::: warning DEPRECATED — use the agent-skills plugins instead
+The Figma workflow MCP tools described on this page are **deprecated** and **not compatible with the Storefront Next 1.0 GA release**. They have been superseded by the [`storefront-next` and `storefront-next-figma`](../guide/agent-skills) agent-skills plugins, which stay current with the GA release. They now live in the opt-in [`STOREFRONTNEXT_DEPRECATED`](./toolsets#storefrontnext-deprecated) toolset and **will be removed in a future release**. For Figma design-kit workflows, install the [`storefront-next-figma` plugin](../guide/agent-skills) instead.
+:::
+
 Prerequisites and setup for using the Figma workflow tools: `sfnext_start_figma_workflow`, `sfnext_analyze_component`, and `sfnext_match_tokens_to_theme`.
 
 ## Overview

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -29,12 +29,16 @@ The server analyzes your project directory and enables toolsets based on what it
 
 With auto-discovery, the **SCAPI** toolset is always included. Hybrid projects (e.g., cartridges + PWA Kit) get combined toolsets. You can also [manually select toolsets](./configuration#toolset-selection).
 
+::: warning Storefront Next `sfnext_*` tools are deprecated
+The legacy Storefront Next MCP tools (`sfnext_*`) are **not compatible with the Storefront Next 1.0 GA release** and have been superseded by the [`storefront-next` and `storefront-next-figma` agent-skills plugins](../guide/agent-skills). They no longer auto-enable for Storefront Next projects and have moved to the opt-in [`STOREFRONTNEXT_DEPRECATED`](./toolsets#storefrontnext-deprecated) toolset. Install the skills plugins instead — see the [Agent Skills guide](../guide/agent-skills).
+:::
+
 ## Prompting Tips
 
 > ⚠️ **Explicitly mention "Use the MCP tool"** in your prompts for reliable tool usage. This ensures the assistant prioritizes MCP tools over general knowledge.
 
 **Examples:**
-- "I'm new to Storefront Next. **Use the MCP tool** to show me the critical rules I need to know."
+- "**Use the MCP tool** to build and push my Storefront Next bundle to staging."
 - "**Use the MCP tool** to list all available SCAPI schemas."
 - "**Use the MCP tool** to deploy my cartridges to the sandbox instance."
 - "**Use the MCP tool** to build and push my Storefront Next bundle to staging."

--- a/docs/mcp/tools/sfnext-add-page-designer-decorator.md
+++ b/docs/mcp/tools/sfnext-add-page-designer-decorator.md
@@ -4,6 +4,10 @@ description: Add Page Designer decorators to React components for Storefront Nex
 
 # sfnext_add_page_designer_decorator
 
+::: warning DEPRECATED — use the agent-skills plugins instead
+This tool is **deprecated** and **not compatible with the Storefront Next 1.0 GA release**. It has been superseded by the [`storefront-next` and `storefront-next-figma`](../../guide/agent-skills) agent-skills plugins, which stay current with the GA release. It now lives in the opt-in [`STOREFRONTNEXT_DEPRECATED`](../toolsets#storefrontnext-deprecated) toolset (never auto-enabled, excluded from `--toolsets ALL`) and **will be removed in a future release**. Install the skills plugins instead — see the [Agent Skills guide](../../guide/agent-skills).
+:::
+
 Adds Page Designer decorators (`@Component`, `@AttributeDefinition`, `@RegionDefinition`) to React components to make them available in Page Designer for Storefront Next.
 
 ## Overview

--- a/docs/mcp/tools/sfnext-analyze-component.md
+++ b/docs/mcp/tools/sfnext-analyze-component.md
@@ -4,6 +4,10 @@ description: Analyze design and discovered components to recommend REUSE, EXTEND
 
 # sfnext_analyze_component
 
+::: warning DEPRECATED — use the agent-skills plugins instead
+This tool is **deprecated** and **not compatible with the Storefront Next 1.0 GA release**. It has been superseded by the [`storefront-next` and `storefront-next-figma`](../../guide/agent-skills) agent-skills plugins, which stay current with the GA release. It now lives in the opt-in [`STOREFRONTNEXT_DEPRECATED`](../toolsets#storefrontnext-deprecated) toolset (never auto-enabled, excluded from `--toolsets ALL`) and **will be removed in a future release**. Install the skills plugins instead — see the [Agent Skills guide](../../guide/agent-skills).
+:::
+
 Analyzes design and discovered components to recommend a component generation strategy. Returns a REUSE, EXTEND, or CREATE action with confidence score, key differences, and suggested implementation approach.
 
 ## Overview

--- a/docs/mcp/tools/sfnext-configure-theme.md
+++ b/docs/mcp/tools/sfnext-configure-theme.md
@@ -4,6 +4,10 @@ description: Get theming guidelines, guided questions, and WCAG color contrast v
 
 # sfnext_configure_theme
 
+::: warning DEPRECATED — use the agent-skills plugins instead
+This tool is **deprecated** and **not compatible with the Storefront Next 1.0 GA release**. It has been superseded by the [`storefront-next` and `storefront-next-figma`](../../guide/agent-skills) agent-skills plugins, which stay current with the GA release. It now lives in the opt-in [`STOREFRONTNEXT_DEPRECATED`](../toolsets#storefrontnext-deprecated) toolset (never auto-enabled, excluded from `--toolsets ALL`) and **will be removed in a future release**. Install the skills plugins instead — see the [Agent Skills guide](../../guide/agent-skills).
+:::
+
 Guides theming changes (colors, fonts, visual styling) for Storefront Next and validates color combinations for WCAG accessibility.
 
 ## Overview

--- a/docs/mcp/tools/sfnext-get-guidelines.md
+++ b/docs/mcp/tools/sfnext-get-guidelines.md
@@ -4,6 +4,10 @@ description: Get Storefront Next development guidelines and best practices for R
 
 # sfnext_get_guidelines
 
+::: warning DEPRECATED — use the agent-skills plugins instead
+This tool is **deprecated** and **not compatible with the Storefront Next 1.0 GA release**. It has been superseded by the [`storefront-next` and `storefront-next-figma`](../../guide/agent-skills) agent-skills plugins, which stay current with the GA release. It now lives in the opt-in [`STOREFRONTNEXT_DEPRECATED`](../toolsets#storefrontnext-deprecated) toolset (never auto-enabled, excluded from `--toolsets ALL`) and **will be removed in a future release**. Install the skills plugins instead — see the [Agent Skills guide](../../guide/agent-skills).
+:::
+
 Returns critical architecture rules, coding standards, and best practices for building Storefront Next applications with React Server Components.
 
 ## Overview

--- a/docs/mcp/tools/sfnext-match-tokens-to-theme.md
+++ b/docs/mcp/tools/sfnext-match-tokens-to-theme.md
@@ -4,6 +4,10 @@ description: Match Figma design tokens to existing theme tokens in app.css with 
 
 # sfnext_match_tokens_to_theme
 
+::: warning DEPRECATED — use the agent-skills plugins instead
+This tool is **deprecated** and **not compatible with the Storefront Next 1.0 GA release**. It has been superseded by the [`storefront-next` and `storefront-next-figma`](../../guide/agent-skills) agent-skills plugins, which stay current with the GA release. It now lives in the opt-in [`STOREFRONTNEXT_DEPRECATED`](../toolsets#storefrontnext-deprecated) toolset (never auto-enabled, excluded from `--toolsets ALL`) and **will be removed in a future release**. Install the skills plugins instead — see the [Agent Skills guide](../../guide/agent-skills).
+:::
+
 Matches Figma design tokens (colors, spacing, radius, etc.) to your Storefront Next theme tokens in `app.css`. Helps you identify which design tokens match existing theme variables and suggests new token names for values that don't have matches.
 
 ## Overview

--- a/docs/mcp/tools/sfnext-start-figma-workflow.md
+++ b/docs/mcp/tools/sfnext-start-figma-workflow.md
@@ -4,6 +4,10 @@ description: Workflow orchestrator for Figma-to-component conversion. Parses you
 
 # sfnext_start_figma_workflow
 
+::: warning DEPRECATED — use the agent-skills plugins instead
+This tool is **deprecated** and **not compatible with the Storefront Next 1.0 GA release**. It has been superseded by the [`storefront-next` and `storefront-next-figma`](../../guide/agent-skills) agent-skills plugins, which stay current with the GA release. It now lives in the opt-in [`STOREFRONTNEXT_DEPRECATED`](../toolsets#storefrontnext-deprecated) toolset (never auto-enabled, excluded from `--toolsets ALL`) and **will be removed in a future release**. Install the skills plugins instead — see the [Agent Skills guide](../../guide/agent-skills).
+:::
+
 Workflow orchestrator for converting Figma designs to Storefront Next components. Provide a Figma design URL to start the workflow, which extracts design data, analyzes your codebase, and produces component recommendations.
 
 ## Overview

--- a/docs/mcp/toolsets.md
+++ b/docs/mcp/toolsets.md
@@ -4,7 +4,7 @@ description: Available toolsets and tools in the B2C DX MCP Server for SCAPI, CA
 
 # Toolsets & Tools
 
-The B2C DX MCP Server provides six toolsets with specialized tools for different B2C Commerce development workflows.
+The B2C DX MCP Server provides six toolsets with specialized tools for different B2C Commerce development workflows, plus one deprecated toolset retained for backward compatibility.
 
 
 ## Overview
@@ -17,7 +17,10 @@ Toolsets are collections of related tools that work together to support specific
 - [MRT](#mrt) - Managed Runtime bundle operations
 - [PWAV3](#pwav3) - PWA Kit v3 development tools
 - [SCAPI](#scapi) - Salesforce Commerce API discovery
-- [STOREFRONTNEXT](#storefrontnext) - Storefront Next development tools
+- [STOREFRONTNEXT](#storefrontnext) - Storefront Next development support (MRT, SCAPI, cartridges)
+
+**Deprecated toolset:**
+- [STOREFRONTNEXT_DEPRECATED](#storefrontnext-deprecated) - Legacy `sfnext_*` tools, superseded by the [`storefront-next`/`storefront-next-figma` agent-skills plugins](../guide/agent-skills). Opt-in only; never auto-enabled and excluded from `--toolsets ALL`.
 
 **Note:** With auto-discovery, the `SCAPI` and `DIAGNOSTICS` toolsets are always included. When using `--toolsets` or `--tools`, only the specified toolsets/tools are enabled.
 
@@ -118,11 +121,38 @@ Salesforce Commerce API discovery and exploration.
 
 ## STOREFRONTNEXT
 
-Storefront Next development tools for building modern storefronts.
+Storefront Next development support.
 
-**Status:** 🚧 Preview — requires `--allow-non-ga-tools` flag.
+**Status:** ✅ Generally Available
 
 **Auto-enabled for:** Storefront Next projects (detected by `@salesforce/storefront-next*` dependencies, package name starting with `storefront-next`, or workspace packages with these indicators)
+
+When a Storefront Next project is detected, the server enables `MRT` and `CARTRIDGES` (plus the base `SCAPI` and `DIAGNOSTICS` toolsets), giving you `mrt_bundle_push`, SCAPI discovery/scaffolding, and the shared diagnostics tools. The legacy `sfnext_*` tools have moved to the deprecated [STOREFRONTNEXT_DEPRECATED](#storefrontnext-deprecated) toolset (see below) — use the agent-skills plugins instead.
+
+### Tools
+
+| Tool | Description | Documentation |
+|------|-------------|---------------|
+| [`mrt_bundle_push`](./tools/mrt-bundle-push) | Build, push bundle (optionally deploy) | [View details](./tools/mrt-bundle-push) |
+| [`scapi_schemas_list`](./tools/scapi-schemas-list) | List or fetch SCAPI schemas (standard and custom). Use apiFamily: "custom" for custom APIs. | [View details](./tools/scapi-schemas-list) |
+| [`scapi_custom_api_generate_scaffold`](./tools/scapi-custom-api-generate-scaffold) | Generate a new custom SCAPI endpoint (schema, api.json, script.js) in an existing cartridge. | [View details](./tools/scapi-custom-api-generate-scaffold) |
+| [`scapi_custom_apis_get_status`](./tools/scapi-custom-apis-get-status) | Get registration status of custom API endpoints (active/not_registered). Remote only, requires OAuth. | [View details](./tools/scapi-custom-apis-get-status) |
+
+## STOREFRONTNEXT_DEPRECATED
+
+::: warning DEPRECATED — use the agent-skills plugins instead
+The `sfnext_*` MCP tools below are **deprecated** and **not compatible with the Storefront Next 1.0 GA release**. They have been superseded by the [`storefront-next`](../guide/agent-skills) and [`storefront-next-figma`](../guide/agent-skills) agent-skills plugins, which are kept up to date with the GA release. **These tools will be removed in a future release.**
+
+Migrate to the skills plugins — see the [Agent Skills guide](../guide/agent-skills) for installation. This toolset is **never auto-enabled** and is **excluded from `--toolsets ALL`**; to use it you must request it explicitly _and_ pass `--allow-non-ga-tools`:
+
+```json
+{ "args": ["--toolsets", "STOREFRONTNEXT_DEPRECATED", "--allow-non-ga-tools"] }
+```
+:::
+
+**Status:** ⛔ Deprecated — opt-in only, requires `--allow-non-ga-tools`.
+
+**Auto-enabled for:** Never. Must be explicitly requested via `--toolsets STOREFRONTNEXT_DEPRECATED`.
 
 ### Tools
 
@@ -134,12 +164,6 @@ Storefront Next development tools for building modern storefronts.
 | [`sfnext_match_tokens_to_theme`](./tools/sfnext-match-tokens-to-theme) | Map design tokens to existing theme tokens in app.css with confidence scores and suggestions | [View details](./tools/sfnext-match-tokens-to-theme) |
 | [`sfnext_add_page_designer_decorator`](./tools/sfnext-add-page-designer-decorator) | Add Page Designer decorators to Storefront Next components | [View details](./tools/sfnext-add-page-designer-decorator) |
 | [`sfnext_configure_theme`](./tools/sfnext-configure-theme) | Get theming guidelines, questions, and WCAG color validation for Storefront Next | [View details](./tools/sfnext-configure-theme) |
-| [`scapi_schemas_list`](./tools/scapi-schemas-list) | List or fetch SCAPI schemas (standard and custom). Use apiFamily: "custom" for custom APIs. | [View details](./tools/scapi-schemas-list) |
-| [`scapi_custom_api_generate_scaffold`](./tools/scapi-custom-api-generate-scaffold) | Generate a new custom SCAPI endpoint (schema, api.json, script.js) in an existing cartridge. | [View details](./tools/scapi-custom-api-generate-scaffold) |
-| [`scapi_custom_apis_get_status`](./tools/scapi-custom-apis-get-status) | Get registration status of custom API endpoints (active/not_registered). Remote only, requires OAuth. | [View details](./tools/scapi-custom-apis-get-status) |
-| [`mrt_bundle_push`](./tools/mrt-bundle-push) | Build, push bundle (optionally deploy) | [View details](./tools/mrt-bundle-push) |
-
-**Figma-to-component tools** (`sfnext_start_figma_workflow`, `sfnext_analyze_component`, `sfnext_match_tokens_to_theme`) require additional setup: an external Figma MCP server and a valid Figma URL with `node-id`. See [Figma-to-Component Tools Setup](./figma-tools-setup) for prerequisites and configuration.
 
 ## Tool Deduplication
 

--- a/packages/b2c-dx-mcp/CONTRIBUTING.md
+++ b/packages/b2c-dx-mcp/CONTRIBUTING.md
@@ -65,6 +65,12 @@ npx mcp-inspector --cli node bin/dev.js --toolsets all --allow-non-ga-tools --me
 # Call a specific tool
 npx mcp-inspector --cli node bin/dev.js --toolsets all --allow-non-ga-tools \
   --method tools/call \
+  --tool-name cartridge_deploy
+
+# Deprecated sfnext_* tools are excluded from `--toolsets all`; request the
+# deprecated toolset explicitly to exercise them
+npx mcp-inspector --cli node bin/dev.js --toolsets STOREFRONTNEXT_DEPRECATED --allow-non-ga-tools \
+  --method tools/call \
   --tool-name sfnext_add_page_designer_decorator
 ```
 

--- a/packages/b2c-dx-mcp/README.md
+++ b/packages/b2c-dx-mcp/README.md
@@ -80,8 +80,11 @@ See the [Configuration Guide](https://salesforcecommercecloud.github.io/b2c-deve
 | CARTRIDGES | `cartridge_deploy` | [toolsets#cartridges](https://salesforcecommercecloud.github.io/b2c-developer-tooling/mcp/toolsets#cartridges) |
 | MRT | `mrt_bundle_push` | [toolsets#mrt](https://salesforcecommercecloud.github.io/b2c-developer-tooling/mcp/toolsets#mrt) |
 | SCAPI | `scapi_schemas_list`, `scapi_custom_apis_get_status`, `scapi_custom_api_generate_scaffold` | [toolsets#scapi](https://salesforcecommercecloud.github.io/b2c-developer-tooling/mcp/toolsets#scapi) |
-| STOREFRONTNEXT | `sfnext_get_guidelines`, `sfnext_add_page_designer_decorator`, `sfnext_configure_theme`, `sfnext_start_figma_workflow`, `sfnext_analyze_component`, `sfnext_match_tokens_to_theme` | [toolsets#storefrontnext](https://salesforcecommercecloud.github.io/b2c-developer-tooling/mcp/toolsets#storefrontnext) |
+| STOREFRONTNEXT | `mrt_bundle_push` + SCAPI tools (auto-enabled for Storefront Next projects) | [toolsets#storefrontnext](https://salesforcecommercecloud.github.io/b2c-developer-tooling/mcp/toolsets#storefrontnext) |
+| STOREFRONTNEXT_DEPRECATED ⛔ | `sfnext_get_guidelines`, `sfnext_add_page_designer_decorator`, `sfnext_configure_theme`, `sfnext_start_figma_workflow`, `sfnext_analyze_component`, `sfnext_match_tokens_to_theme` — **deprecated, see note below** | [toolsets#storefrontnext-deprecated](https://salesforcecommercecloud.github.io/b2c-developer-tooling/mcp/toolsets#storefrontnext-deprecated) |
 | PWAV3 | `pwakit_get_guidelines` + SCAPI tools | [toolsets#pwav3](https://salesforcecommercecloud.github.io/b2c-developer-tooling/mcp/toolsets#pwav3) |
+
+> **⛔ `sfnext_*` tools are deprecated.** The Storefront Next MCP tools are **not compatible with the Storefront Next 1.0 GA release** and have been superseded by the [`storefront-next` and `storefront-next-figma` agent-skills plugins](https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/agent-skills), which stay current with the GA release. They have moved to the `STOREFRONTNEXT_DEPRECATED` toolset, which is **never auto-enabled** and **excluded from `--toolsets all`**; to use them you must request the toolset explicitly (`--toolsets STOREFRONTNEXT_DEPRECATED --allow-non-ga-tools`). They will be removed in a future release.
 
 ### cartridge_deploy
 
@@ -117,6 +120,10 @@ Generate new custom SCAPI endpoint in a cartridge. [Details](https://salesforcec
 
 - "Use the MCP tool to scaffold a new custom API named my-products."
 - "Use the MCP tool to create a custom admin API called customer-trips."
+
+## Deprecated: Storefront Next (`sfnext_*`) tools
+
+> **⛔ Deprecated and not compatible with the Storefront Next 1.0 GA release.** The tools below have been superseded by the [`storefront-next` and `storefront-next-figma` agent-skills plugins](https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/agent-skills) and will be removed in a future release. They no longer auto-enable for Storefront Next projects and are excluded from `--toolsets all`; to use them, request `--toolsets STOREFRONTNEXT_DEPRECATED --allow-non-ga-tools`. Migrate to the skills plugins.
 
 ### sfnext_get_guidelines
 

--- a/packages/b2c-dx-mcp/src/registry.ts
+++ b/packages/b2c-dx-mcp/src/registry.ts
@@ -7,7 +7,7 @@
 import {getLogger} from '@salesforce/b2c-tooling-sdk/logging';
 import {detectWorkspaceType, type ProjectType} from '@salesforce/b2c-tooling-sdk/discovery';
 import type {McpTool, Toolset, StartupFlags} from './utils/index.js';
-import {ALL_TOOLSETS, TOOLSETS, VALID_TOOLSET_NAMES} from './utils/index.js';
+import {ALL_TOOLSETS, DEPRECATED_TOOLSETS, TOOLSETS, VALID_TOOLSET_NAMES} from './utils/index.js';
 import type {B2CDxMcpServer} from './server.js';
 import type {Services} from './services.js';
 import type {ServerContext} from './server-context.js';
@@ -34,6 +34,9 @@ const BASE_TOOLSETS: Toolset[] = ['SCAPI', 'DIAGNOSTICS'];
 const PROJECT_TYPE_TOOLSETS: Record<ProjectType, Toolset[]> = {
   cartridges: ['CARTRIDGES'],
   'pwa-kit-v3': ['PWAV3', 'MRT'],
+  // Note: STOREFRONTNEXT_DEPRECATED is intentionally NOT auto-activated. The
+  // legacy sfnext_* tools are superseded by the storefront-next agent-skills
+  // plugins and must be explicitly requested via --toolsets.
   'storefront-next': ['STOREFRONTNEXT', 'MRT', 'CARTRIDGES'],
 };
 
@@ -97,6 +100,7 @@ export function createToolRegistry(
     PWAV3: [],
     SCAPI: [],
     STOREFRONTNEXT: [],
+    STOREFRONTNEXT_DEPRECATED: [],
   };
 
   // Collect all tools from all factories
@@ -233,9 +237,14 @@ export async function registerToolsets(
     );
   }
 
-  // Determine which toolsets to enable
+  // Determine which toolsets to enable.
+  // `ALL` expands to every toolset EXCEPT deprecated ones — deprecated toolsets
+  // must always be named explicitly.
   const validToolsets = toolsets.filter((t): t is Toolset => TOOLSETS.includes(t as Toolset));
-  const toolsetsToEnable = new Set<Toolset>(toolsets.includes(ALL_TOOLSETS) ? TOOLSETS : validToolsets);
+  const allNonDeprecatedToolsets = TOOLSETS.filter(
+    (t) => !DEPRECATED_TOOLSETS.includes(t as (typeof DEPRECATED_TOOLSETS)[number]),
+  );
+  const toolsetsToEnable = new Set<Toolset>(toolsets.includes(ALL_TOOLSETS) ? allNonDeprecatedToolsets : validToolsets);
 
   // Auto-discovery: If no valid toolsets AND no valid individual tools, detect workspace type.
   // This handles both: (1) no flags provided, and (2) all provided flags are invalid.

--- a/packages/b2c-dx-mcp/src/tools/storefrontnext/figma/figma-to-component/index.ts
+++ b/packages/b2c-dx-mcp/src/tools/storefrontnext/figma/figma-to-component/index.ts
@@ -339,6 +339,7 @@ export function createFigmaToComponentTool(loadServices: () => Promise<Services>
     {
       name: 'sfnext_start_figma_workflow',
       description:
+        '[DEPRECATED] Superseded by the storefront-next and storefront-next-figma agent-skills plugins and NOT compatible with the Storefront Next 1.0 GA release. Will be removed in a future release. ' +
         'WORKFLOW ORCHESTRATOR: Call this tool FIRST when converting Figma designs. ' +
         'Parses Figma URL to extract fileKey and nodeId, returns step-by-step workflow instructions ' +
         'and parameters for subsequent tool calls. ' +
@@ -346,7 +347,7 @@ export function createFigmaToComponentTool(loadServices: () => Promise<Services>
         'the complete workflow: 1) Call Figma MCP tools, 2) Discover similar components, ' +
         '3) Call sfnext_analyze_component tool, 4) Call sfnext_match_tokens_to_theme tool, ' +
         '5) Show both outputs to the user then implement the recommended approach.',
-      toolsets: ['STOREFRONTNEXT'],
+      toolsets: ['STOREFRONTNEXT_DEPRECATED'],
       isGA: false,
       requiresInstance: false,
       inputSchema: figmaToComponentSchema.shape,

--- a/packages/b2c-dx-mcp/src/tools/storefrontnext/figma/generate-component/index.ts
+++ b/packages/b2c-dx-mcp/src/tools/storefrontnext/figma/generate-component/index.ts
@@ -136,13 +136,14 @@ export function createGenerateComponentTool(loadServices: () => Promise<Services
     {
       name: 'sfnext_analyze_component',
       description:
+        '[DEPRECATED] Superseded by the storefront-next and storefront-next-figma agent-skills plugins and NOT compatible with the Storefront Next 1.0 GA release. Will be removed in a future release. ' +
         'Analyzes Figma design and discovered components to recommend component generation strategy. ' +
         'Workflow: 1) Discover similar components using Glob/Grep/Read tools, ' +
         '2) Call this tool with the discoveredComponents parameter, ' +
         '3) Tool analyzes differences and recommends REUSE/EXTEND/CREATE action, ' +
         '4) Tool provides formatted recommendation with code examples and workflow steps. ' +
         'Call this tool AFTER retrieving Figma design data and discovering similar components.',
-      toolsets: ['STOREFRONTNEXT'],
+      toolsets: ['STOREFRONTNEXT_DEPRECATED'],
       isGA: false,
       requiresInstance: false,
       inputSchema: generateComponentSchema.shape,

--- a/packages/b2c-dx-mcp/src/tools/storefrontnext/figma/map-tokens/index.ts
+++ b/packages/b2c-dx-mcp/src/tools/storefrontnext/figma/map-tokens/index.ts
@@ -262,12 +262,13 @@ export function createMapTokensToThemeTool(loadServices: () => Promise<Services>
     {
       name: 'sfnext_match_tokens_to_theme',
       description:
+        '[DEPRECATED] Superseded by the storefront-next and storefront-next-figma agent-skills plugins and NOT compatible with the Storefront Next 1.0 GA release. Will be removed in a future release. ' +
         'Maps Figma design tokens to existing StorefrontNext theme tokens in app.css. ' +
         'Analyzes Figma design tokens (colors, spacing, radius, etc.) and finds exact matches, ' +
         'provides fuzzy matches with confidence scores, suggests new token names for unmatched values, ' +
         'and recommends where to add new tokens in the CSS file. ' +
         'Use this tool after retrieving design variables from Figma MCP to ensure components use theme tokens instead of hardcoded values.',
-      toolsets: ['STOREFRONTNEXT'],
+      toolsets: ['STOREFRONTNEXT_DEPRECATED'],
       isGA: false,
       requiresInstance: false,
       inputSchema: mapTokensToThemeSchema.shape,

--- a/packages/b2c-dx-mcp/src/tools/storefrontnext/index.ts
+++ b/packages/b2c-dx-mcp/src/tools/storefrontnext/index.ts
@@ -5,9 +5,15 @@
  */
 
 /**
- * Storefront Next toolset for B2C Commerce.
+ * Storefront Next (deprecated) toolset for B2C Commerce.
  *
- * This toolset provides MCP tools for Storefront Next development.
+ * **DEPRECATED:** These `sfnext_*` tools are superseded by the `storefront-next`
+ * and `storefront-next-figma` agent-skills plugins and are NOT compatible with
+ * the Storefront Next 1.0 GA release. They now live in the
+ * `STOREFRONTNEXT_DEPRECATED` toolset, which is never auto-activated by project
+ * detection and is excluded from `--toolsets ALL`. To use them you must request
+ * the toolset explicitly (`--toolsets STOREFRONTNEXT_DEPRECATED`). They will be
+ * removed in a future release.
  *
  * **Implemented Tools:**
  * - `sfnext_get_guidelines` - Get development guidelines and best practices
@@ -16,8 +22,6 @@
  * - `sfnext_start_figma_workflow` - Convert Figma to components
  * - `sfnext_analyze_component` - Analyze design and recommend REUSE/EXTEND/CREATE
  * - `sfnext_match_tokens_to_theme` - Match design tokens to theme
- *
- * Note: mrt_bundle_push is defined in the MRT toolset and appears in STOREFRONTNEXT.
  *
  * @module tools/storefrontnext
  */
@@ -32,11 +36,7 @@ import {createGenerateComponentTool} from './figma/generate-component/index.js';
 import {createMapTokensToThemeTool} from './figma/map-tokens/index.js';
 
 /**
- * Creates all tools for the STOREFRONTNEXT toolset.
- *
- * Note: mrt_bundle_push is defined in the MRT toolset with
- * toolsets: ["MRT", "PWAV3", "STOREFRONTNEXT"] and will
- * automatically appear in STOREFRONTNEXT.
+ * Creates all tools for the deprecated STOREFRONTNEXT_DEPRECATED toolset.
  *
  * @param loadServices - Function that loads configuration and returns Services instance
  * @returns Array of MCP tools

--- a/packages/b2c-dx-mcp/src/tools/storefrontnext/page-designer-decorator/index.ts
+++ b/packages/b2c-dx-mcp/src/tools/storefrontnext/page-designer-decorator/index.ts
@@ -632,6 +632,7 @@ export function createPageDesignerDecoratorTool(loadServices: () => Promise<Serv
     name: 'sfnext_add_page_designer_decorator',
 
     description:
+      '[DEPRECATED] Superseded by the storefront-next and storefront-next-figma agent-skills plugins and NOT compatible with the Storefront Next 1.0 GA release. Will be removed in a future release. ' +
       'Adds Page Designer decorators (@Component, @AttributeDefinition, @RegionDefinition) to React components. ' +
       'Two modes: autoMode=true for quick setup with defaults, or interactive mode via conversationContext.step. ' +
       'Component discovery uses --project-directory flag or SFCC_PROJECT_DIRECTORY env var. ' +
@@ -639,7 +640,7 @@ export function createPageDesignerDecoratorTool(loadServices: () => Promise<Serv
       'Interactive mode: multi-step workflow (analyze → select_props → configure_attrs → configure_regions → confirm_generation).',
 
     inputSchema: pageDesignerDecoratorSchema.shape as ZodRawShape,
-    toolsets: ['STOREFRONTNEXT'],
+    toolsets: ['STOREFRONTNEXT_DEPRECATED'],
     isGA: false,
 
     async handler(args: Record<string, unknown>) {

--- a/packages/b2c-dx-mcp/src/tools/storefrontnext/sfnext-development-guidelines.ts
+++ b/packages/b2c-dx-mcp/src/tools/storefrontnext/sfnext-development-guidelines.ts
@@ -108,13 +108,14 @@ export function createDeveloperGuidelinesTool(loadServices: () => Promise<Servic
     {
       name: 'sfnext_get_guidelines',
       description:
+        '[DEPRECATED] Superseded by the storefront-next and storefront-next-figma agent-skills plugins and NOT compatible with the Storefront Next 1.0 GA release. Will be removed in a future release. ' +
         'ESSENTIAL FIRST STEP for Storefront Next development. Returns critical architecture rules, coding standards, and best practices. ' +
         'Use this tool FIRST before writing any Storefront Next code to understand non-negotiable patterns for React Server Components, ' +
         'data loading, and framework constraints. Returns comprehensive guidelines by default (quick-reference + key sections); ' +
         'supports retrieving specific topic sections. ' +
         'CRITICAL INSTRUCTION: ALWAYS present ALL returned content in FULL - DO NOT SUMMARIZE, DO NOT ADD SUMMARIES, ' +
         'DO NOT ADD OVERVIEWS. The returned content IS the complete answer - display it exactly as provided.',
-      toolsets: ['STOREFRONTNEXT'],
+      toolsets: ['STOREFRONTNEXT_DEPRECATED'],
       isGA: false,
       requiresInstance: false,
       inputSchema: {

--- a/packages/b2c-dx-mcp/src/tools/storefrontnext/site-theming/index.ts
+++ b/packages/b2c-dx-mcp/src/tools/storefrontnext/site-theming/index.ts
@@ -46,6 +46,7 @@ export function createSiteThemingTool(loadServices: () => Promise<Services> | Se
     {
       name: 'sfnext_configure_theme',
       description:
+        '[DEPRECATED] Superseded by the storefront-next and storefront-next-figma agent-skills plugins and NOT compatible with the Storefront Next 1.0 GA release. Will be removed in a future release. ' +
         '⚠️ MANDATORY: Call this tool FIRST before implementing any theming changes. ' +
         'Provides theming guidelines, questions, and automatic validation. ' +
         'CRITICAL RULES: Call immediately when user requests theming (even if colors/fonts provided). ' +
@@ -55,7 +56,7 @@ export function createSiteThemingTool(loadServices: () => Promise<Services> | Se
         'DEFAULT FILES: theming-questions, theming-validation, theming-accessibility. ' +
         'Use fileKeys to add custom files. ' +
         'WORKFLOW: Call tool → Ask questions → Call with colorMapping (validation) → Present findings → Wait confirmation → Implement',
-      toolsets: ['STOREFRONTNEXT'],
+      toolsets: ['STOREFRONTNEXT_DEPRECATED'],
       isGA: false,
       requiresInstance: false,
       inputSchema: {

--- a/packages/b2c-dx-mcp/src/utils/constants.ts
+++ b/packages/b2c-dx-mcp/src/utils/constants.ts
@@ -12,7 +12,27 @@ export const ALL_TOOLSETS = 'ALL';
 /**
  * Available toolsets that can be enabled.
  */
-export const TOOLSETS = ['CARTRIDGES', 'DIAGNOSTICS', 'MRT', 'PWAV3', 'SCAPI', 'STOREFRONTNEXT'] as const;
+export const TOOLSETS = [
+  'CARTRIDGES',
+  'DIAGNOSTICS',
+  'MRT',
+  'PWAV3',
+  'SCAPI',
+  'STOREFRONTNEXT',
+  'STOREFRONTNEXT_DEPRECATED',
+] as const;
+
+/**
+ * Deprecated toolsets. These can only be enabled by explicitly naming them via
+ * `--toolsets`; they are never auto-activated by project detection and are NOT
+ * included when `--toolsets ALL` is used.
+ *
+ * `STOREFRONTNEXT_DEPRECATED` holds the legacy `sfnext_*` MCP tools. They are
+ * superseded by the `storefront-next` and `storefront-next-figma` agent-skills
+ * plugins and are not compatible with the Storefront Next 1.0 GA release. They
+ * will be removed in a future release.
+ */
+export const DEPRECATED_TOOLSETS = ['STOREFRONTNEXT_DEPRECATED'] as const;
 
 /**
  * Valid toolset names including the special "ALL" value.

--- a/packages/b2c-dx-mcp/test/e2e/mcp-e2e.test.ts
+++ b/packages/b2c-dx-mcp/test/e2e/mcp-e2e.test.ts
@@ -95,6 +95,27 @@ describe('MCP Server E2E', function () {
       await client.stop();
     });
 
+    it('excludes deprecated sfnext_* tools from --toolsets all', async () => {
+      const client = new McpE2EClient({args: ['--toolsets', 'all', '--allow-non-ga-tools']});
+      await client.start();
+      const result = (await client.call('tools/list')) as {tools: Array<{name: string}>};
+      const names = result.tools.map((t) => t.name);
+      expect(names.some((n) => n.startsWith('sfnext_'))).to.be.false;
+      await client.stop();
+    });
+
+    it('registers deprecated sfnext_* tools only when STOREFRONTNEXT_DEPRECATED is requested', async () => {
+      const client = new McpE2EClient({
+        args: ['--toolsets', 'STOREFRONTNEXT_DEPRECATED', '--allow-non-ga-tools'],
+      });
+      await client.start();
+      const result = (await client.call('tools/list')) as {tools: Array<{name: string}>};
+      const names = result.tools.map((t) => t.name);
+      expect(names).to.include('sfnext_get_guidelines');
+      expect(names).to.include('sfnext_add_page_designer_decorator');
+      await client.stop();
+    });
+
     it('filters tools by individual tool name', async () => {
       const client = new McpE2EClient({
         args: ['--tools', 'scapi_schemas_list,scapi_custom_apis_get_status', '--allow-non-ga-tools'],
@@ -207,7 +228,11 @@ describe('MCP Server E2E', function () {
       await client.start();
       const result = (await client.call('tools/list')) as {tools: Array<{name: string}>};
       const names = result.tools.map((t) => t.name);
-      expect(names.some((n) => n.includes('sfnext') || n.includes('scapi'))).to.be.true;
+      // Storefront Next auto-discovery enables the shared GA tools...
+      expect(names).to.include('mrt_bundle_push');
+      expect(names.some((n) => n.startsWith('scapi_'))).to.be.true;
+      // ...but NOT the deprecated sfnext_* tools, which are opt-in only.
+      expect(names.some((n) => n.startsWith('sfnext_'))).to.be.false;
       await client.stop();
     });
 

--- a/packages/b2c-dx-mcp/test/registry.test.ts
+++ b/packages/b2c-dx-mcp/test/registry.test.ts
@@ -42,6 +42,7 @@ describe('registry', () => {
       expect(registry).to.have.property('PWAV3');
       expect(registry).to.have.property('SCAPI');
       expect(registry).to.have.property('STOREFRONTNEXT');
+      expect(registry).to.have.property('STOREFRONTNEXT_DEPRECATED');
     });
 
     it('should create CARTRIDGES tools', () => {
@@ -89,7 +90,7 @@ describe('registry', () => {
       expect(toolNames).to.include('scapi_custom_api_generate_scaffold');
     });
 
-    it('should create STOREFRONTNEXT tools', () => {
+    it('should create STOREFRONTNEXT tools (shared GA tools only; sfnext_* are deprecated)', () => {
       const loadServices = createMockLoadServicesWrapper();
       const registry = createToolRegistry(loadServices);
 
@@ -97,10 +98,28 @@ describe('registry', () => {
       expect(registry.STOREFRONTNEXT.length).to.be.greaterThan(0);
 
       const toolNames = registry.STOREFRONTNEXT.map((t) => t.name);
+      // mrt_bundle_push and scapi tools appear in STOREFRONTNEXT (multi-toolset, GA)
+      expect(toolNames).to.include('mrt_bundle_push');
+      expect(toolNames).to.include('scapi_schemas_list');
+      // The legacy sfnext_* tools have moved to STOREFRONTNEXT_DEPRECATED
+      expect(toolNames).to.not.include('sfnext_get_guidelines');
+      expect(toolNames).to.not.include('sfnext_add_page_designer_decorator');
+    });
+
+    it('should create STOREFRONTNEXT_DEPRECATED tools (legacy sfnext_* tools)', () => {
+      const loadServices = createMockLoadServicesWrapper();
+      const registry = createToolRegistry(loadServices);
+
+      expect(registry.STOREFRONTNEXT_DEPRECATED).to.be.an('array');
+      expect(registry.STOREFRONTNEXT_DEPRECATED.length).to.be.greaterThan(0);
+
+      const toolNames = registry.STOREFRONTNEXT_DEPRECATED.map((t) => t.name);
       expect(toolNames).to.include('sfnext_get_guidelines');
       expect(toolNames).to.include('sfnext_add_page_designer_decorator');
-      // mrt_bundle_push should also appear in STOREFRONTNEXT (multi-toolset)
-      expect(toolNames).to.include('mrt_bundle_push');
+      expect(toolNames).to.include('sfnext_configure_theme');
+      expect(toolNames).to.include('sfnext_start_figma_workflow');
+      expect(toolNames).to.include('sfnext_analyze_component');
+      expect(toolNames).to.include('sfnext_match_tokens_to_theme');
     });
 
     it('should assign correct toolsets to each tool', () => {
@@ -123,6 +142,9 @@ describe('registry', () => {
       for (const tool of registry.STOREFRONTNEXT) {
         expect(tool.toolsets).to.include('STOREFRONTNEXT');
       }
+      for (const tool of registry.STOREFRONTNEXT_DEPRECATED) {
+        expect(tool.toolsets).to.include('STOREFRONTNEXT_DEPRECATED');
+      }
     });
 
     it('registered tool handlers are invokable end-to-end', async () => {
@@ -131,8 +153,8 @@ describe('registry', () => {
       // Uses sfnext_get_guidelines (pure, no network/services needed).
       const loadServices = createMockLoadServicesWrapper();
       const registry = createToolRegistry(loadServices);
-      const tool = registry.STOREFRONTNEXT.find((t) => t.name === 'sfnext_get_guidelines');
-      expect(tool, 'sfnext_get_guidelines must be registered in STOREFRONTNEXT').to.not.be.undefined;
+      const tool = registry.STOREFRONTNEXT_DEPRECATED.find((t) => t.name === 'sfnext_get_guidelines');
+      expect(tool, 'sfnext_get_guidelines must be registered in STOREFRONTNEXT_DEPRECATED').to.not.be.undefined;
 
       const result = await tool!.handler({sections: ['quick-reference']});
       expect(result).to.have.property('content');
@@ -222,11 +244,55 @@ describe('registry', () => {
       const loadServices = createMockLoadServicesWrapper();
       await registerToolsets(flags, server, loadServices);
 
-      // Should include tools from all toolsets (placeholder tools removed)
+      // Should include tools from all non-deprecated toolsets (placeholder tools removed)
       expect(server.registeredTools).to.include('cartridge_deploy');
       expect(server.registeredTools).to.include('mrt_bundle_push');
       expect(server.registeredTools).to.include('scapi_schemas_list');
+      // ALL excludes the deprecated toolset — sfnext_* tools must NOT be registered
+      expect(server.registeredTools).to.not.include('sfnext_get_guidelines');
+      expect(server.registeredTools).to.not.include('sfnext_add_page_designer_decorator');
+    });
+
+    it('should NOT register deprecated toolset tools when ALL is specified', async () => {
+      const server = createMockServer();
+      const flags: StartupFlags = {
+        toolsets: ['ALL'],
+        allowNonGaTools: true,
+      };
+
+      const loadServices = createMockLoadServicesWrapper();
+      await registerToolsets(flags, server, loadServices);
+
+      // The deprecated toolset is opt-in only and excluded from ALL.
+      for (const toolName of [
+        'sfnext_get_guidelines',
+        'sfnext_add_page_designer_decorator',
+        'sfnext_configure_theme',
+        'sfnext_start_figma_workflow',
+        'sfnext_analyze_component',
+        'sfnext_match_tokens_to_theme',
+      ]) {
+        expect(server.registeredTools).to.not.include(toolName);
+      }
+    });
+
+    it('should register deprecated tools only when STOREFRONTNEXT_DEPRECATED is explicitly requested', async () => {
+      const server = createMockServer();
+      const flags: StartupFlags = {
+        toolsets: ['STOREFRONTNEXT_DEPRECATED'],
+        allowNonGaTools: true,
+      };
+
+      const loadServices = createMockLoadServicesWrapper();
+      await registerToolsets(flags, server, loadServices);
+
+      // All legacy sfnext_* tools should be registered when explicitly requested
       expect(server.registeredTools).to.include('sfnext_get_guidelines');
+      expect(server.registeredTools).to.include('sfnext_add_page_designer_decorator');
+      expect(server.registeredTools).to.include('sfnext_configure_theme');
+      expect(server.registeredTools).to.include('sfnext_start_figma_workflow');
+      expect(server.registeredTools).to.include('sfnext_analyze_component');
+      expect(server.registeredTools).to.include('sfnext_match_tokens_to_theme');
     });
 
     it('should register individual tools via --tools flag', async () => {
@@ -348,15 +414,15 @@ describe('registry', () => {
     it('should skip non-GA tools when allowNonGaTools is false', async () => {
       const server = createMockServer();
       const flags: StartupFlags = {
-        toolsets: ['STOREFRONTNEXT'],
+        toolsets: ['STOREFRONTNEXT_DEPRECATED'],
         allowNonGaTools: false,
       };
 
       const loadServices = createMockLoadServicesWrapper();
       await registerToolsets(flags, server, loadServices);
 
-      // STOREFRONTNEXT-only tools are non-GA (isGA: false), so they should be skipped.
-      // Multi-toolset GA tools (mrt_bundle_push, scapi_*) that appear in STOREFRONTNEXT are still registered.
+      // The deprecated sfnext_* tools are non-GA (isGA: false), so even when the
+      // deprecated toolset is explicitly requested they are skipped without --allow-non-ga-tools.
       const sfnextOnlyTools = ['sfnext_get_guidelines', 'sfnext_add_page_designer_decorator'];
       for (const toolName of sfnextOnlyTools) {
         expect(server.registeredTools).to.not.include(toolName);

--- a/packages/b2c-dx-mcp/test/tools/storefrontnext/page-designer-decorator/index.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/storefrontnext/page-designer-decorator/index.test.ts
@@ -158,9 +158,9 @@ describe('tools/storefrontnext/page-designer-decorator', () => {
       expect(desc).to.include('@AttributeDefinition');
     });
 
-    it('should be in STOREFRONTNEXT toolset', () => {
+    it('should be in STOREFRONTNEXT_DEPRECATED toolset', () => {
       const tool = createPageDesignerDecoratorTool(getServices);
-      expect(tool.toolsets).to.include('STOREFRONTNEXT');
+      expect(tool.toolsets).to.include('STOREFRONTNEXT_DEPRECATED');
       expect(tool.toolsets).to.have.lengthOf(1);
     });
 

--- a/packages/b2c-dx-mcp/test/tools/storefrontnext/sfnext-development-guidelines.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/storefrontnext/sfnext-development-guidelines.test.ts
@@ -65,8 +65,14 @@ describe('tools/storefrontnext/sfnext-development-guidelines', () => {
       expect(desc).to.match(/comprehensive|quick reference/i);
 
       // Should be reasonably short (optimized for LLM consumption)
-      // Note: Description includes critical instructions, so slightly longer than ideal
-      expect(desc.length).to.be.lessThan(650);
+      // Note: Description includes critical instructions plus a deprecation
+      // notice prefix, so slightly longer than ideal.
+      expect(desc.length).to.be.lessThan(900);
+    });
+
+    it('should carry a deprecation notice', () => {
+      const tool = createDeveloperGuidelinesTool(() => services);
+      expect(tool.description).to.include('[DEPRECATED]');
     });
 
     it('should list all sections in inputSchema description', () => {
@@ -105,8 +111,9 @@ describe('tools/storefrontnext/sfnext-development-guidelines', () => {
       const desc = tool.description;
 
       // Main description should be concise, not list all topics
-      // Note: Description includes critical instructions, so slightly longer than ideal
-      expect(desc.length).to.be.lessThan(650);
+      // Note: Description includes critical instructions plus a deprecation
+      // notice prefix, so slightly longer than ideal.
+      expect(desc.length).to.be.lessThan(900);
 
       // Main description focuses on WHEN and WHY
       expect(desc).to.include('ESSENTIAL FIRST STEP');
@@ -116,9 +123,9 @@ describe('tools/storefrontnext/sfnext-development-guidelines', () => {
       // This keeps main description scannable for LLMs while providing full detail where needed
     });
 
-    it('should be in STOREFRONTNEXT toolset', () => {
+    it('should be in STOREFRONTNEXT_DEPRECATED toolset', () => {
       const tool = createDeveloperGuidelinesTool(() => services);
-      expect(tool.toolsets).to.include('STOREFRONTNEXT');
+      expect(tool.toolsets).to.include('STOREFRONTNEXT_DEPRECATED');
       expect(tool.toolsets).to.have.lengthOf(1);
     });
 

--- a/packages/b2c-dx-mcp/test/tools/storefrontnext/site-theming/index.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/storefrontnext/site-theming/index.test.ts
@@ -60,9 +60,9 @@ describe('tools/storefrontnext/site-theming', () => {
       expect(tool.handler).to.be.a('function');
     });
 
-    it('should be in STOREFRONTNEXT toolset', () => {
+    it('should be in STOREFRONTNEXT_DEPRECATED toolset', () => {
       const tool = createSiteThemingTool(createMockLoadServices(services));
-      expect(tool.toolsets).to.include('STOREFRONTNEXT');
+      expect(tool.toolsets).to.include('STOREFRONTNEXT_DEPRECATED');
     });
   });
 

--- a/skills/eval/eval_lib.py
+++ b/skills/eval/eval_lib.py
@@ -33,7 +33,12 @@ def find_eval_project() -> Path:
     """
     eval_dir = Path(__file__).resolve().parent
     project_dir = eval_dir / "project"
-    if project_dir.is_dir() and (project_dir / ".claude").is_dir():
+    # Detect the eval project by a stable, committed marker (dw.json).
+    # The .claude/skills/ dir is gitignored and created here at runtime, so
+    # it must not be used as the guard — otherwise a fresh checkout silently
+    # falls back to the main repo root and no skills get installed.
+    if project_dir.is_dir() and (project_dir / "dw.json").is_file():
+        (project_dir / ".claude").mkdir(exist_ok=True)
         _ensure_git_repo(project_dir)
         _sync_skills(eval_dir, project_dir)
         return project_dir


### PR DESCRIPTION
## Summary

Deprecates the Storefront Next MCP tools (`sfnext_*`) in favor of the `storefront-next` and `storefront-next-figma` agent-skills plugins. These tools are **not compatible with the Storefront Next 1.0 GA release** and will be removed in a future release.

- The six `sfnext_*` tools move from `STOREFRONTNEXT` into a new **`STOREFRONTNEXT_DEPRECATED`** toolset.
- That toolset is **never auto-activated** by project detection and is **excluded from `--toolsets all`** — it must be requested explicitly (`--toolsets STOREFRONTNEXT_DEPRECATED --allow-non-ga-tools`).
- **Storefront detection and the `STOREFRONTNEXT` toolset are kept**: detected SFNext projects still auto-enable `STOREFRONTNEXT`, which now holds the shared GA tools (`mrt_bundle_push`, SCAPI discovery/scaffolding, diagnostics) plus MRT + CARTRIDGES.
- Each `sfnext_*` tool description now carries a `[DEPRECATED]` notice citing the 1.0 GA incompatibility and pointing to the skills plugins.

## Docs

Deprecation messaging added across every surface: the toolsets reference (split GA vs deprecated section with warning banner), all six individual tool pages, the Figma setup page, the configuration page, the MCP landing page, the package README, the contributor guide, and the sidebar nav.

## Also included

Fixes the skills eval harness (`skills/eval/eval_lib.py`): project setup was gated on the gitignored `.claude/` dir, so on a fresh checkout it silently fell back to the main repo and installed no skills — making every should-trigger eval score 0. Now keys off the committed `dw.json` marker.