### PR TITLE
Add --create-pr flag to cap install

### DIFF
--- a/.changeset/cap-install-create-pr.md
+++ b/.changeset/cap-install-create-pr.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/b2c-tooling-sdk': minor
+'@salesforce/b2c-cli': minor
+---
+
+Add a `--create-pr` flag to `cap install`. When a Commerce App includes Storefront Next content and a repository is connected to the storefront, this opens a pull request with the app's storefront changes instead of applying them directly. Off by default.

--- a/docs/cli/cap.md
+++ b/docs/cli/cap.md
@@ -151,6 +151,7 @@ b2c cap install PATH --site-id SITE_ID
 | `--clean-archive` | | Delete the uploaded zip from the instance after install |
 | `--timeout SECONDS` | `-t` | Timeout in seconds (default: no timeout) |
 | `--skip-validate` | | Skip CAP structure validation before install |
+| `--create-pr` | | Create a pull request against the Storefront Next storefront when the app includes storefront content and a repository is connected to the storefront (default: off) |
 | `--json` | | Output result as JSON |
 
 ### Install Process
@@ -176,6 +177,19 @@ b2c cap install ./commerce-avalara-tax-app-v0.2.5 --site-id RefArch --skip-valid
 
 # Remove the uploaded archive after install
 b2c cap install ./commerce-avalara-tax-app-v0.2.5 --site-id RefArch --clean-archive
+
+# Create a Storefront Next pull request for the app's storefront content
+b2c cap install ./commerce-avalara-tax-app-v0.2.5 --site-id RefArch --create-pr
+```
+
+### Creating a Storefront Pull Request
+
+When a Commerce App includes Storefront Next content, the `--create-pr` flag instructs the install job to automatically open a pull request against the related Storefront Next storefront — provided a repository is also connected to the storefront. The pull request contains the storefront changes the app provides, so a developer can review and merge them rather than having them applied directly.
+
+This flag is **off by default**. If the app has no storefront content, or no repository is connected to the storefront, the flag has no effect and the install proceeds normally.
+
+```bash
+b2c cap install ./commerce-avalara-tax-app-v0.2.5 --site-id RefArch --create-pr
 ```
 
 ---

--- a/docs/guide/commerce-apps.md
+++ b/docs/guide/commerce-apps.md
@@ -91,7 +91,17 @@ b2c cap install ./commerce-my-integration-v1.0.0 --site RefArch
 b2c cap install ./dist/my-integration-v1.0.0.zip --site RefArch
 ```
 
-The CLI uploads the package to WebDAV (`Temp/`) and triggers the `sfcc-install-commerce-app` platform job, which deploys cartridges, imports IMPEX data, and creates a Storefront Next PR (if applicable).
+The CLI uploads the package to WebDAV (`Temp/`) and triggers the `sfcc-install-commerce-app` platform job, which deploys cartridges and imports IMPEX data.
+
+### Creating a Storefront Pull Request
+
+If a CAP includes Storefront Next content, pass `--create-pr` to have the install job automatically open a pull request against the related Storefront Next storefront — provided a repository is also connected to the storefront:
+
+```bash
+b2c cap install ./commerce-my-integration-v1.0.0 --site RefArch --create-pr
+```
+
+The pull request contains the storefront changes the app provides, so a developer can review and merge them rather than having them applied directly. The flag is **off by default**; if the app has no storefront content or no repository is connected to the storefront, it has no effect.
 
 ### 5. Complete Configuration Tasks
 

--- a/packages/b2c-cli/src/commands/cap/install.ts
+++ b/packages/b2c-cli/src/commands/cap/install.ts
@@ -32,6 +32,7 @@ export default class CapInstall extends JobCommand<typeof CapInstall> {
     '<%= config.bin %> <%= command.id %> ./commerce-avalara-tax-app-v0.2.5 --site RefArch',
     '<%= config.bin %> <%= command.id %> ./commerce-avalara-tax-app-v0.2.5.zip --site RefArch',
     '<%= config.bin %> <%= command.id %> ./commerce-avalara-tax-app-v0.2.5 --site RefArch --skip-validate',
+    '<%= config.bin %> <%= command.id %> ./commerce-avalara-tax-app-v0.2.5 --site RefArch --create-pr',
   ];
 
   static flags = {
@@ -54,6 +55,11 @@ export default class CapInstall extends JobCommand<typeof CapInstall> {
       description: 'Skip CAP structure validation before install',
       default: false,
     }),
