### PR TITLE
@W-22850150 ci: drop Node 26 from the Windows test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,13 @@ jobs:
         # in src/win/fs-event.c during chokidar's recursive watch tests.
         # Revisit when upstream Node ships a fix.
         #
-        # Node 26 is floating (26.x) here; this job is continue-on-error so any
-        # Windows-specific 26 regression surfaces without blocking CI. Pin it
-        # like 24 above if it hits the same libuv/chokidar assertion.
-        node-version: [22.x, 24.15.0, 26.x]
+        # Node 26 is intentionally absent from the Windows matrix: every 26.x
+        # release ships the same broken libuv (1.52.1) and aborts with that
+        # fs-event.c assertion during chokidar's recursive watch tests, so
+        # there is no 26.x to pin to (unlike 24, where 24.15.0 is safe). Node
+        # 26 is exercised on the Linux matrix above; add it back here once
+        # upstream libuv ships a fix.
+        node-version: [22.x, 24.15.0]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Follow-up to #499. Removes `26.x` from the **Windows** CI matrix only — Node 26 stays on the Linux matrix (where it's fully green) and in the dev/CLI toolchain.

## Why

After #499 merged, the `test-windows (26.x)` job failed with:

```
Assertion failed: !_wcsnicmp(filename, dir, dirlen), file src\win\fs-event.c, line 72
```

This is a **libuv/chokidar bug**, not a regression from the mocha 11 / tsx / yargs work:

- It's the **same assertion** that already pinned Windows Node 24 to `24.15.0` (see the existing matrix comment).
- It lives in **libuv 1.52.1**, which ships in **every** Node 26.x release (26.0.0–26.3.0), so — unlike Node 24, where 24.15.0 is safe — there is **no 26.x version to pin to**.
- It fires from `chokidar`'s recursive watch tests (`src/operations/code/watch.ts`), is **Windows-only**, and aborts the process before tests finish (exit 255, 0% coverage).
- **Linux Node 26 passes** in #499, proving the actual toolchain changes work on Node 26.

The `test-windows` job is `continue-on-error: true` (advisory), so this never blocked merges — but leaving a permanent red X is misleading. Dropping 26.x from the Windows matrix (with a comment explaining why) keeps CI signal honest. Add it back once upstream libuv ships a fix.

## Change

- `.github/workflows/ci.yml`: Windows matrix `[22.x, 24.15.0, 26.x]` → `[22.x, 24.15.0]`, with an updated comment. Linux matrix unchanged (`[22.x, 24.x, 26.x]`).