### PR TITLE
@W-23018754: [MRT] Surface deploy warnings (x86 deprecation notice) on push/deploy

### DIFF
--- a/.changeset/x86-deprecation-warning.md
+++ b/.changeset/x86-deprecation-warning.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/b2c-cli': patch
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+Surface Managed Runtime deploy warnings (including the x86 environment deprecation notice) when pushing or deploying a bundle. The warning is informational and does not block the deploy.

--- a/packages/b2c-cli/src/commands/mrt/bundle/deploy.ts
+++ b/packages/b2c-cli/src/commands/mrt/bundle/deploy.ts
@@ -206,6 +206,8 @@ export default class MrtBundleDeploy extends MrtCommand<typeof MrtBundleDeploy> 
         }
       }
 
+      for (const w of result.warnings ?? []) this.warn(w);
+
       if (this.flags.wait) {
         return this.waitForDeployment(project, environment);
       }
@@ -283,6 +285,8 @@ export default class MrtBundleDeploy extends MrtCommand<typeof MrtBundleDeploy> 
           },
         ),
       );
+
+      for (const w of result.warnings ?? []) this.warn(w);
 
       if (this.flags.wait) {
         if (!target) {

--- a/packages/b2c-cli/test/commands/mrt/bundle/deploy.test.ts
+++ b/packages/b2c-cli/test/commands/mrt/bundle/deploy.test.ts
@@ -106,6 +106,40 @@ describe('mrt bundle deploy', () => {
       expect(result.bundleId).to.equal(123);
     });
 
+    it('prints warnings returned by pushBundle', async () => {
+      const command = createCommand();
+      const warning = 'x86 support ends January 31, 2027. Switch to ARM in environment settings to avoid disruptions';
+
+      stubParse(
+        command,
+        {project: 'my-project', environment: 'staging', 'build-dir': 'dist', 'ssr-param': [], wait: false},
+        {},
+      );
+      await command.init();
+
+      stubCommonAuth(command);
+      sinon.stub(command, 'jsonEnabled').returns(true);
+      sinon.stub(command, 'log').returns(void 0);
+      const warnStub = sinon.stub(command, 'warn').returns(void 0);
+      sinon
+        .stub(command, 'resolvedConfig')
+        .get(() => ({values: {mrtProject: 'my-project', mrtEnvironment: 'staging', mrtOrigin: 'https://example.com'}}));
+
+      const pushStub = sinon.stub().resolves({
+        bundleId: 123,
+        deployed: true,
+        message: 'Test push',
+        projectSlug: 'my-project',
+        target: 'staging',
+        warnings: [warning],
+      } as any);
+      command.operations = {...command.operations, pushBundle: pushStub};
+
+      await command.run();
+
+      expect(warnStub.calledWith(warning)).to.equal(true);
+    });
+
     it('throws error when ssr-param has invalid format', async () => {
       const command = createCommand();
 
@@ -193,6 +227,34 @@ describe('mrt bundle deploy', () => {
       expect(input.targetSlug).to.equal('staging');
       expect(input.bundleId).to.equal(12_345);
       expect(result.bundleId).to.equal(12_345);
+    });
+
+    it('prints warnings returned by createDeployment', async () => {
+      const command = createCommand();
+      const warning = 'x86 support ends January 31, 2027. Switch to ARM in environment settings to avoid disruptions';
+
+      stubParse(command, {project: 'my-project', environment: 'staging', wait: false}, {bundleId: 12_345});
+      await command.init();
+
+      stubCommonAuth(command);
+      sinon.stub(command, 'jsonEnabled').returns(true);
+      sinon.stub(command, 'log').returns(void 0);
+      const warnStub = sinon.stub(command, 'warn').returns(void 0);
+      sinon
+        .stub(command, 'resolvedConfig')
+        .get(() => ({values: {mrtProject: 'my-project', mrtEnvironment: 'staging', mrtOrigin: 'https://example.com'}}));
+
+      const deployStub = sinon.stub().resolves({
+        bundleId: 12_345,
+        targetSlug: 'staging',
+        status: 'pending',
+        warnings: [warning],
+      } as any);
+      command.operations = {...command.operations, createDeployment: deployStub};
+
+      await command.run();
+
+      expect(warnStub.calledWith(warning)).to.equal(true);
     });
   });
 

--- a/packages/b2c-tooling-sdk/src/operations/mrt/deployment.ts
+++ b/packages/b2c-tooling-sdk/src/operations/mrt/deployment.ts
@@ -189,6 +189,12 @@ export interface CreateDeploymentResult {
    * Initial deployment status.
    */
   status: string;
+
+  /**
+   * Non-blocking warnings returned by MRT for this deployment (e.g. x86 deprecation).
+   * Optional — absent if the deploy endpoint returns no warnings.
+   */
+  warnings?: string[];
 }
 
 /**
@@ -229,7 +235,7 @@ export async function createDeployment(
 
   const client = createMrtClient({origin: origin || DEFAULT_MRT_ORIGIN}, auth);
 
-  const {error} = await client.POST('/api/projects/{project_slug}/target/{target_slug}/deploy/', {
+  const {data, error} = await client.POST('/api/projects/{project_slug}/target/{target_slug}/deploy/', {
     params: {
       path: {project_slug: projectSlug, target_slug: targetSlug},
     },
@@ -246,11 +252,18 @@ export async function createDeployment(
     throw new Error(`Failed to create deployment: ${errorMessage}`);
   }
 
+  // Defensive: the deploy endpoint response shape is not strongly typed and may not
+  // include `warnings`; default to [] so nothing breaks. We return these for the caller
+  // (e.g. the CLI) to surface — we don't log them here, to avoid double-printing.
+  const deployData = (data ?? {}) as {warnings?: string[]};
+  const warnings = deployData.warnings ?? [];
+
   logger.debug({bundleId}, '[MRT] Deployment created');
 
   return {
     bundleId,
     targetSlug,
     status: 'pending',
+    warnings,
   };
 }

--- a/packages/b2c-tooling-sdk/src/operations/mrt/push.ts
+++ b/packages/b2c-tooling-sdk/src/operations/mrt/push.ts
@@ -62,6 +62,11 @@ export interface PushResult {
    * The bundle message.
    */
   message: string;
+
+  /**
+   * Non-blocking warnings returned by MRT for this push/deploy (e.g. x86 deprecation).
+   */
+  warnings?: string[];
 }
 
 /**
@@ -170,6 +175,7 @@ export async function uploadBundle(
       target,
       deployed: true,
       message: bundle.message,
+      warnings: buildData.warnings ?? [],
     };
   } else {
     logger.debug({projectSlug}, '[MRT] Uploading bundle (no deployment)');
@@ -196,15 +202,14 @@ export async function uploadBundle(
 
     const buildData = data as unknown as BuildPushResponse;
 
-    buildData.warnings.forEach((warning: string) => {
-      logger.warn(warning);
-    });
-
+    // Return warnings for the caller (e.g. the CLI) to surface — we don't log them
+    // here, to avoid double-printing.
     return {
       bundleId: buildData.bundle_id,
       projectSlug,
       deployed: false,
       message: bundle.message,
+      warnings: buildData.warnings ?? [],
     };
   }
 }

--- a/packages/b2c-tooling-sdk/test/operations/mrt/deployment.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/mrt/deployment.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {expect} from 'chai';
+import {http, HttpResponse} from 'msw';
+import {setupServer} from 'msw/node';
+import {DEFAULT_MRT_ORIGIN} from '../../../src/clients/mrt.js';
+import {createDeployment} from '../../../src/operations/mrt/deployment.js';
+import {MockAuthStrategy} from '../../helpers/mock-auth.js';
+
+const DEFAULT_BASE_URL = DEFAULT_MRT_ORIGIN;
+
+describe('operations/mrt/deployment', () => {
+  const server = setupServer();
+
+  before(() => {
+    server.listen({onUnhandledRequest: 'error'});
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  describe('createDeployment', () => {
+    it('starts a deployment for an existing bundle', async () => {
+      let receivedBody: {bundle_id?: number} | undefined;
+
+      server.use(
+        http.post(`${DEFAULT_BASE_URL}/api/projects/:projectSlug/target/:targetSlug/deploy/`, async ({request}) => {
+          receivedBody = (await request.json()) as {bundle_id?: number};
+          return HttpResponse.json({}, {status: 202});
+        }),
+      );
+
+      const auth = new MockAuthStrategy();
+      const result = await createDeployment({projectSlug: 'my-project', targetSlug: 'staging', bundleId: 123}, auth);
+
+      expect(receivedBody?.bundle_id).to.equal(123);
+      expect(result.bundleId).to.equal(123);
+      expect(result.targetSlug).to.equal('staging');
+      expect(result.status).to.equal('pending');
+      expect(result.warnings).to.deep.equal([]);
+    });
+
+    it('returns warnings from the deploy response', async () => {
+      const warning = 'x86 support ends January 31, 2027. Switch to ARM in environment settings to avoid disruptions';
+
+      server.use(
+        http.post(`${DEFAULT_BASE_URL}/api/projects/:projectSlug/target/:targetSlug/deploy/`, () => {
+          return HttpResponse.json({warnings: [warning]}, {status: 202});
+        }),
+      );
+
+      const auth = new MockAuthStrategy();
+      const result = await createDeployment({projectSlug: 'my-project', targetSlug: 'staging', bundleId: 123}, auth);
+
+      expect(result.warnings).to.deep.equal([warning]);
+    });
+
+    it('defaults warnings to [] when the response has no body', async () => {
+      server.use(
+        http.post(`${DEFAULT_BASE_URL}/api/projects/:projectSlug/target/:targetSlug/deploy/`, () => {
+          return new HttpResponse(null, {status: 204});
+        }),
+      );
+
+      const auth = new MockAuthStrategy();
+      const result = await createDeployment({projectSlug: 'my-project', targetSlug: 'staging', bundleId: 123}, auth);
+
+      expect(result.warnings).to.deep.equal([]);
+    });
+
+    it('throws on deploy failure', async () => {
+      server.use(
+        http.post(`${DEFAULT_BASE_URL}/api/projects/:projectSlug/target/:targetSlug/deploy/`, () => {
+          return HttpResponse.json({message: 'Target not found'}, {status: 404});
+        }),
+      );
+
+      const auth = new MockAuthStrategy();
+      try {
+        await createDeployment({projectSlug: 'my-project', targetSlug: 'invalid', bundleId: 123}, auth);
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect((error as Error).message).to.include('Failed to create deployment');
+      }
+    });
+  });
+});

--- a/packages/b2c-tooling-sdk/test/operations/mrt/push.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/mrt/push.test.ts
@@ -65,12 +65,36 @@ describe('operations/mrt/push', () => {
       expect(result.deployed).to.be.false;
       expect(result.target).to.be.undefined;
       expect(result.message).to.equal('Test bundle');
+      expect(result.warnings).to.deep.equal([]);
 
       expect(receivedBody).to.deep.include({
         message: 'Test bundle',
         encoding: 'base64',
         data: 'dGVzdC1kYXRh',
       });
+    });
+
+    it('returns warnings from the no-target upload response', async () => {
+      const warning = 'x86 support ends January 31, 2027. Switch to ARM in environment settings to avoid disruptions';
+
+      server.use(
+        http.post(`${DEFAULT_BASE_URL}/api/projects/:projectSlug/builds/`, () => {
+          return HttpResponse.json({
+            bundle_id: 123,
+            message: 'Bundle created',
+            url: 'https://runtime.commercecloud.com/...',
+            bundle_preview_url: null,
+            warnings: [warning],
+          });
+        }),
+      );
+
+      const auth = new MockAuthStrategy();
+      const client = createMrtClient({}, auth);
+
+      const result = await uploadBundle(client, 'my-project', testBundle);
+
+      expect(result.warnings).to.deep.equal([warning]);
     });
 
     it('uploads bundle with deployment to target', async () => {
@@ -100,6 +124,7 @@ describe('operations/mrt/push', () => {
       expect(result.projectSlug).to.equal('my-project');
       expect(result.deployed).to.be.true;
       expect(result.target).to.equal('staging');
+      expect(result.warnings).to.deep.equal([]);
       expect(targetSlug).to.equal('staging');
 
       expect(receivedBody).to.deep.include({
@@ -107,6 +132,49 @@ describe('operations/mrt/push', () => {
         ssr_only: ['ssr.js'],
         ssr_shared: ['static/index.html', 'static/app.js'],
       });
+    });
+
+    it('returns warnings from the with-target deploy response', async () => {
+      const warning = 'x86 support ends January 31, 2027. Switch to ARM in environment settings to avoid disruptions';
+
+      server.use(
+        http.post(`${DEFAULT_BASE_URL}/api/projects/:projectSlug/builds/:targetSlug/`, () => {
+          return HttpResponse.json({
+            bundle_id: 456,
+            message: 'Bundle created and deployed',
+            url: 'https://runtime.commercecloud.com/...',
+            bundle_preview_url: null,
+            warnings: [warning],
+          });
+        }),
+      );
+
+      const auth = new MockAuthStrategy();
+      const client = createMrtClient({}, auth);
+
+      const result = await uploadBundle(client, 'my-project', testBundle, 'staging');
+
+      expect(result.warnings).to.deep.equal([warning]);
+    });
+
+    it('defaults warnings to [] when the response omits the field', async () => {
+      server.use(
+        http.post(`${DEFAULT_BASE_URL}/api/projects/:projectSlug/builds/:targetSlug/`, () => {
+          return HttpResponse.json({
+            bundle_id: 789,
+            message: 'Bundle created and deployed',
+            url: 'https://runtime.commercecloud.com/...',
+            bundle_preview_url: null,
+          });
+        }),
+      );
+
+      const auth = new MockAuthStrategy();
+      const client = createMrtClient({}, auth);
+
+      const result = await uploadBundle(client, 'my-project', testBundle, 'staging');
+
+      expect(result.warnings).to.deep.equal([]);
     });
 
     it('throws error on upload failure without target', async () => {


### PR DESCRIPTION
## Summary

The MRT backend returns a non-blocking `warnings[]` array on build/deploy responses (for example, the upcoming x86 environment deprecation notice: _"x86 support ends January 31, 2027. Switch to ARM in environment settings to avoid disruptions"_). The shared SDK dropped these warnings on the deploy paths, and `PushResult` had no field to carry them, so `b2c mrt bundle deploy` never surfaced them to the user.

This PR threads those warnings from the SDK through to the CLI, informationally and **without blocking** the deploy.

- **SDK** (`@salesforce/b2c-tooling-sdk`):
  - Add optional `warnings?: string[]` to `PushResult` and `CreateDeploymentResult`.
  - Return `warnings` from both `uploadBundle` branches (push and push+deploy) and from `createDeployment` (deploy existing bundle).
  - All reads default to `[]`, so a response that omits the field is a harmless no-op.
- **CLI** (`@salesforce/b2c-cli`):
  - `mrt bundle deploy` prints any returned warnings via `this.warn()` (non-blocking, stderr) on both the push+deploy and deploy-existing-bundle paths.

The backend change that populates `warnings[]` for x86 environments is tracked separately (in `portal_app`); until it ships, these paths are a no-op.

## Testing

- `pnpm --filter @salesforce/b2c-tooling-sdk test` — 1776 passing (new cases assert `warnings` is returned on both the no-target and with-target paths, a warnings-present case for each, a default-`[]` case, plus a new `deployment.test.ts` covering `createDeployment` success / warnings / no-body / failure).
- `pnpm --filter @salesforce/b2c-cli test` — 1346 passing (new cases assert `this.warn` is called with the warning string on both CLI deploy paths).
- `pnpm run lint:agent`, `pnpm run typecheck:agent`, and `pnpm run format:check` clean for both changed packages.

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)

<img width="1742" height="318" alt="image" src="https://github.com/user-attachments/assets/89925aae-4204-4c83-8519-10efc38e6880" />

<img width="1772" height="292" alt="image" src="https://github.com/user-attachments/assets/d43b85f5-3e0f-4824-93f7-ebfa17803c4d" />