+    'create-pr': Flags.boolean({
+      description:
+        'Create a pull request against the connected Storefront Next repository when the app includes storefront content',
+      default: false,
+    }),
   };
 
   protected operations = {
@@ -66,7 +72,13 @@ export default class CapInstall extends JobCommand<typeof CapInstall> {
     this.requireWebDavCredentials();
 
     const {path} = this.args;
-    const {'site-id': site, 'clean-archive': cleanArchive, timeout, 'skip-validate': skipValidate} = this.flags;
+    const {
+      'site-id': site,
+      'clean-archive': cleanArchive,
+      timeout,
+      'skip-validate': skipValidate,
+      'create-pr': createPr,
+    } = this.flags;
     const hostname = this.resolvedConfig.values.hostname!;
 
     // Validate first unless skipped
@@ -118,6 +130,7 @@ export default class CapInstall extends JobCommand<typeof CapInstall> {
       const result = await this.operations.commerceAppInstall(this.instance, path, {
         siteId: site,
         keepArchive: !cleanArchive,
+        shouldCreatePr: createPr,
         waitOptions: {
           timeoutSeconds: timeout || undefined,
           onPoll: (info) => {

--- a/packages/b2c-cli/test/commands/cap/install.test.ts
+++ b/packages/b2c-cli/test/commands/cap/install.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import {expect} from 'chai';
+import {afterEach, beforeEach} from 'mocha';
+import sinon from 'sinon';
+import CapInstall from '../../../src/commands/cap/install.js';
+import {createIsolatedConfigHooks, createTestCommand, expectError} from '../../helpers/test-setup.js';
+
+describe('cap install', () => {
+  const hooks = createIsolatedConfigHooks();
+
+  beforeEach(hooks.beforeEach);
+
+  afterEach(hooks.afterEach);
+
+  async function createCommand(flags: Record<string, unknown>, args: Record<string, unknown>) {
+    return createTestCommand(CapInstall, hooks.getConfig(), flags, args);
+  }
+
+  /** Stub credential checks, config, instance, and silence output. Returns the fake instance. */
+  function stubCommon(command: any) {
+    const instance = {config: {hostname: 'example.com'}};
+    sinon.stub(command, 'requireOAuthCredentials').returns(void 0);
+    sinon.stub(command, 'requireWebDavCredentials').returns(void 0);
+    sinon.stub(command, 'log').returns(void 0);
+    sinon.stub(command, 'resolvedConfig').get(() => ({values: {hostname: 'example.com'}}));
+    sinon.stub(command, 'instance').get(() => instance);
+    return instance;
+  }
+
+  /** A successful install result the operation stub can resolve with. */
+  const installResult = {
+    execution: {execution_status: 'finished', exit_status: {code: 'OK'}, duration: 1000},
+    appName: 'avalara-tax',
+    appVersion: '0.2.5',
+    archiveFilename: 'avalara-tax-v0.2.5.zip',
+    archiveKept: true,
+  };
+
+  it('validates before install and passes flags through to the install operation', async () => {
+    // The oclif flag default (false) is applied at runtime; the test harness
+    // does not apply defaults, so pass the resolved value explicitly here.
+    const command: any = await createCommand({'site-id': 'RefArch', 'create-pr': false}, {path: './my-cap'});
+    const instance = stubCommon(command);
+
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    sinon.stub(command, 'runAfterHooks').resolves(void 0);
+
+    const validateStub = sinon.stub().resolves({valid: true, errors: [], warnings: []});
+    const installStub = sinon.stub().resolves(installResult);
+    command.operations = {validateCap: validateStub, commerceAppInstall: installStub};
+
+    const result = await command.run();
+
+    expect(validateStub.calledOnceWithExactly('./my-cap')).to.be.true;
+    expect(installStub.calledOnce).to.be.true;
+    expect(installStub.firstCall.args[0]).to.equal(instance);
+    expect(installStub.firstCall.args[1]).to.equal('./my-cap');
+    expect(installStub.firstCall.args[2]).to.deep.include({
+      siteId: 'RefArch',
+      keepArchive: true,
+      shouldCreatePr: false,
+    });
+    expect(result).to.equal(installResult);
+  });
+
+  it('passes shouldCreatePr=true when --create-pr is set', async () => {
+    const command: any = await createCommand({'site-id': 'RefArch', 'create-pr': true}, {path: './my-cap'});
+    stubCommon(command);
+
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    sinon.stub(command, 'runAfterHooks').resolves(void 0);
+
+    const installStub = sinon.stub().resolves(installResult);
+    command.operations = {
+      validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: []}),
+      commerceAppInstall: installStub,
+    };
+
+    await command.run();
+
+    expect(installStub.firstCall.args[2]).to.deep.include({shouldCreatePr: true});
+  });
+
+  it('maps --clean-archive to keepArchive=false', async () => {
+    const command: any = await createCommand({'site-id': 'RefArch', 'clean-archive': true}, {path: './my-cap'});
+    stubCommon(command);
+
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    sinon.stub(command, 'runAfterHooks').resolves(void 0);
+
+    const installStub = sinon.stub().resolves(installResult);
+    command.operations = {
+      validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: []}),
+      commerceAppInstall: installStub,
+    };
+
+    await command.run();
+
+    expect(installStub.firstCall.args[2]).to.deep.include({keepArchive: false});
+  });
+
+  it('skips validation when --skip-validate is set', async () => {
+    const command: any = await createCommand({'site-id': 'RefArch', 'skip-validate': true}, {path: './my-cap'});
+    stubCommon(command);
+
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    sinon.stub(command, 'runAfterHooks').resolves(void 0);
+
+    const validateStub = sinon.stub().resolves({valid: true, errors: [], warnings: []});
+    const installStub = sinon.stub().resolves(installResult);
+    command.operations = {validateCap: validateStub, commerceAppInstall: installStub};
+
+    await command.run();
+
+    expect(validateStub.called).to.be.false;
+    expect(installStub.calledOnce).to.be.true;
+  });
+
+  it('errors and does not install when validation fails', async () => {
+    const command: any = await createCommand({'site-id': 'RefArch'}, {path: './my-cap'});
+    stubCommon(command);
+
+    const installStub = sinon.stub().resolves(installResult);
+    command.operations = {
+      validateCap: sinon.stub().resolves({valid: false, errors: ['missing commerce-app.json'], warnings: []}),
+      commerceAppInstall: installStub,
+    };
+
+    const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
+
+    await expectError(() => command.run());
+
+    expect(errorStub.called).to.be.true;
+    expect(errorStub.firstCall.args[0]).to.include('validation failed');
+    expect(installStub.called).to.be.false;
+  });
+
+  it('returns early without installing when a before hook skips', async () => {
+    const command: any = await createCommand({'site-id': 'RefArch', 'skip-validate': true}, {path: './my-cap'});
+    stubCommon(command);
+
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: true, skipReason: 'by plugin'});
+    sinon.stub(command, 'runAfterHooks').rejects(new Error('Unexpected after hooks'));
+
+    const installStub = sinon.stub().rejects(new Error('Unexpected install'));
+    command.operations = {
+      validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: []}),
+      commerceAppInstall: installStub,
+    };
+
+    const result: any = await command.run();
+
+    expect(installStub.called).to.be.false;
+    expect(result.execution.execution_status).to.equal('finished');
+  });
+});

--- a/packages/b2c-tooling-sdk/src/operations/cap/install.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cap/install.ts
@@ -27,6 +27,11 @@ export interface CommerceAppInstallOptions {
   siteId: string;
   /** Keep the uploaded zip on the instance after install (default: false). */
   keepArchive?: boolean;
+  /**
+   * Create a pull request against the connected Storefront Next repository
+   * when the app includes storefront content (default: false).
+   */
+  shouldCreatePr?: boolean;
   /** Wait options for job completion. */
   waitOptions?: WaitForJobOptions;
 }
@@ -73,7 +78,7 @@ export async function commerceAppInstall(
   options: CommerceAppInstallOptions,
 ): Promise<CommerceAppInstallResult> {
   const logger = getLogger();
-  const {siteId: rawSiteId, keepArchive = false, waitOptions} = options;
+  const {siteId: rawSiteId, keepArchive = false, shouldCreatePr = false, waitOptions} = options;
   const siteId = normalizeSiteId(rawSiteId);
 
   if (!fs.existsSync(target)) {
@@ -121,6 +126,7 @@ export async function commerceAppInstall(
       app_domain: manifest.domain,
       site_id: siteId,
       app_path: appPath,
+      should_create_pr: shouldCreatePr,
     } as unknown as string,
   });
 
@@ -140,6 +146,7 @@ export async function commerceAppInstall(
           {name: 'AppDomain', value: manifest.domain},
           {name: 'SiteId', value: siteId},
           {name: 'AppPath', value: appPath},
+          {name: 'ShouldCreatePR', value: String(shouldCreatePr)},
         ],
       } as unknown as string,
     });

--- a/packages/b2c-tooling-sdk/test/operations/cap/install.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/cap/install.test.ts
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import {expect} from 'chai';
+import {http, HttpResponse} from 'msw';
+import {setupServer} from 'msw/node';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import JSZip from 'jszip';
+import {WebDavClient} from '../../../src/clients/webdav.js';
+import {createOcapiClient} from '../../../src/clients/ocapi.js';
+import {MockAuthStrategy} from '../../helpers/mock-auth.js';
+import {commerceAppInstall} from '../../../src/operations/cap/install.js';
+
+const TEST_HOST = 'test.demandware.net';
+const WEBDAV_BASE = `https://${TEST_HOST}/on/demandware.servlet/webdav/Sites`;
+const OCAPI_BASE = `https://${TEST_HOST}/s/-/dw/data/v25_6`;
+const INSTALL_EXECUTIONS = `${OCAPI_BASE}/jobs/sfcc-install-commerce-app/executions`;
+
+// Use short poll interval and no real sleeping for fast tests.
+const FAST_WAIT_OPTIONS = {pollIntervalSeconds: 1, sleep: () => Promise.resolve()};
+
+const FIXTURE_CAP = path.join(
+  path.dirname(new URL(import.meta.url).pathname),
+  '../../fixtures/commerce-avalara-tax-app-v0.2.5',
+);
+
+/** Register WebDAV handlers (MKCOL/PUT/DELETE) and capture the uploaded zip + whether DELETE ran. */
+function captureWebdav(): {uploaded: () => Buffer | null; deleted: () => boolean} {
+  let uploadedZip: Buffer | null = null;
+  let deleteRequested = false;
+
+  server.use(
+    http.all(`${WEBDAV_BASE}/*`, async ({request}) => {
+      if (request.method === 'PUT') {
+        uploadedZip = Buffer.from(await request.arrayBuffer());
+        return new HttpResponse(null, {status: 201});
+      }
+      if (request.method === 'DELETE') {
+        deleteRequested = true;
+        return new HttpResponse(null, {status: 204});
+      }
+      // MKCOL and anything else
+      return new HttpResponse(null, {status: 201});
+    }),
+  );
+
+  return {uploaded: () => uploadedZip, deleted: () => deleteRequested};
+}
+
+/** Register the install job execution + polling handlers, capturing the POST body. */
+function captureInstallJob(
+  executionId: string,
+  exitStatus: {code: string; message?: string} = {code: 'OK'},
+): {body: () => any} {
+  let seenBody: any = null;
+
+  server.use(
+    http.post(INSTALL_EXECUTIONS, async ({request}) => {
+      seenBody = await request.json();
+      return HttpResponse.json({id: executionId, execution_status: 'running'});
+    }),
+    http.get(`${INSTALL_EXECUTIONS}/${executionId}`, () =>
+      HttpResponse.json({
+        id: executionId,
+        execution_status: 'finished',
+        exit_status: exitStatus,
+        is_log_file_existing: false,
+      }),
+    ),
+  );
+
+  return {body: () => seenBody};
+}
+
+const server = setupServer();
+
+describe('operations/cap/install', () => {
+  let mockInstance: any;
+  let tempDir: string;
+
+  before(() => {
+    server.listen({onUnhandledRequest: 'error'});
+  });
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-cap-install-'));
+
+    const auth = new MockAuthStrategy();
+    mockInstance = {
+      config: {hostname: TEST_HOST},
+      webdav: new WebDavClient(TEST_HOST, auth),
+      ocapi: createOcapiClient(TEST_HOST, auth),
+    };
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+    if (tempDir) {
+      fs.rmSync(tempDir, {recursive: true, force: true});
+    }
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  describe('commerceAppInstall', () => {
+    it('uploads the CAP and runs the install job from a directory', async () => {
+      const {uploaded, deleted} = captureWebdav();
+      const job = captureInstallJob('exec-1');
+
+      const result = await commerceAppInstall(mockInstance, FIXTURE_CAP, {
+        siteId: 'RefArch',
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      expect(result.execution.id).to.equal('exec-1');
+      expect(result.execution.execution_status).to.equal('finished');
+      expect(result.appName).to.equal('avalara-tax');
+      expect(result.appVersion).to.equal('0.2.5');
+      expect(result.archiveFilename).to.equal('avalara-tax-v0.2.5.zip');
+
+      // The direct OCAPI body carries the manifest-derived fields.
+      expect(job.body()).to.include({
+        app_name: 'avalara-tax',
+        app_source: 'WebDAV',
+        app_domain: 'tax',
+        site_id: 'Sites-RefArch',
+        app_path: 'webdav/Sites/Impex/commerce-apps/avalara-tax-v0.2.5.zip',
+      });
+
+      // A real zip was uploaded.
+      const zip = await JSZip.loadAsync(uploaded()!);
+      expect(Object.keys(zip.files).some((p) => p.endsWith('commerce-app.json'))).to.be.true;
+
+      // Archive removed by default (keepArchive defaults to false).
+      expect(deleted()).to.be.true;
+      expect(result.archiveKept).to.be.false;
+    });
+
+    it('defaults should_create_pr to false', async () => {
+      captureWebdav();
+      const job = captureInstallJob('exec-default');
+
+      await commerceAppInstall(mockInstance, FIXTURE_CAP, {
+        siteId: 'RefArch',
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      expect(job.body().should_create_pr).to.equal(false);
+    });
+
+    it('sends should_create_pr=true when shouldCreatePr is set', async () => {
+      captureWebdav();
+      const job = captureInstallJob('exec-pr');
+
+      await commerceAppInstall(mockInstance, FIXTURE_CAP, {
+        siteId: 'RefArch',
+        shouldCreatePr: true,
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      expect(job.body().should_create_pr).to.equal(true);
+    });
+
+    it('keeps the uploaded archive when keepArchive is true', async () => {
+      const {deleted} = captureWebdav();
+      captureInstallJob('exec-keep');
+
+      const result = await commerceAppInstall(mockInstance, FIXTURE_CAP, {
+        siteId: 'RefArch',
+        keepArchive: true,
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      expect(result.archiveKept).to.be.true;
+      expect(deleted()).to.be.false;
+    });
+
+    it('normalizes a site id that already has the Sites- prefix', async () => {
+      captureWebdav();
+      const job = captureInstallJob('exec-prefixed');
+
+      await commerceAppInstall(mockInstance, FIXTURE_CAP, {
+        siteId: 'Sites-RefArch',
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      expect(job.body().site_id).to.equal('Sites-RefArch');
+    });
+
+    it('retries with the parameters format for internal users and includes ShouldCreatePR', async () => {
+      const {uploaded} = captureWebdav();
+
+      let directBody: any = null;
+      let retryBody: any = null;
+      let postCount = 0;
+
+      server.use(
+        http.post(INSTALL_EXECUTIONS, async ({request}) => {
+          postCount++;
+          const body = (await request.json()) as any;
+          if (postCount === 1) {
+            directBody = body;
+            // Mirror the platform rejecting the direct document format.
+            return HttpResponse.json(
+              {
+                fault: {
+                  type: 'UnknownPropertyException',
+                  message: 'Unknown property',
+                  arguments: {document: 'job_execution_request'},
+                },
+              },
+              {status: 400},
+            );
+          }
+          retryBody = body;
+          return HttpResponse.json({id: 'exec-retry', execution_status: 'running'});
+        }),
+        http.get(`${INSTALL_EXECUTIONS}/exec-retry`, () =>
+          HttpResponse.json({
+            id: 'exec-retry',
+            execution_status: 'finished',
+            exit_status: {code: 'OK'},
+            is_log_file_existing: false,
+          }),
+        ),
+      );
+
+      const result = await commerceAppInstall(mockInstance, FIXTURE_CAP, {
+        siteId: 'RefArch',
+        shouldCreatePr: true,
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      expect(result.execution.id).to.equal('exec-retry');
+      expect(postCount).to.equal(2);
+      expect(directBody.should_create_pr).to.equal(true);
+
+      // Retry uses the parameters array with PascalCase names.
+      const params: Array<{name: string; value: string}> = retryBody.parameters;
+      const byName = Object.fromEntries(params.map((p) => [p.name, p.value]));
+      expect(byName).to.include({
+        AppName: 'avalara-tax',
+        AppSource: 'WebDAV',
+        AppDomain: 'tax',
+        SiteId: 'Sites-RefArch',
+        ShouldCreatePR: 'true',
+      });
+
+      expect(uploaded()).to.not.be.null;
+    });
+
+    it('throws JobExecutionError when the install job fails', async () => {
+      captureWebdav();
+      captureInstallJob('exec-fail', {code: 'ERROR', message: 'Install failed'});
+
+      try {
+        await commerceAppInstall(mockInstance, FIXTURE_CAP, {
+          siteId: 'RefArch',
+          waitOptions: FAST_WAIT_OPTIONS,
+        });
+        expect.fail('Should have thrown JobExecutionError');
+      } catch (error: any) {
+        expect(error.name).to.equal('JobExecutionError');
+        expect(error.message).to.include('failed');
+      }
+    });
+
+    it('throws when the target does not exist', async () => {
+      try {
+        await commerceAppInstall(mockInstance, path.join(tempDir, 'missing'), {
+          siteId: 'RefArch',
+          waitOptions: FAST_WAIT_OPTIONS,
+        });
+        expect.fail('Should have thrown');
+      } catch (error: any) {
+        expect(error.message).to.include('Target not found');
+      }
+    });
+
+    it('installs from a prebuilt zip file', async () => {
+      // Build a minimal CAP zip with the manifest one level deep.
+      const srcZip = new JSZip();
+      const root = srcZip.folder('my-app-v1.0.0')!;
+      root.file('commerce-app.json', JSON.stringify({id: 'my-app', name: 'My App', version: '1.0.0', domain: 'tax'}));
+      const zipBuffer = await srcZip.generateAsync({type: 'nodebuffer'});
+      const zipPath = path.join(tempDir, 'my-app-v1.0.0.zip');
+      fs.writeFileSync(zipPath, zipBuffer);
+
+      captureWebdav();
+      const job = captureInstallJob('exec-zip');
+
+      const result = await commerceAppInstall(mockInstance, zipPath, {
+        siteId: 'RefArch',
+        waitOptions: FAST_WAIT_OPTIONS,
+      });
+
+      expect(result.appName).to.equal('my-app');
+      expect(result.appVersion).to.equal('1.0.0');
+      // Zip target keeps its original filename.
+      expect(result.archiveFilename).to.equal('my-app-v1.0.0.zip');
+      expect(job.body().app_path).to.equal('webdav/Sites/Impex/commerce-apps/my-app-v1.0.0.zip');
+    });
+  });
+});

--- a/skills/b2c-cli/skills/b2c-cap/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-cap/SKILL.md
@@ -101,6 +101,10 @@ b2c cap install ./commerce-avalara-tax-app-v0.2.5 --site-id RefArch --skip-valid
 
 # remove the uploaded archive after install
 b2c cap install ./commerce-avalara-tax-app-v0.2.5 --site-id RefArch --clean-archive
+
+# create a Storefront Next pull request for the app's storefront content
+# (requires a repository connected to the storefront; off by default)
+b2c cap install ./commerce-avalara-tax-app-v0.2.5 --site-id RefArch --create-pr
 ```
 
 ### Uninstall a CAP


### PR DESCRIPTION
## Summary

Adds an opt-in `--create-pr` flag to `b2c cap install`.

When a Commerce App Package includes Storefront Next content and a repository is connected to the storefront, this flag instructs the `sfcc-install-commerce-app` job to open a pull request containing the app's storefront changes — so a developer can review and merge them — rather than applying them directly. The flag is **off by default**; if the app has no storefront content or no repository is connected to the storefront, it has no effect.

The job attribute backing this (`ShouldCreatePR`, OCAPI `InstallCommerceAppConfigurationWO` from v25.6) was confirmed against the ECOM server source.

## Changes

- **SDK** (`operations/cap/install.ts`): new `shouldCreatePr?: boolean` option (default false). Sends `should_create_pr` in the direct OCAPI body and `ShouldCreatePR` in the parameters-retry body.
- **CLI** (`commands/cap/install.ts`): new `--create-pr` boolean flag (default false) wired through to the SDK, plus an example.
- **Docs**: `docs/cli/cap.md` (flag + "Creating a Storefront Pull Request" section) and `docs/guide/commerce-apps.md` (corrected the install step to gate PR creation behind the flag).
- **Skill**: `skills/b2c-cli/skills/b2c-cap/SKILL.md` install example.
- **Changeset**: minor bump for CLI + SDK.

## Note

The direct-body wire name uses `should_create_pr` (single token for the `PR` acronym). The parameters-retry path uses the confirmed `ShouldCreatePR` constant. Worth a quick verify against a live instance that the direct-body form is accepted.