### PR TITLE
Replace applicationinsights SDK with zero-dependency fetch client

### DIFF
--- a/.changeset/replace-appinsights-with-fetch-client.md
+++ b/.changeset/replace-appinsights-with-fetch-client.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+'b2c-vs-extension': patch
+---
+
+Replace the `applicationinsights` dependency with a tiny built-in telemetry client that posts directly to the Application Insights ingestion endpoint using Node's native `fetch`. This removes ~270 transitive packages (the OpenTelemetry, Azure SDK, and gRPC trees that the v3 SDK pulled in for auto-collection features we never used) and shrinks the published packages and the VS Code extension bundle. Telemetry behavior is unchanged — the same events and exceptions are reported — and the machine-identifying cloud role instance is now correctly suppressed for GDPR. A new optional `flushIntervalMs` option enables periodic delivery for long-lived hosts; the VS Code extension uses it so a session's usage events are not lost on a non-clean shutdown. No public SDK API change.

--- a/packages/b2c-tooling-sdk/package.json
+++ b/packages/b2c-tooling-sdk/package.json
@@ -273,7 +273,6 @@
   },
   "dependencies": {
     "@vscode/debugadapter": "1.68.0",
-    "applicationinsights": "3.15.0",
     "chokidar": "5.0.0",
     "cliui": "catalog:",
     "ejs": "3.1.10",

--- a/packages/b2c-tooling-sdk/src/telemetry/app-insights-client.ts
+++ b/packages/b2c-tooling-sdk/src/telemetry/app-insights-client.ts
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * Zero-dependency Application Insights ingestion client.
+ *
+ * This is a deliberately tiny replacement for the `applicationinsights` npm
+ * package. We only ever did manual event/exception tracking (every
+ * auto-collection feature was disabled), so the full SDK — which in v3.x pulls
+ * in ~98 transitive packages (OpenTelemetry, the Azure SDK, gRPC/protobuf, DB
+ * instrumentations) — was vastly more than we needed.
+ *
+ * Instead we POST classic "Breeze" telemetry envelopes directly to the
+ * ingestion endpoint using Node's built-in global `fetch` (Node >= 22). The
+ * wire format and `/v2.1/track` endpoint were verified by capturing what the
+ * real v3 SDK emits and by a live round-trip against the ingestion endpoint
+ * (which returned `itemsAccepted` for these exact envelopes).
+ *
+ * Only the surface the {@link Telemetry} wrapper uses is implemented:
+ * {@link AppInsightsClient.trackEvent}, {@link AppInsightsClient.trackException},
+ * and {@link AppInsightsClient.flush}. The shape mirrors the SDK's
+ * `TelemetryClient` (`config`, `context.tags`/`context.keys`) so the wrapper
+ * stays a thin adapter.
+ *
+ * @module telemetry/app-insights-client
+ * @internal
+ */
+
+/** Path appended to the ingestion endpoint. The v3 SDK uses v2.1. */
+const TRACK_PATH = '/v2.1/track';
+/** Default ingestion endpoint when the connection string omits one. */
+const DEFAULT_INGESTION_ENDPOINT = 'https://dc.services.visualstudio.com';
+/** Envelope-level schema version (Breeze `ver`). */
+const ENVELOPE_VERSION = 1;
+/** baseData schema version (Breeze EventData/ExceptionData `ver`). */
+const BASE_DATA_VERSION = 2;
+/** We never sample client-side. */
+const SAMPLE_RATE = 100;
+/** Default request timeout so a hung endpoint never blocks CLI exit. */
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/** Breeze property/measurement limits (server truncates beyond these). */
+const MAX_KEY_LENGTH = 150;
+const MAX_VALUE_LENGTH = 8192;
+
+/**
+ * Context tag keys, mirroring `client.context.keys` from the SDK so callers can
+ * keep using the familiar `tags[keys.userId]` idiom.
+ */
+export const contextTagKeys = {
+  userId: 'ai.user.id',
+  cloudRoleInstance: 'ai.cloud.roleInstance',
+} as const;
+
+/** A single Breeze telemetry envelope as serialized on the wire. */
+interface Envelope {
+  ver: number;
+  name: string;
+  time: string;
+  sampleRate: number;
+  iKey: string;
+  tags: Record<string, string>;
+  data: {
+    baseType: 'EventData' | 'ExceptionData';
+    baseData: Record<string, unknown>;
+  };
+}
+
+/** Arguments for {@link AppInsightsClient.trackEvent}. */
+export interface TrackEventArgs {
+  name: string;
+  properties?: Record<string, string>;
+  measurements?: Record<string, number>;
+}
+
+/** Arguments for {@link AppInsightsClient.trackException}. */
+export interface TrackExceptionArgs {
+  exception: Error;
+  properties?: Record<string, string>;
+  measurements?: Record<string, number>;
+}
+
+/**
+ * Parse an Application Insights connection string into the instrumentation key
+ * and resolved ingestion `/v2.1/track` URL.
+ *
+ * The connection string is semicolon-delimited `key=value` pairs with
+ * case-insensitive keys, e.g.
+ * `InstrumentationKey=<guid>;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/`.
+ *
+ * Plain GUIDs (legacy instrumentation keys with no `=`) are also accepted.
+ *
+ * @returns the iKey and track URL, or `null` if no instrumentation key is present.
+ */
+export function parseConnectionString(connectionString: string): {iKey: string; trackUrl: string} | null {
+  const fields: Record<string, string> = {};
+  let bareKey: string | undefined;
+
+  for (const part of connectionString.split(';')) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 0) {
+      // A bare token with no '=' — treat as a legacy instrumentation key.
+      bareKey = trimmed;
+      continue;
+    }
+    fields[trimmed.slice(0, eq).trim().toLowerCase()] = trimmed.slice(eq + 1).trim();
+  }
+
+  const iKey = fields.instrumentationkey ?? bareKey;
+  if (!iKey) return null;
+
+  let endpoint: string;
+  if (fields.ingestionendpoint) {
+    endpoint = fields.ingestionendpoint;
+  } else if (fields.endpointsuffix) {
+    const locationPrefix = fields.location ? `${fields.location}.` : '';
+    endpoint = `https://${locationPrefix}dc.${fields.endpointsuffix}`;
+  } else {
+    endpoint = DEFAULT_INGESTION_ENDPOINT;
+  }
+
+  // Sanitize: upgrade http -> https and strip any trailing slash, matching the SDK.
+  endpoint = endpoint.replace(/^http:\/\//i, 'https://').replace(/\/+$/, '');
+
+  return {iKey, trackUrl: endpoint + TRACK_PATH};
+}
+
+/**
+ * Truncate a string to a maximum length (Breeze enforces server-side; we mirror
+ * it to keep payloads tidy).
+ */
+function truncate(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+/** Clamp a Record's keys/values to Breeze limits. */
+function clampProperties(properties: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    out[truncate(key, MAX_KEY_LENGTH)] = truncate(value, MAX_VALUE_LENGTH);
+  }
+  return out;
+}
+
+function clampMeasurementKeys(measurements: Record<string, number>): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [key, value] of Object.entries(measurements)) {
+    out[truncate(key, MAX_KEY_LENGTH)] = value;
+  }
+  return out;
+}
+
+/**
+ * A minimal, dependency-free Application Insights client.
+ *
+ * Construct with an instrumentation key or connection string, optionally set
+ * {@link AppInsightsClient.context} tags, then buffer telemetry via
+ * {@link AppInsightsClient.trackEvent}/{@link AppInsightsClient.trackException}
+ * and deliver it with {@link AppInsightsClient.flush}.
+ *
+ * If the connection string has no instrumentation key, the client becomes an
+ * inert no-op (every method silently does nothing) — it never throws into
+ * calling code.
+ */
+export class AppInsightsClient {
+  /**
+   * SDK-compatible config bag. Retained so callers can read
+   * `config.connectionString`; the SDK's auto-collection toggles are obsolete
+   * here (this client only does manual tracking) and are intentionally absent.
+   */
+  readonly config: {connectionString: string};
+
+  /** SDK-compatible context: per-envelope tags plus the canonical key names. */
+  readonly context: {tags: Record<string, string>; keys: typeof contextTagKeys};
+
+  private readonly iKey: string | undefined;
+  private readonly trackUrl: string | undefined;
+  private readonly timeoutMs: number;
+  private buffer: Envelope[] = [];
+
+  constructor(connectionString: string, options: {timeoutMs?: number} = {}) {
+    this.config = {connectionString};
+    this.context = {tags: {}, keys: contextTagKeys};
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    const parsed = parseConnectionString(connectionString);
+    if (parsed) {
+      this.iKey = parsed.iKey;
+      this.trackUrl = parsed.trackUrl;
+    }
+  }
+
+  /** Buffer an event envelope. Delivered on the next {@link flush}. */
+  trackEvent(args: TrackEventArgs): void {
+    if (!this.iKey) return;
+    this.buffer.push(
+      this.envelope('EventData', {
+        ver: BASE_DATA_VERSION,
+        name: args.name,
+        properties: clampProperties(args.properties ?? {}),
+        measurements: clampMeasurementKeys(args.measurements ?? {}),
+      }),
+    );
+  }
+
+  /** Buffer an exception envelope. Delivered on the next {@link flush}. */
+  trackException(args: TrackExceptionArgs): void {
+    if (!this.iKey) return;
+    const {exception} = args;
+    const stack = exception.stack;
+    const details: Record<string, unknown> = {
+      typeName: truncate(exception.name || 'Error', 1024),
+      message: truncate(exception.message || '', 32768),
+      hasFullStack: Boolean(stack),
+    };
+    if (stack) details.stack = truncate(stack, 32768);
+
+    this.buffer.push(
+      this.envelope('ExceptionData', {
+        ver: BASE_DATA_VERSION,
+        exceptions: [details],
+        severityLevel: 'Error',
+        properties: clampProperties(args.properties ?? {}),
+        measurements: clampMeasurementKeys(args.measurements ?? {}),
+      }),
+    );
+  }
+
+  /**
+   * POST all buffered envelopes to the ingestion endpoint in one request and
+   * clear the buffer. Best-effort: any network/HTTP error is swallowed (the
+   * buffer is still cleared) so telemetry never affects the caller.
+   */
+  async flush(): Promise<void> {
+    if (!this.trackUrl || this.buffer.length === 0) {
+      this.buffer = [];
+      return;
+    }
+    const body = JSON.stringify(this.buffer);
+    this.buffer = [];
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      await fetch(this.trackUrl, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json', Accept: 'application/json'},
+        body,
+        signal: controller.signal,
+      });
+    } catch {
+      // best-effort: ignore network errors, timeouts, and abort
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Build a Breeze envelope, stamping the current context tags and time. */
+  private envelope(baseType: 'EventData' | 'ExceptionData', baseData: Record<string, unknown>): Envelope {
+    return {
+      ver: ENVELOPE_VERSION,
+      name:
+        baseType === 'EventData' ? 'Microsoft.ApplicationInsights.Event' : 'Microsoft.ApplicationInsights.Exception',
+      time: new Date().toISOString(),
+      sampleRate: SAMPLE_RATE,
+      iKey: this.iKey as string,
+      tags: {...this.context.tags},
+      data: {baseType, baseData},
+    };
+  }
+}

--- a/packages/b2c-tooling-sdk/src/telemetry/telemetry.ts
+++ b/packages/b2c-tooling-sdk/src/telemetry/telemetry.ts
@@ -7,12 +7,7 @@
 import {randomBytes} from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-// Namespace import (not default): `applicationinsights` is a legacy CommonJS
-// module whose default-export interop is not synthesized when the file is
-// loaded as native ESM (e.g. mocha 11's tsx loader), leaving the default
-// binding `undefined`. The namespace form resolves `TelemetryClient` correctly
-// under every loader — mocha, tsx, and the production ESM build.
-import * as appInsights from 'applicationinsights';
+import {AppInsightsClient} from './app-insights-client.js';
 import type {TelemetryAttributes, TelemetryEventProperties, TelemetryOptions} from './types.js';
 import {getLogger, type Logger} from '../logging/index.js';
 
@@ -120,12 +115,14 @@ export class Telemetry {
   private attributes: TelemetryAttributes;
   private cliId: string;
   private project: string;
-  private client: appInsights.TelemetryClient | undefined;
+  private client: AppInsightsClient | undefined;
   private sessionId: string;
   private started: boolean;
   private version: string;
   private appInsightsKey: string | undefined;
   private traceLog: Logger | undefined;
+  private flushIntervalMs: number | undefined;
+  private flushTimer: ReturnType<typeof setInterval> | undefined;
 
   /**
    * Check if telemetry is disabled via environment variables.
@@ -154,6 +151,7 @@ export class Telemetry {
     this.sessionId = generateRandomId();
     this.started = false;
     this.version = options.version ?? '0.0.0';
+    this.flushIntervalMs = options.flushIntervalMs;
 
     if (process.env.SFCC_TELEMETRY_LOG === 'true') {
       this.traceLog = getLogger().child({component: 'telemetry'});
@@ -240,6 +238,15 @@ export class Telemetry {
     } catch {
       // best-effort — telemetry failure never impacts the application
     }
+
+    // Long-lived hosts (e.g. the VS Code extension) buffer events for a whole
+    // session and may not get a clean shutdown flush. An opt-in periodic flush
+    // delivers events on a cadence so a dirty exit loses at most one interval.
+    // The timer is unref'd so it never keeps a short-lived process alive.
+    if (this.client && this.flushIntervalMs && this.flushIntervalMs > 0) {
+      this.flushTimer = setInterval(() => void this.flush(), this.flushIntervalMs);
+      this.flushTimer.unref?.();
+    }
   }
 
   /**
@@ -249,7 +256,6 @@ export class Telemetry {
   async flush(): Promise<void> {
     if (!this.started || !this.client) return;
 
-    // applicationinsights 3.x: flush() returns a Promise and no longer takes a callback.
     await this.client.flush();
   }
 
@@ -262,17 +268,18 @@ export class Telemetry {
     this.traceLog?.debug('telemetry stop');
     this.started = false;
 
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = undefined;
+    }
+
     if (this.client) {
-      // applicationinsights 3.x: flush() returns a Promise and no longer takes a callback.
       await this.client.flush();
       this.client = undefined;
     }
 
-    // Allow pending HTTP requests to flush before process exits.
-    // Application Insights SDK sends events asynchronously, so we need
-    // a delay to ensure events reach the server on fast exits.
-    // 300ms gives enough time for the HTTP request to complete even on
-    // cold starts when establishing the initial connection.
+    // flush() awaits the ingestion POST directly, but keep a small drain delay
+    // so any in-flight request started elsewhere can settle before a fast exit.
     await new Promise((resolve) => setTimeout(resolve, 300));
   }
 
@@ -295,31 +302,14 @@ export class Telemetry {
   }
 
   private createClient(): void {
-    // applicationinsights 3.x removed the `disableStatsbeat` config flag; statsbeat
-    // is now opted out via this environment variable (read by the Azure Monitor
-    // exporter at client construction). Set it before constructing the client.
-    process.env.APPLICATIONINSIGHTS_STATSBEAT_DISABLED = 'true';
+    // Manual event tracking only — no auto-collection, no statsbeat, no
+    // background telemetry. This zero-dependency client POSTs Breeze envelopes
+    // directly, so there is nothing to opt out of.
+    const client = new AppInsightsClient(this.appInsightsKey as string);
 
-    const client = new appInsights.TelemetryClient(this.appInsightsKey);
-
-    // Disable all auto-collection — we only do manual event tracking
-    client.config.enableAutoCollectConsole = false;
-    client.config.enableAutoCollectExceptions = false;
-    client.config.enableAutoCollectPerformance = false;
-    client.config.enableAutoCollectRequests = false;
-    client.config.enableAutoCollectDependencies = false;
-    client.config.enableAutoDependencyCorrelation = false;
-    client.config.enableAutoCollectHeartbeat = false;
-    client.config.enableAutoCollectPreAggregatedMetrics = false;
-    client.config.enableAutoCollectIncomingRequestAzureFunctions = false;
-    client.config.enableSendLiveMetrics = false;
-    client.config.enableUseDiskRetryCaching = false;
-    client.config.enableInternalDebugLogging = false;
-    client.config.enableInternalWarningLogging = false;
-
-    // Set user ID for session tracking
+    // Set user ID for session tracking.
     client.context.tags[client.context.keys.userId] = this.cliId;
-    // GDPR: hide machine-identifying cloud role instance
+    // GDPR: hide machine-identifying cloud role instance.
     client.context.tags[client.context.keys.cloudRoleInstance] = '';
 
     this.client = client;

--- a/packages/b2c-tooling-sdk/src/telemetry/types.ts
+++ b/packages/b2c-tooling-sdk/src/telemetry/types.ts
@@ -71,4 +71,17 @@ export interface TelemetryOptions {
    * If not provided or non-writable, falls back to random ID.
    */
   dataDir?: string;
+
+  /**
+   * Optional periodic auto-flush interval in milliseconds. When set (> 0),
+   * buffered events are delivered on this cadence in addition to explicit
+   * {@link Telemetry.flush}/{@link Telemetry.stop} calls.
+   *
+   * Intended for long-lived hosts (e.g. the VS Code extension) that buffer
+   * events for a whole session and cannot guarantee a clean shutdown flush.
+   * Short-lived processes (CLI, MCP) should leave this unset and flush
+   * deterministically. The interval timer is `unref`'d, so it never keeps a
+   * process alive on its own.
+   */
+  flushIntervalMs?: number;
 }

--- a/packages/b2c-tooling-sdk/test/telemetry/app-insights-client.test.ts
+++ b/packages/b2c-tooling-sdk/test/telemetry/app-insights-client.test.ts
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {expect} from 'chai';
+import sinon from 'sinon';
+import {AppInsightsClient, contextTagKeys, parseConnectionString} from '../../src/telemetry/app-insights-client.js';
+
+const FULL_CONN =
+  'InstrumentationKey=6fcc215f-0b11-4864-ad5c-3945ae19e2f3;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=a60f17ec-265a-4dfc-b8df-03a64695697d';
+
+interface CapturedRequest {
+  url: string;
+  init: RequestInit;
+  body: unknown;
+}
+
+/**
+ * Stub global fetch and capture the request. Returns a 200 ingestion response.
+ */
+function stubFetch(sandbox: sinon.SinonSandbox, captured: CapturedRequest[]): sinon.SinonStub {
+  return sandbox.stub(globalThis, 'fetch').callsFake(async (url: string | URL | Request, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    captured.push({url: String(url), init: init ?? {}, body});
+    return new Response(JSON.stringify({itemsReceived: 1, itemsAccepted: 1, errors: []}), {
+      status: 200,
+      headers: {'Content-Type': 'application/json'},
+    });
+  });
+}
+
+describe('telemetry/app-insights-client', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('parseConnectionString', () => {
+    it('parses a full connection string into iKey and v2.1/track URL', () => {
+      const parsed = parseConnectionString(FULL_CONN);
+      expect(parsed).to.not.be.null;
+      expect(parsed!.iKey).to.equal('6fcc215f-0b11-4864-ad5c-3945ae19e2f3');
+      // trailing slash stripped, /v2.1/track appended
+      expect(parsed!.trackUrl).to.equal('https://eastus-8.in.applicationinsights.azure.com/v2.1/track');
+    });
+
+    it('is case-insensitive on keys', () => {
+      const parsed = parseConnectionString('instrumentationkey=abc;ingestionendpoint=https://example.com/');
+      expect(parsed!.iKey).to.equal('abc');
+      expect(parsed!.trackUrl).to.equal('https://example.com/v2.1/track');
+    });
+
+    it('upgrades http endpoints to https', () => {
+      const parsed = parseConnectionString('InstrumentationKey=abc;IngestionEndpoint=http://insecure.example.com/');
+      expect(parsed!.trackUrl).to.equal('https://insecure.example.com/v2.1/track');
+    });
+
+    it('builds endpoint from EndpointSuffix when no IngestionEndpoint is given', () => {
+      const parsed = parseConnectionString('InstrumentationKey=abc;EndpointSuffix=applicationinsights.azure.cn');
+      expect(parsed!.trackUrl).to.equal('https://dc.applicationinsights.azure.cn/v2.1/track');
+    });
+
+    it('includes the location prefix with EndpointSuffix', () => {
+      const parsed = parseConnectionString(
+        'InstrumentationKey=abc;EndpointSuffix=applicationinsights.azure.cn;Location=chinaeast',
+      );
+      expect(parsed!.trackUrl).to.equal('https://chinaeast.dc.applicationinsights.azure.cn/v2.1/track');
+    });
+
+    it('falls back to the default ingestion endpoint', () => {
+      const parsed = parseConnectionString('InstrumentationKey=abc');
+      expect(parsed!.trackUrl).to.equal('https://dc.services.visualstudio.com/v2.1/track');
+    });
+
+    it('accepts a bare GUID (legacy instrumentation key)', () => {
+      const parsed = parseConnectionString('00000000-0000-0000-0000-000000000000');
+      expect(parsed!.iKey).to.equal('00000000-0000-0000-0000-000000000000');
+      expect(parsed!.trackUrl).to.equal('https://dc.services.visualstudio.com/v2.1/track');
+    });
+
+    it('returns null when no instrumentation key is present', () => {
+      expect(parseConnectionString('IngestionEndpoint=https://example.com/')).to.be.null;
+      expect(parseConnectionString('')).to.be.null;
+    });
+  });
+
+  describe('trackEvent envelope', () => {
+    it('produces a Breeze EventData envelope accepted by the ingestion endpoint', async () => {
+      const captured: CapturedRequest[] = [];
+      stubFetch(sandbox, captured);
+
+      const client = new AppInsightsClient(FULL_CONN);
+      client.context.tags[contextTagKeys.userId] = 'cliid-123';
+      client.context.tags[contextTagKeys.cloudRoleInstance] = '';
+      client.trackEvent({
+        name: 'b2c-cli/TEST_EVENT',
+        properties: {action: 'click', version: '1.0.0'},
+        measurements: {duration: 42},
+      });
+      await client.flush();
+
+      expect(captured).to.have.length(1);
+      const req = captured[0];
+      expect(req.url).to.equal('https://eastus-8.in.applicationinsights.azure.com/v2.1/track');
+      expect(req.init.method).to.equal('POST');
+      expect((req.init.headers as Record<string, string>)['Content-Type']).to.equal('application/json');
+
+      // body is a JSON array of envelopes
+      expect(req.body).to.be.an('array').with.length(1);
+      const env = (req.body as Record<string, unknown>[])[0];
+      expect(env.ver).to.equal(1);
+      expect(env.name).to.equal('Microsoft.ApplicationInsights.Event');
+      expect(env.sampleRate).to.equal(100);
+      expect(env.iKey).to.equal('6fcc215f-0b11-4864-ad5c-3945ae19e2f3');
+      expect(env.time).to.be.a('string').and.match(/Z$/); // ISO-8601 UTC
+
+      // GDPR tags live on the envelope, not in properties
+      const tags = env.tags as Record<string, string>;
+      expect(tags['ai.user.id']).to.equal('cliid-123');
+      expect(tags['ai.cloud.roleInstance']).to.equal('');
+
+      const data = env.data as {baseType: string; baseData: Record<string, unknown>};
+      expect(data.baseType).to.equal('EventData');
+      expect(data.baseData.ver).to.equal(2);
+      expect(data.baseData.name).to.equal('b2c-cli/TEST_EVENT');
+      expect(data.baseData.properties).to.deep.equal({action: 'click', version: '1.0.0'});
+      expect(data.baseData.measurements).to.deep.equal({duration: 42});
+    });
+
+    it('defaults properties and measurements to empty objects', async () => {
+      const captured: CapturedRequest[] = [];
+      stubFetch(sandbox, captured);
+
+      const client = new AppInsightsClient(FULL_CONN);
+      client.trackEvent({name: 'b2c-cli/BARE'});
+      await client.flush();
+
+      const data = (captured[0].body as Record<string, unknown>[])[0].data as {baseData: Record<string, unknown>};
+      expect(data.baseData.properties).to.deep.equal({});
+      expect(data.baseData.measurements).to.deep.equal({});
+    });
+  });
+
+  describe('trackException envelope', () => {
+    it('produces a Breeze ExceptionData envelope with the raw stack', async () => {
+      const captured: CapturedRequest[] = [];
+      stubFetch(sandbox, captured);
+
+      const client = new AppInsightsClient(FULL_CONN);
+      const error = new TypeError('Something failed');
+      client.trackException({exception: error, properties: {context: 'test'}, measurements: {count: 1}});
+      await client.flush();
+
+      const env = (captured[0].body as Record<string, unknown>[])[0];
+      expect(env.name).to.equal('Microsoft.ApplicationInsights.Exception');
+      const data = env.data as {baseType: string; baseData: Record<string, unknown>};
+      expect(data.baseType).to.equal('ExceptionData');
+      expect(data.baseData.ver).to.equal(2);
+      expect(data.baseData.severityLevel).to.equal('Error');
+      expect(data.baseData.properties).to.deep.equal({context: 'test'});
+      expect(data.baseData.measurements).to.deep.equal({count: 1});
+
+      const exceptions = data.baseData.exceptions as Record<string, unknown>[];
+      expect(exceptions).to.have.length(1);
+      expect(exceptions[0].typeName).to.equal('TypeError');
+      expect(exceptions[0].message).to.equal('Something failed');
+      expect(exceptions[0].hasFullStack).to.equal(true);
+      expect(exceptions[0].stack).to.be.a('string');
+    });
+
+    it('omits stack and sets hasFullStack false when the error has no stack', async () => {
+      const captured: CapturedRequest[] = [];
+      stubFetch(sandbox, captured);
+
+      const client = new AppInsightsClient(FULL_CONN);
+      const error = new Error('no stack');
+      delete error.stack;
+      client.trackException({exception: error});
+      await client.flush();
+
+      const data = (captured[0].body as Record<string, unknown>[])[0].data as {baseData: Record<string, unknown>};
+      const ex = (data.baseData.exceptions as Record<string, unknown>[])[0];
+      expect(ex.hasFullStack).to.equal(false);
+      expect(ex).to.not.have.property('stack');
+    });
+  });
+
+  describe('property/measurement clamping', () => {
+    it('truncates over-long property keys (150) and values (8192)', async () => {
+      const captured: CapturedRequest[] = [];
+      stubFetch(sandbox, captured);
+
+      const client = new AppInsightsClient(FULL_CONN);
+      const longKey = 'k'.repeat(200);
+      const longValue = 'v'.repeat(10_000);
+      client.trackEvent({
+        name: 'b2c-cli/LONG',
+        properties: {[longKey]: longValue},
+        measurements: {['m'.repeat(200)]: 1},
+      });
+      await client.flush();
+
+      const data = (captured[0].body as Record<string, unknown>[])[0].data as {baseData: Record<string, unknown>};
+      const props = data.baseData.properties as Record<string, string>;
+      const [emittedKey] = Object.keys(props);
+      expect(emittedKey).to.have.lengthOf(150);
+      expect(props[emittedKey]).to.have.lengthOf(8192);
+
+      const measurements = data.baseData.measurements as Record<string, number>;
+      expect(Object.keys(measurements)[0]).to.have.lengthOf(150);
+    });
+
+    it('truncates exception typeName (1024) and message (32768)', async () => {
+      const captured: CapturedRequest[] = [];
+      stubFetch(sandbox, captured);
+
+      const client = new AppInsightsClient(FULL_CONN);
+      const error = new Error('m'.repeat(40_000));
+      error.name = 'N'.repeat(2000);
+      client.trackException({exception: error});
+      await client.flush();
+
+      const data = (captured[0].body as Record<string, unknown>[])[0].data as {baseData: Record<string, unknown>};
+      const ex = (data.baseData.exceptions as Record<string, unknown>[])[0];
+      expect((ex.typeName as string).length).to.equal(1024);
+      expect((ex.message as string).length).to.equal(32768);
+    });
+  });
+
+  describe('buffering and flush', () => {
+    it('batches multiple items into one request', async () => {
+      const captured: CapturedRequest[] = [];
+      stubFetch(sandbox, captured);
+
+      const client = new AppInsightsClient(FULL_CONN);
+      client.trackEvent({name: 'A'});
+      client.trackEvent({name: 'B'});
+      client.trackException({exception: new Error('C')});
+      await client.flush();
+
+      expect(captured).to.have.length(1);
+      expect(captured[0].body).to.be.an('array').with.length(3);
+    });
+
+    it('clears the buffer after flush so a second flush sends nothing', async () => {
+      const captured: CapturedRequest[] = [];
+      stubFetch(sandbox, captured);
+
+      const client = new AppInsightsClient(FULL_CONN);
+      client.trackEvent({name: 'A'});
+      await client.flush();
+      await client.flush();
+
+      expect(captured).to.have.length(1);
+    });
+
+    it('does not call fetch when the buffer is empty', async () => {
+      const fetchStub = stubFetch(sandbox, []);
+      const client = new AppInsightsClient(FULL_CONN);
+      await client.flush();
+      expect(fetchStub.called).to.be.false;
+    });
+  });
+
+  describe('no-op when no instrumentation key', () => {
+    it('does not buffer or send when the connection string has no key', async () => {
+      const fetchStub = stubFetch(sandbox, []);
+      const client = new AppInsightsClient('IngestionEndpoint=https://example.com/');
+      client.trackEvent({name: 'A'});
+      client.trackException({exception: new Error('B')});
+      await client.flush();
+      expect(fetchStub.called).to.be.false;
+    });
+  });
+
+  describe('error handling', () => {
+    it('swallows network errors and still clears the buffer', async () => {
+      const fetchStub = sandbox.stub(globalThis, 'fetch').rejects(new Error('network down'));
+      const client = new AppInsightsClient(FULL_CONN);
+      client.trackEvent({name: 'A'});
+
+      // must not throw
+      await client.flush();
+      expect(fetchStub.calledOnce).to.be.true;
+
+      // buffer was cleared despite the failure: a second flush sends nothing
+      await client.flush();
+      expect(fetchStub.calledOnce).to.be.true;
+    });
+
+    it('aborts the request after the timeout', async () => {
+      let signal: AbortSignal | undefined;
+      sandbox.stub(globalThis, 'fetch').callsFake(async (_url, init?: RequestInit) => {
+        signal = init?.signal ?? undefined;
+        // Never resolves on its own; rely on the abort signal.
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        });
+      });
+
+      const client = new AppInsightsClient(FULL_CONN, {timeoutMs: 10});
+      client.trackEvent({name: 'A'});
+      await client.flush(); // resolves because the abort rejection is swallowed
+      expect(signal?.aborted).to.equal(true);
+    });
+  });
+});

--- a/packages/b2c-tooling-sdk/test/telemetry/telemetry.test.ts
+++ b/packages/b2c-tooling-sdk/test/telemetry/telemetry.test.ts
@@ -8,17 +8,12 @@ import sinon from 'sinon';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-// Namespace import (not default): `applicationinsights` is a legacy CommonJS
-// module whose default-export interop is not synthesized when the file is
-// loaded as native ESM (mocha 11's tsx loader), leaving the default binding
-// `undefined`. The namespace form resolves `TelemetryClient` correctly.
-//
-// Stubbing `TelemetryClient.prototype` methods works (the class prototype is
-// mutable), but the constructor itself cannot be spied through this binding —
-// the ESM namespace exposes it as a non-configurable getter. Tests that need to
-// observe client construction spy the SDK's own `Telemetry.prototype.createClient`
-// seam instead (see the `start` suite below).
-import * as appInsights from 'applicationinsights';
+// The Telemetry wrapper delegates to our zero-dependency AppInsightsClient.
+// Stubbing its prototype methods (the class prototype is mutable) lets us assert
+// the {name, properties, measurements} contract Telemetry passes down without
+// hitting the network. Tests that observe client construction spy the SDK's own
+// `Telemetry.prototype.createClient` seam instead (see the `start` suite below).
+import {AppInsightsClient} from '../../src/telemetry/app-insights-client.js';
 import {Telemetry, createTelemetry} from '@salesforce/b2c-tooling-sdk/telemetry';
 import {configureLogger, resetLogger} from '@salesforce/b2c-tooling-sdk/logging';
 
@@ -45,10 +40,10 @@ describe('telemetry/telemetry', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    trackEventStub = sandbox.stub(appInsights.TelemetryClient.prototype, 'trackEvent');
-    trackExceptionStub = sandbox.stub(appInsights.TelemetryClient.prototype, 'trackException');
-    // applicationinsights 3.x: flush() takes no arguments and returns a Promise.
-    flushStub = sandbox.stub(appInsights.TelemetryClient.prototype, 'flush').resolves();
+    trackEventStub = sandbox.stub(AppInsightsClient.prototype, 'trackEvent');
+    trackExceptionStub = sandbox.stub(AppInsightsClient.prototype, 'trackException');
+    // flush() takes no arguments and returns a Promise.
+    flushStub = sandbox.stub(AppInsightsClient.prototype, 'flush').resolves();
   });
 
   afterEach(() => {
@@ -357,6 +352,26 @@ describe('telemetry/telemetry', () => {
       expect(properties.key).to.equal('event');
     });
 
+    it('redacts the home directory ($HOME -> ~) in string property values for GDPR', async () => {
+      const originalHome = process.env.HOME;
+      process.env.HOME = '/Users/testuser';
+      try {
+        const telemetry = new Telemetry({
+          project: 'test-project',
+          appInsightsKey: 'InstrumentationKey=00000000-0000-0000-0000-000000000000',
+        });
+
+        await telemetry.start();
+        telemetry.sendEvent('TEST_EVENT', {projectPath: '/Users/testuser/projects/x'});
+
+        const {properties} = trackEventStub.firstCall.args[0];
+        expect(properties.projectPath).to.equal('~/projects/x');
+      } finally {
+        if (originalHome !== undefined) process.env.HOME = originalHome;
+        else delete process.env.HOME;
+      }
+    });
+
     it('silently catches errors during send', async () => {
       trackEventStub.throws(new Error('Send failed'));
 
@@ -525,12 +540,10 @@ describe('telemetry/telemetry', () => {
   });
 
   describe('start', () => {
-    // The AppInsights TelemetryClient is constructed inside the private
-    // `createClient` method. Spying that seam (a normal class prototype, always
-    // mutable) lets us assert construction behaviour without spying the
-    // `applicationinsights` constructor export, which is not replaceable under
-    // the native-ESM test loader. The constructed client's resolved
-    // `config.instrumentationKey` confirms the connection string was forwarded.
+    // The AppInsightsClient is constructed inside the private `createClient`
+    // method. Spying that seam (a normal class prototype, always mutable) lets
+    // us assert construction behaviour. The constructed client retains the
+    // supplied connection string on `config.connectionString`.
     it('does nothing when already started', async () => {
       const createClientSpy = sandbox.spy(Telemetry.prototype, 'createClient' as never);
 
@@ -566,11 +579,24 @@ describe('telemetry/telemetry', () => {
       await telemetry.start();
 
       expect(createClientSpy.calledOnce).to.be.true;
-      // The AppInsights client stores the supplied connection string on its config.
-      // applicationinsights 3.x no longer exposes a parsed `instrumentationKey`
-      // property — the full connection string is retained on `config.connectionString`.
+      // The client retains the supplied connection string on `config.connectionString`.
       const client = (telemetry as unknown as {client?: {config?: {connectionString?: string}}}).client;
       expect(client?.config?.connectionString).to.equal('InstrumentationKey=11111111-1111-1111-1111-111111111111');
+    });
+
+    it('sets GDPR context tags on the client (user id + suppressed cloud role instance)', async () => {
+      const telemetry = new Telemetry({
+        project: 'test-project',
+        appInsightsKey: 'InstrumentationKey=00000000-0000-0000-0000-000000000000',
+      });
+
+      await telemetry.start();
+
+      const client = (telemetry as unknown as {client?: {context?: {tags?: Record<string, string>}}}).client;
+      // Machine-identifying cloud role instance must be suppressed (GDPR).
+      expect(client?.context?.tags?.['ai.cloud.roleInstance']).to.equal('');
+      // User id carries the persistent (pseudonymous) cliId.
+      expect(client?.context?.tags?.['ai.user.id']).to.be.a('string').and.not.be.empty;
     });
   });
 
@@ -624,8 +650,7 @@ describe('telemetry/telemetry', () => {
       await telemetry.start();
       await telemetry.flush();
 
-      // applicationinsights 3.x: flush() takes no arguments and returns a Promise
-      // (the 2.x callback-option form was removed).
+      // AppInsightsClient.flush() takes no arguments and returns a Promise.
       expect(flushStub.calledOnce).to.be.true;
       expect(flushStub.firstCall.args).to.have.length(0);
     });
@@ -645,6 +670,67 @@ describe('telemetry/telemetry', () => {
       expect(trackEventStub.calledTwice).to.be.true;
       expect(trackEventStub.firstCall.args[0].name).to.equal('test-project/BEFORE_FLUSH');
       expect(trackEventStub.secondCall.args[0].name).to.equal('test-project/AFTER_FLUSH');
+    });
+  });
+
+  describe('periodic auto-flush (flushIntervalMs)', () => {
+    it('flushes on the configured interval for long-lived hosts', async () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        const telemetry = new Telemetry({
+          project: 'test-project',
+          appInsightsKey: 'InstrumentationKey=00000000-0000-0000-0000-000000000000',
+          flushIntervalMs: 1000,
+        });
+
+        await telemetry.start();
+        expect(flushStub.called).to.be.false;
+
+        await clock.tickAsync(1000);
+        expect(flushStub.calledOnce).to.be.true;
+
+        await clock.tickAsync(1000);
+        expect(flushStub.calledTwice).to.be.true;
+      } finally {
+        clock.restore();
+      }
+    });
+
+    it('does not start a timer when flushIntervalMs is not set', async () => {
+      const setIntervalSpy = sinon.spy(global, 'setInterval');
+      try {
+        const telemetry = new Telemetry({
+          project: 'test-project',
+          appInsightsKey: 'InstrumentationKey=00000000-0000-0000-0000-000000000000',
+        });
+        await telemetry.start();
+        expect(setIntervalSpy.called).to.be.false;
+      } finally {
+        setIntervalSpy.restore();
+      }
+    });
+
+    it('clears the interval timer on stop', async () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        const telemetry = new Telemetry({
+          project: 'test-project',
+          appInsightsKey: 'InstrumentationKey=00000000-0000-0000-0000-000000000000',
+          flushIntervalMs: 1000,
+        });
+
+        await telemetry.start();
+        const stopPromise = telemetry.stop();
+        await clock.tickAsync(300); // drain delay in stop()
+        await stopPromise;
+
+        const flushesAfterStop = flushStub.callCount;
+        await clock.tickAsync(5000);
+        // No further periodic flushes once stopped.
+        expect(flushStub.callCount).to.equal(flushesAfterStop);
+      } finally {
+        clock.restore();
+      }
     });
   });
 

--- a/packages/b2c-vs-extension/src/telemetry.ts
+++ b/packages/b2c-vs-extension/src/telemetry.ts
@@ -50,9 +50,11 @@ function isExtensionTelemetryEnabled(): boolean {
  *   - A connection string is available (from `telemetry.connectionString` in
  *     this package's package.json, or from the `SFCC_APP_INSIGHTS_KEY` env var).
  *
- * Initialization runs in the background and never blocks activation. The HTTP
- * client used by Application Insights buffers events in memory and flushes via
- * a background timer, so subsequent `sendEvent` calls are non-blocking too.
+ * Initialization runs in the background and never blocks activation. The
+ * telemetry client buffers events in memory, so `sendEvent` calls are
+ * non-blocking. Because the extension host is long-lived and may not get a
+ * clean `deactivate()` flush, we enable a periodic auto-flush (see
+ * `flushIntervalMs`) so a dirty shutdown loses at most one interval of events.
  * Failure to initialize is silent — the extension continues without telemetry.
  */
 export function initTelemetry(context: vscode.ExtensionContext): void {
@@ -70,6 +72,9 @@ export function initTelemetry(context: vscode.ExtensionContext): void {
     appInsightsKey: connectionString,
     version: __EXT_VERSION__,
     dataDir: context.globalStorageUri.fsPath,
+    // Long-lived host: deliver buffered events every 30s so a non-clean
+    // shutdown (window force-close, host crash) loses at most one interval.
+    flushIntervalMs: 30_000,
     initialAttributes: {
       host: vscode.env.appName,
       uiKind: vscode.env.uiKind === vscode.UIKind.Web ? 'web' : 'desktop',
@@ -88,8 +93,9 @@ export function initTelemetry(context: vscode.ExtensionContext): void {
 }
 
 /**
- * Send an event. Fire-and-forget — writes into the App Insights in-memory
- * buffer, no HTTP I/O on the calling stack. No-ops when telemetry is disabled.
+ * Send an event. Fire-and-forget — writes into the in-memory buffer, no HTTP
+ * I/O on the calling stack; delivery happens on the periodic flush or at
+ * dispose. No-ops when telemetry is disabled.
  */
 export function sendEvent(eventName: string, attributes: TelemetryAttributes = {}): void {
   instance?.sendEvent(eventName, attributes);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,9 +473,6 @@ importers:
       '@vscode/debugadapter':
         specifier: 1.68.0
         version: 1.68.0
-      applicationinsights:
-        specifier: 3.15.0
-        version: 3.15.0
       chokidar:
         specifier: 5.0.0
         version: 5.0.0
@@ -1494,10 +1491,6 @@ packages:
   '@azu/style-format@1.0.1':
     resolution: {integrity: sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==}
 
-  '@azure-rest/core-client@2.6.1':
-    resolution: {integrity: sha512-KzI10qnkWTsVS2yRBUdc8NLUJ1rOm+292mYs7Pe9wqAj/jv4bRskVm1l8XkKeVTN0OCQtrU5RG0Yhjbz1Wmg7g==}
-    engines: {node: '>=20.0.0'}
-
   '@azure/abort-controller@2.1.2':
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
     engines: {node: '>=18.0.0'}
@@ -1526,9 +1519,6 @@ packages:
     resolution: {integrity: sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==}
     engines: {node: '>=18.0'}
 
-  '@azure/functions@3.5.1':
-    resolution: {integrity: sha512-6UltvJiuVpvHSwLcK/Zc6NfUwlkDLOFFx97BHCJzlWNsfiWwzwmTsxJXg4kE/LemKTHxPpfoPE+kOJ8hAdiKFQ==}
-
   '@azure/functions@4.16.0':
     resolution: {integrity: sha512-cwLld7tRi1VLYNdm1evgS9n8ABP/e+0uLjRO++OjM/kigERG80OfFRRMbag/vpXUzCtda83lDiuCvcwPlxgwZw==}
     engines: {node: '>=20.0'}
@@ -1539,14 +1529,6 @@ packages:
 
   '@azure/logger@1.3.0':
     resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
-    engines: {node: '>=20.0.0'}
-
-  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.42':
-    resolution: {integrity: sha512-xfy6aaoJPvN5bXVA9sVck0qTA5SA9sdqnR17FcqeOYTh5/1sIye0YpbC0ak5GEj8KYFCqPdUqtTxWXEyJB8L+g==}
-    engines: {node: '>=20.0.0'}
-
-  '@azure/monitor-opentelemetry@1.18.1':
-    resolution: {integrity: sha512-v4GArKWlj+ty+Y+bHD+ZjHSaxqTMfx/UwcOxHI16UMaYXrzNhM0r5t5yDwS32Y+uuZRNPWO+MauTtV3o7B/+9g==}
     engines: {node: '>=20.0.0'}
 
   '@azure/msal-browser@4.28.1':
@@ -1560,14 +1542,6 @@ packages:
   '@azure/msal-node@3.8.6':
     resolution: {integrity: sha512-XTmhdItcBckcVVTy65Xp+42xG4LX5GK+9AqAsXPXk4IqUNv+LyQo5TMwNjuFYBfAB2GTG9iSQGk+QLc03vhf3w==}
     engines: {node: '>=16'}
-
-  '@azure/opentelemetry-instrumentation-azure-sdk@1.0.0':
-    resolution: {integrity: sha512-Y8rZOIMXQY/GwNRL+uLVuwIn9aEa/KnnggyYUmFxC1MigmRJCNH5NxMmxKSpddXF9SW6Z1ijRd6Pptd2A5OhGw==}
-    engines: {node: '>=20.0.0'}
-
-  '@azure/opentelemetry-instrumentation-azure-sdk@1.0.0-beta.9':
-    resolution: {integrity: sha512-gNCFokEoQQEkhu2T8i1i+1iW2o9wODn2slu5tpqJmjV1W7qf9dxVv6GNXW1P1WC8wMga8BCc2t/oMhOK3iwRQg==}
-    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -2247,15 +2221,6 @@ packages:
   '@gerrit0/mini-shiki@3.15.0':
     resolution: {integrity: sha512-L5IHdZIDa4bG4yJaOzfasOH/o22MCesY0mx+n6VATbaiCtMeR59pdRqYk4bEiQkIHfxsHPNgdi7VJlZb2FhdMQ==}
 
-  '@grpc/grpc-js@1.14.4':
-    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
-    engines: {node: '>=12.10.0'}
-
-  '@grpc/proto-loader@0.8.1':
-    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   '@h4ad/serverless-adapter@4.4.0':
     resolution: {integrity: sha512-Cj/dBqhOmmzf1ILrXPppEA4e8qWGSm/Mod0uAsftupmMrCGUjvzLq4PBvevnK9ASC5WPbAtnbgkwao+f4tDklw==}
     engines: {node: '>=18.0.0'}
@@ -2679,17 +2644,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@js-sdsl/ordered-map@4.4.2':
-    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
-
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
-
-  '@microsoft/applicationinsights-web-snippet@1.2.3':
-    resolution: {integrity: sha512-59ex4x1/PabGQIg+o0GKG5olqAJYBvMOiXec/9HCD3hK2y36YMWT0ivq5mequvtS5+21kco3SOnMB6QyScLPIA==}
 
   '@modelcontextprotocol/inspector-cli@0.18.0':
     resolution: {integrity: sha512-QMPjKx8zKmX17S1LF2gWuwbYglKexkdgB0HhKZFXzGrQ0MYoKUsIgokMyV48xr4LipaLS3b2v3ut3nV/jhWeSg==}
@@ -2793,360 +2752,6 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
-
-  '@opentelemetry/api-logs@0.200.0':
-    resolution: {integrity: sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==}
-    engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/api-logs@0.211.0':
-    resolution: {integrity: sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==}
-    engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/api-logs@0.217.0':
-    resolution: {integrity: sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==}
-    engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/api-logs@0.218.0':
-    resolution: {integrity: sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==}
-    engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
-    engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/configuration@0.218.0':
-    resolution: {integrity: sha512-W8wIz7H2R1pufR5jfjb3gU2XkMpm2x/7b1RJcsuzvd70Il/rWWE+g5/Od7hQKrxRTSrTrOWlru101PWXz5I1EQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-
-  '@opentelemetry/context-async-hooks@2.7.1':
-    resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/context-async-hooks@2.8.0':
-    resolution: {integrity: sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/core@2.8.0':
-    resolution: {integrity: sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/exporter-logs-otlp-grpc@0.218.0':
-    resolution: {integrity: sha512-hoxrNH1l/Xy6F9WTJ5IK+6j1r9nQFlPOmrnTlhYHTySdunfXLmUCPv3bQtKYntxag9h3wLYBZQ2HI6FOx+BT2g==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-logs-otlp-http@0.217.0':
-    resolution: {integrity: sha512-KfLAdt1uilVE+3FxbgVnp2ZrzqbIawzcesnRoi+Kh9ckB5Ld5D8btUgoBvwTbdmuNx1j6b132Wsh72azq+pPNQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-logs-otlp-http@0.218.0':
-    resolution: {integrity: sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-logs-otlp-proto@0.218.0':
-    resolution: {integrity: sha512-1/noQNsp9gXD75HPzgjBrcF1+XTtry7pFAUfxVEJgg7mPv2AawKQuYkhMmJ8qjxz4Ubc3Y8bwvfxevXsKTq4cg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-metrics-otlp-grpc@0.218.0':
-    resolution: {integrity: sha512-YapQ9vNMX0NSZF6LK5pWAFfjpJleV2O9uYWfYGeb/5F1Kb9rPGK8tZDMJFa/sOksgdFuflDvYuA0B4qjDB4fjQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-metrics-otlp-http@0.217.0':
-    resolution: {integrity: sha512-1zkMzzhiNJdVmLxuwkltqWGw4fOOam47bqRxmuQNjyKJe/9NmY5cIrZ4kiQV7sVGxoOgT0ZvGUfLcjvtpC/b9Q==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-metrics-otlp-http@0.218.0':
-    resolution: {integrity: sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-metrics-otlp-proto@0.217.0':
-    resolution: {integrity: sha512-nfxt/KxVGFkjkO/M+58y1ugHu/dwPtxG4eYq0KApcQ7xk5CHzhdn+IuLZfDSvNDrJ3Uy5q++Fj/wbK7i8yryfQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-metrics-otlp-proto@0.218.0':
-    resolution: {integrity: sha512-ubLddKjWULhla9YZRCj/rTBeppjJYE4e9w0icx5mTu3eFhWjQzbV75NYjXuIlEG+NJsBl6d+sTFw5Qu+oej4oQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-prometheus@0.218.0':
-    resolution: {integrity: sha512-RT5oEyu1kddZJ1vt7/BUo5wV+P7hpNAESsR3dUd3+8deHuX7gWNoCOZn+SfDT+hJHlIJ5h/AxiCLXIrutswDJg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-trace-otlp-grpc@0.218.0':
-    resolution: {integrity: sha512-3fXxVQEj9TNAFaCi79JeFKfeLd0sDtInaR3gaZDVlzNSPHtz8PZuCV34JKWjD4XXzT20IdMe8IpX6mRVNDA4Tw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-trace-otlp-http@0.217.0':
-    resolution: {integrity: sha512-38YQoqtYjglz2GV94LGUN/djLvxtvGIQO68o6qAFPVshjmwSdX1F2i0c7vn3lEl1L5B/YqjB/bgKXaVx7KO+RQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-trace-otlp-http@0.218.0':
-    resolution: {integrity: sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-trace-otlp-proto@0.218.0':
-    resolution: {integrity: sha512-r1Msf8SNLRmwh9J6XQ5uh82D7CdDWMNHnPB7LAVHjzut0TkSeKc5KcIvr4SvHvfk/xwN5gxC+VLKQ1k0o8PSPw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-zipkin@2.7.1':
-    resolution: {integrity: sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.0.0
-
-  '@opentelemetry/instrumentation-bunyan@0.62.0':
-    resolution: {integrity: sha512-4PjSfgyzKzhnnczUkbh8ogDclQqInBsSK0J3BQX4wRueK7cCGUyQghLQYqPW1TbzrXUfM0kNtrnu1D5Xbk3LEA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-http@0.218.0':
-    resolution: {integrity: sha512-x9djaqdzpT8WAboep1H9nCAQ1E+MMsm08TNfA02TqM3bNNddZeiim+E3KMWVQFaX6JpUy7V0nm/wfN/K2Em+Zw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-mongodb@0.70.0':
-    resolution: {integrity: sha512-9DeBe6SiOkguL5uRyj20ma0I1lXgW0EYc9mUnABlMzbxYC3b7sczUFSj37eWaLzZNzTVQNr+U8UZZP2LvlZ+vw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-mysql@0.63.0':
-    resolution: {integrity: sha512-IFzZiZtLgQEzK74OHT921n1ARRUyRWWe/5oa5nezuwQF4XzLEXIqTP+vthrZ4QJc1qIkRLgPROVDcjz20gEKew==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-pg@0.69.0':
-    resolution: {integrity: sha512-5tHz2AOyuYaWJePxybooIHPlV8v1EPBwrgFlfuuGXBV/EFnnQME+KEPJ9u9e3oe2aKd0gi8CEkTzZ61VwuWo5g==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-redis@0.65.0':
-    resolution: {integrity: sha512-NwEhtBXwIKvcPSEGyYqjWaUZB1vfda1aVbEOTjhtBSbNDsxSXnGF1/xlwBB2yYZtLC4oYzlc9FRS7wX//X4LTg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-winston@0.61.0':
-    resolution: {integrity: sha512-H600rWjFPFXK0UDGmWucEcbylXKI9i+7i2g8LGSkYqU44PCw09xFhKwv4VPTvyGmcEsCIlckbIKj/GvYy0UeEw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation@0.200.0':
-    resolution: {integrity: sha512-pmPlzfJd+vvgaZd/reMsC8RWgTXn2WY1OWT5RT42m3aOn5532TozwXNDhg1vzqJ+jnvmkREcdLr27ebJEQt0Jg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation@0.211.0':
-    resolution: {integrity: sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation@0.217.0':
-    resolution: {integrity: sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation@0.218.0':
-    resolution: {integrity: sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/otlp-exporter-base@0.217.0':
-    resolution: {integrity: sha512-eYfqnB3UhKu/5frhd1R6+FprKygbhkomuaceMXDyzxbfXB9tKgZOVmjaJ02CkLA6Tdzumxl+e2H+vo2a8jiMPQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/otlp-exporter-base@0.218.0':
-    resolution: {integrity: sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/otlp-grpc-exporter-base@0.218.0':
-    resolution: {integrity: sha512-H/lCGJ536N98VpYJOaWTQOkv4Dx6TnmStK6Rqfu1W7KkFbPAx04hjdYEMZF/YbnHzPUSIK4kM6OE2GKGBTpV9A==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/otlp-transformer@0.217.0':
-    resolution: {integrity: sha512-MKK8UHKFUOGAvbZRWh90MhwHG+Fxm6OROBdjKPCF+HQobjuJ/Kuf8Chs8CR45X1aqotxrMj7OxTdsXe8sXuGVA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/otlp-transformer@0.218.0':
-    resolution: {integrity: sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/propagator-b3@2.7.1':
-    resolution: {integrity: sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/propagator-jaeger@2.7.1':
-    resolution: {integrity: sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/redis-common@0.38.3':
-    resolution: {integrity: sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-
-  '@opentelemetry/resource-detector-azure@0.25.0':
-    resolution: {integrity: sha512-e/NRDC3W2NYfxXJIto38wF1qgEyWpelaKp6QPIHGn320EknobnHCI7gUuoOAB6J2EJaW9ewNTIoDWDhO3AbdKA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.0.0
-
-  '@opentelemetry/resources@2.5.0':
-    resolution: {integrity: sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/resources@2.7.1':
-    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/resources@2.8.0':
-    resolution: {integrity: sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-logs@0.217.0':
-    resolution: {integrity: sha512-BB+PcHItcZDL63dPMW+mJvwN9rk37wuIDjRxbVlg6pPDvDR/7GL7UJHbGsllgoggOoTimsKgENaWPoGch/oE1A==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.4.0 <1.10.0'
-
-  '@opentelemetry/sdk-logs@0.218.0':
-    resolution: {integrity: sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.4.0 <1.10.0'
-
-  '@opentelemetry/sdk-metrics@2.7.1':
-    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.9.0 <1.10.0'
-
-  '@opentelemetry/sdk-metrics@2.8.0':
-    resolution: {integrity: sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.9.0 <1.10.0'
-
-  '@opentelemetry/sdk-node@0.218.0':
-    resolution: {integrity: sha512-tPMjHrLV5gsfNdYqoRHjeGbCAZBXXD9c1Qo/2ut7VwnUABDNh76xNxrT0SEhkIIJuCN45bbN1vZnYL1gY0IkOg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-base@2.5.0':
-    resolution: {integrity: sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-base@2.7.1':
-    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-base@2.8.0':
-    resolution: {integrity: sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-node@2.7.1':
-    resolution: {integrity: sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-node@2.8.0':
-    resolution: {integrity: sha512-nZt9OGufioAc3AfoLTqA9bsAeaMJAictYDdI2VcNQ+PmT+3rfKjAZDZvgPfd8VPX0O5Bw1hdQF6kDK8VSpZiWg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-web@2.5.0':
-    resolution: {integrity: sha512-xWibakHs+xbx6vxH7Q8TbFS6zjf812o/kIS4xBDB32qSL9wF+Z5IZl2ZAGu4rtmPBQ7coZcOd684DobMhf8dKw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/semantic-conventions@1.39.0':
-    resolution: {integrity: sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==}
-    engines: {node: '>=14'}
-
-  '@opentelemetry/semantic-conventions@1.41.1':
-    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
-    engines: {node: '>=14'}
-
-  '@opentelemetry/sql-common@0.41.2':
-    resolution: {integrity: sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-
-  '@opentelemetry/winston-transport@0.27.0':
-    resolution: {integrity: sha512-Imeoqm9CqxSJRo6INwtOn1Kx2XXYZzkyrH6q2teIDJ7ZypKx7DRf23l5ylQZ3vYibkcCLIANbzpeMqCNPp4CEw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -4350,9 +3955,6 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
-  '@types/bunyan@1.8.11':
-    resolution: {integrity: sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==}
-
   '@types/chai@4.3.20':
     resolution: {integrity: sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==}
 
@@ -4437,9 +4039,6 @@ packages:
   '@types/mute-stream@0.0.4':
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
 
-  '@types/mysql@2.15.27':
-    resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
-
   '@types/negotiator@0.6.4':
     resolution: {integrity: sha512-elf6BsTq+AkyNsb2h5cGNst2Mc7dPliVoAPm1fXglC/BM3f2pFA40BaSSv3E5lyHteEawVKLP+8TwiY1DMNb3A==}
 
@@ -4454,12 +4053,6 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
-
-  '@types/pg-pool@2.0.7':
-    resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
-
-  '@types/pg@8.15.6':
-    resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -4478,9 +4071,6 @@ packages:
 
   '@types/set-cookie-parser@2.4.10':
     resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
-
-  '@types/shimmer@1.2.0':
-    resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
 
   '@types/sinon@17.0.4':
     resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
@@ -4871,11 +4461,6 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  acorn-import-attributes@1.9.5:
-    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
-    peerDependencies:
-      acorn: ^8
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -4951,10 +4536,6 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
-
-  applicationinsights@3.15.0:
-    resolution: {integrity: sha512-v1RaIh6+thS3OnobQn2iSvDxrjZhyEU4XRigQzkEGXbnSlV+6IveAI29690a+o7EOR1gsIiREQrljq8R4WCeTA==}
-    engines: {node: '>=20.0.0'}
 
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
@@ -5314,12 +4895,6 @@ packages:
     resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
     engines: {node: '>=8'}
 
-  cjs-module-lexer@1.4.3:
-    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
-
-  cjs-module-lexer@2.2.0:
-    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
-
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -5653,14 +5228,6 @@ packages:
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
-
-  diagnostic-channel-publishers@1.0.8:
-    resolution: {integrity: sha512-HmSm9hXxSPxA9BaLGY98QU1zsdjeCk113KjAYGPCen1ZP6mhVaTPzHd6UYv5r21DnWANi+f+NyPOHruGT9jpqQ==}
-    peerDependencies:
-      diagnostic-channel: '*'
-
-  diagnostic-channel@1.1.1:
-    resolution: {integrity: sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==}
 
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
@@ -6269,9 +5836,6 @@ packages:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
     engines: {node: '>=14.0.0'}
 
-  forwarded-parse@2.1.2:
-    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
-
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -6620,16 +6184,6 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
-
-  import-in-the-middle@1.15.0:
-    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
-
-  import-in-the-middle@2.0.6:
-    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
-
-  import-in-the-middle@3.0.2:
-    resolution: {integrity: sha512-LGLYRl0A2gtyUJb2WDliBHmk6TtlHwdDjxonacZ8QrEs/ZW+YDgNv2QAfjRQWpS8HqvNcq6GGnN6jrOa5FysDQ==}
-    engines: {node: '>=18'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -7048,9 +6602,6 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash.camelcase@4.3.0:
-    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -7095,9 +6646,6 @@ packages:
   logform@2.7.0:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
-
-  long@4.0.0:
-    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -7314,9 +6862,6 @@ packages:
     resolution: {integrity: sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
-
-  module-details-from-path@1.0.4:
-    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -7809,17 +7354,6 @@ packages:
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
-  pg-int8@1.0.1:
-    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
-    engines: {node: '>=4.0.0'}
-
-  pg-protocol@1.14.0:
-    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
-
-  pg-types@2.2.0:
-    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
-    engines: {node: '>=4'}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -7875,22 +7409,6 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postgres-array@2.0.0:
-    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
-    engines: {node: '>=4'}
-
-  postgres-bytea@1.0.1:
-    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
-    engines: {node: '>=0.10.0'}
-
-  postgres-date@1.0.7:
-    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
-    engines: {node: '>=0.10.0'}
-
-  postgres-interval@1.2.0:
-    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
-    engines: {node: '>=0.10.0'}
-
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
@@ -7945,10 +7463,6 @@ packages:
 
   protobufjs@7.6.4:
     resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
-    engines: {node: '>=12.0.0'}
-
-  protobufjs@8.6.4:
-    resolution: {integrity: sha512-/+XMv9JalknuncEJSwsyEVlwcxVLKx2iaoSUXFZA86MJkdqyOdfrlB1sB7S6aKyUk9tl20YY+SgQe5J2sJHTcg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -8142,14 +7656,6 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  require-in-the-middle@7.5.2:
-    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
-    engines: {node: '>=8.6.0'}
-
-  require-in-the-middle@8.0.1:
-    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
-    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
-
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
@@ -8328,9 +7834,6 @@ packages:
 
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
-
-  shimmer@1.2.1:
-    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
 
   shx@0.3.4:
     resolution: {integrity: sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==}
@@ -9170,10 +8673,6 @@ packages:
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
-
-  xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -10674,17 +10173,6 @@ snapshots:
     dependencies:
       '@azu/format-text': 1.0.2
 
-  '@azure-rest/core-client@2.6.1':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-rest-pipeline': 1.22.2
-      '@azure/core-tracing': 1.3.1
-      '@typespec/ts-http-runtime': 0.3.3
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@azure/abort-controller@2.1.2':
     dependencies:
       tslib: 2.8.1
@@ -10733,18 +10221,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/functions-extensions-base@0.3.0': {}
-
-  '@azure/functions@3.5.1':
-    dependencies:
-      iconv-lite: 0.6.3
-      long: 4.0.0
-      uuid: 8.3.2
+  '@azure/functions-extensions-base@0.3.0':
+    optional: true
 
   '@azure/functions@4.16.0':
     dependencies:
       '@azure/functions-extensions-base': 0.3.0
       cookie: 0.7.2
+    optional: true
 
   '@azure/identity@4.13.0':
     dependencies:
@@ -10769,58 +10253,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.42':
-    dependencies:
-      '@azure-rest/core-client': 2.6.1
-      '@azure/core-auth': 1.10.1
-      '@azure/core-client': 1.10.1
-      '@azure/core-rest-pipeline': 1.22.2
-      '@azure/core-util': 1.13.1
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.218.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/monitor-opentelemetry@1.18.1':
-    dependencies:
-      '@azure-rest/core-client': 2.6.1
-      '@azure/core-auth': 1.10.1
-      '@azure/core-rest-pipeline': 1.22.2
-      '@azure/logger': 1.3.0
-      '@azure/monitor-opentelemetry-exporter': 1.0.0-beta.42
-      '@azure/opentelemetry-instrumentation-azure-sdk': 1.0.0
-      '@microsoft/applicationinsights-web-snippet': 1.2.3
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.218.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-bunyan': 0.62.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-http': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-mongodb': 0.70.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-mysql': 0.63.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-pg': 0.69.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-redis': 0.65.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-winston': 0.61.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resource-detector-azure': 0.25.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-node': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-node': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@opentelemetry/winston-transport': 0.27.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@azure/msal-browser@4.28.1':
     dependencies:
       '@azure/msal-common': 15.14.1
@@ -10832,30 +10264,6 @@ snapshots:
       '@azure/msal-common': 15.14.1
       jsonwebtoken: 9.0.3
       uuid: 8.3.2
-
-  '@azure/opentelemetry-instrumentation-azure-sdk@1.0.0':
-    dependencies:
-      '@azure/core-tracing': 1.3.1
-      '@azure/logger': 1.3.0
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-web': 2.5.0(@opentelemetry/api@1.9.0)
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/opentelemetry-instrumentation-azure-sdk@1.0.0-beta.9':
-    dependencies:
-      '@azure/core-tracing': 1.3.1
-      '@azure/logger': 1.3.0
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.200.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-web': 2.5.0(@opentelemetry/api@1.9.0)
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -11422,18 +10830,6 @@ snapshots:
       '@shikijs/types': 3.15.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@grpc/grpc-js@1.14.4':
-    dependencies:
-      '@grpc/proto-loader': 0.8.1
-      '@js-sdsl/ordered-map': 4.4.2
-
-  '@grpc/proto-loader@0.8.1':
-    dependencies:
-      lodash.camelcase: 4.3.0
-      long: 5.3.2
-      protobufjs: 7.6.4
-      yargs: 17.7.2(patch_hash=93c6b35288ee71f8125ecb75d3f2a609bfaf8917db71d23b4e0034f39a0d9961)
-
   '@h4ad/serverless-adapter@4.4.0(@azure/functions@4.16.0)(@types/aws-lambda@8.10.160)(@types/body-parser@1.19.6)(@types/cors@2.8.19)(@types/express@5.0.3)(body-parser@2.2.1)(cors@2.8.5)(express@5.1.0)(http-errors@2.0.1)':
     dependencies:
       '@types/body-parser': 1.19.6
@@ -11816,8 +11212,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@js-sdsl/ordered-map@4.4.2': {}
-
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -11833,8 +11227,6 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
-
-  '@microsoft/applicationinsights-web-snippet@1.2.3': {}
 
   '@modelcontextprotocol/inspector-cli@0.18.0(zod@3.25.76)':
     dependencies:
@@ -12068,481 +11460,6 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
-
-  '@opentelemetry/api-logs@0.200.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-
-  '@opentelemetry/api-logs@0.211.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-
-  '@opentelemetry/api-logs@0.217.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-
-  '@opentelemetry/api-logs@0.218.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-
-  '@opentelemetry/api@1.9.0': {}
-
-  '@opentelemetry/configuration@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      yaml: 2.9.0
-
-  '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-
-  '@opentelemetry/context-async-hooks@2.8.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-
-  '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.39.0
-
-  '@opentelemetry/exporter-logs-otlp-grpc@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@grpc/grpc-js': 1.14.4
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-logs-otlp-http@0.217.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-logs-otlp-http@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.218.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-logs-otlp-proto@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.218.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-metrics-otlp-grpc@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@grpc/grpc-js': 1.14.4
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-metrics-otlp-http@0.217.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-metrics-otlp-http@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-metrics-otlp-proto@0.217.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-metrics-otlp-proto@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-prometheus@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-
-  '@opentelemetry/exporter-trace-otlp-grpc@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@grpc/grpc-js': 1.14.4
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/exporter-zipkin@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-
-  '@opentelemetry/instrumentation-bunyan@0.62.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.0)
-      '@types/bunyan': 1.8.11
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-http@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      forwarded-parse: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-mongodb@0.70.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-mysql@0.63.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@types/mysql': 2.15.27
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-pg@0.69.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
-      '@types/pg': 8.15.6
-      '@types/pg-pool': 2.0.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-redis@0.65.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/redis-common': 0.38.3
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-winston@0.61.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation@0.200.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.200.0
-      '@types/shimmer': 1.2.0
-      import-in-the-middle: 1.15.0
-      require-in-the-middle: 7.5.2
-      shimmer: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.211.0
-      import-in-the-middle: 2.0.6
-      require-in-the-middle: 8.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.217.0
-      import-in-the-middle: 3.0.2
-      require-in-the-middle: 8.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.218.0
-      import-in-the-middle: 3.0.2
-      require-in-the-middle: 8.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/otlp-exporter-base@0.217.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/otlp-exporter-base@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/otlp-grpc-exporter-base@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@grpc/grpc-js': 1.14.4
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/otlp-transformer@0.217.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-      protobufjs: 8.6.4
-
-  '@opentelemetry/otlp-transformer@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.218.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/propagator-jaeger@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/redis-common@0.38.3': {}
-
-  '@opentelemetry/resource-detector-azure@0.25.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-
-  '@opentelemetry/resources@2.5.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
-
-  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
-
-  '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
-
-  '@opentelemetry/sdk-logs@0.217.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
-
-  '@opentelemetry/sdk-logs@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.218.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-
-  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/sdk-node@0.218.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.218.0
-      '@opentelemetry/configuration': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-logs-otlp-grpc': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-logs-otlp-http': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-logs-otlp-proto': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-grpc': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-proto': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-prometheus': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-grpc': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-proto': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-zipkin': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/propagator-b3': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/propagator-jaeger': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.5.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
-
-  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
-
-  '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
-
-  '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/sdk-trace-web@2.5.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.5.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/semantic-conventions@1.39.0': {}
-
-  '@opentelemetry/semantic-conventions@1.41.1': {}
-
-  '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/winston-transport@0.27.0':
-    dependencies:
-      '@opentelemetry/api-logs': 0.217.0
-      winston-transport: 4.9.0
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -13856,10 +12773,6 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 22.19.0
 
-  '@types/bunyan@1.8.11':
-    dependencies:
-      '@types/node': 22.19.0
-
   '@types/chai@4.3.20': {}
 
   '@types/compressible@2.0.3': {}
@@ -13944,10 +12857,6 @@ snapshots:
     dependencies:
       '@types/node': 22.19.0
 
-  '@types/mysql@2.15.27':
-    dependencies:
-      '@types/node': 22.19.0
-
   '@types/negotiator@0.6.4': {}
 
   '@types/node@12.20.55': {}
@@ -13961,16 +12870,6 @@ snapshots:
       undici-types: 7.24.6
 
   '@types/normalize-package-data@2.4.4': {}
-
-  '@types/pg-pool@2.0.7':
-    dependencies:
-      '@types/pg': 8.15.6
-
-  '@types/pg@8.15.6':
-    dependencies:
-      '@types/node': 22.19.0
-      pg-protocol: 1.14.0
-      pg-types: 2.2.0
 
   '@types/qs@6.14.0': {}
 
@@ -13990,8 +12889,6 @@ snapshots:
   '@types/set-cookie-parser@2.4.10':
     dependencies:
       '@types/node': 22.19.0
-
-  '@types/shimmer@1.2.0': {}
 
   '@types/sinon@17.0.4':
     dependencies:
@@ -14411,10 +13308,6 @@ snapshots:
       mime-types: 3.0.1
       negotiator: 1.0.0
 
-  acorn-import-attributes@1.9.5(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
-
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -14475,34 +13368,6 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
-
-  applicationinsights@3.15.0:
-    dependencies:
-      '@azure/core-auth': 1.10.1
-      '@azure/functions': 4.16.0
-      '@azure/functions-old': '@azure/functions@3.5.1'
-      '@azure/identity': 4.13.0
-      '@azure/monitor-opentelemetry': 1.18.1
-      '@azure/monitor-opentelemetry-exporter': 1.0.0-beta.42
-      '@azure/opentelemetry-instrumentation-azure-sdk': 1.0.0-beta.9
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-logs-otlp-http': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-proto': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-node': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
-      diagnostic-channel: 1.1.1
-      diagnostic-channel-publishers: 1.0.8(diagnostic-channel@1.1.1)
-    transitivePeerDependencies:
-      - supports-color
 
   are-docs-informative@0.0.2: {}
 
@@ -14937,10 +13802,6 @@ snapshots:
 
   ci-info@4.3.1: {}
 
-  cjs-module-lexer@1.4.3: {}
-
-  cjs-module-lexer@2.2.0: {}
-
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -15245,14 +14106,6 @@ snapshots:
     dependencies:
       asap: 2.0.6
       wrappy: 1.0.2
-
-  diagnostic-channel-publishers@1.0.8(diagnostic-channel@1.1.1):
-    dependencies:
-      diagnostic-channel: 1.1.1
-
-  diagnostic-channel@1.1.1:
-    dependencies:
-      semver: 7.7.3
 
   diff@4.0.4: {}
 
@@ -16180,8 +15033,6 @@ snapshots:
       dezalgo: 1.0.4
       once: 1.4.0
 
-  forwarded-parse@2.1.2: {}
-
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -16574,27 +15425,6 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-in-the-middle@1.15.0:
-    dependencies:
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
-      cjs-module-lexer: 1.4.3
-      module-details-from-path: 1.0.4
-
-  import-in-the-middle@2.0.6:
-    dependencies:
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
-      cjs-module-lexer: 2.2.0
-      module-details-from-path: 1.0.4
-
-  import-in-the-middle@3.0.2:
-    dependencies:
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
-      cjs-module-lexer: 2.2.0
-      module-details-from-path: 1.0.4
-
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -16972,8 +15802,6 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash.camelcase@4.3.0: {}
-
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -17014,8 +15842,6 @@ snapshots:
       ms: 2.1.3
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
-
-  long@4.0.0: {}
 
   long@5.3.2: {}
 
@@ -17228,8 +16054,6 @@ snapshots:
       yargs: 17.7.2(patch_hash=93c6b35288ee71f8125ecb75d3f2a609bfaf8917db71d23b4e0034f39a0d9961)
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
-
-  module-details-from-path@1.0.4: {}
 
   mri@1.2.0: {}
 
@@ -17694,18 +16518,6 @@ snapshots:
 
   perfect-debounce@2.1.0: {}
 
-  pg-int8@1.0.1: {}
-
-  pg-protocol@1.14.0: {}
-
-  pg-types@2.2.0:
-    dependencies:
-      pg-int8: 1.0.1
-      postgres-array: 2.0.0
-      postgres-bytea: 1.0.1
-      postgres-date: 1.0.7
-      postgres-interval: 1.2.0
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -17772,16 +16584,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgres-array@2.0.0: {}
-
-  postgres-bytea@1.0.1: {}
-
-  postgres-date@1.0.7: {}
-
-  postgres-interval@1.2.0:
-    dependencies:
-      xtend: 4.0.2
-
   powershell-utils@0.1.0: {}
 
   prebuild-install@7.1.3:
@@ -17838,10 +16640,6 @@ snapshots:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
       '@types/node': 22.19.0
-      long: 5.3.2
-
-  protobufjs@8.6.4:
-    dependencies:
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -18050,21 +16848,6 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
-
-  require-in-the-middle@7.5.2:
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      module-details-from-path: 1.0.4
-      resolve: 1.22.11
-    transitivePeerDependencies:
-      - supports-color
-
-  require-in-the-middle@8.0.1:
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      module-details-from-path: 1.0.4
-    transitivePeerDependencies:
-      - supports-color
 
   requires-port@1.0.0: {}
 
@@ -18323,8 +17106,6 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
-
-  shimmer@1.2.1: {}
 
   shx@0.3.4:
     dependencies:
@@ -19291,8 +18072,6 @@ snapshots:
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
-
-  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary

Replaces the `applicationinsights` SDK dependency in `@salesforce/b2c-tooling-sdk` with a small, zero-runtime-dependency client that posts telemetry directly to the Application Insights ingestion endpoint using Node's built-in `fetch`.

The `applicationinsights` v3.x package pulls in ~270 transitive packages (OpenTelemetry, the Azure SDK, gRPC/protobuf, DB instrumentations) to support auto-collection features we never used — our telemetry is manual event/exception tracking only, with every auto-collection feature explicitly disabled. The new `AppInsightsClient` (~230 lines) POSTs classic "Breeze" envelopes to `/v2.1/track` and exposes a `TelemetryClient`-compatible shape, so the public `Telemetry` API is unchanged and the CLI/MCP/extension consumers need no changes.

### Impact
- **Removes ~274 packages** from the install (`pnpm-lock.yaml` sheds ~1,227 lines); shrinks published packages and the VS Code extension bundle.
- **Fixes a GDPR regression introduced by v3:** the v3 SDK leaked the machine hostname into `ai.cloud.roleInstance` despite our suppression code. The new client suppresses it correctly (verified on the wire).
- **Restores background-delivery parity for long-lived hosts:** adds an opt-in `flushIntervalMs` option. The VS Code extension uses it (30s) so a session's usage events aren't lost on a non-clean shutdown — short-lived processes (CLI, MCP) keep flushing deterministically.

### Wire-format verification
The Breeze envelope shape and transport were not guessed — they were verified by (1) capturing what the real v3 SDK emits on the wire, and (2) live round-trips against the real ingestion endpoint, which returned `itemsReceived == itemsAccepted, errors: []` for the hand-rolled envelopes (events, exceptions, and the end-to-end `Telemetry` path including periodic flush).

## Testing

Covered by the existing test suites plus new unit tests for connection-string parsing, envelope shape, tag placement, buffering/flush, error/timeout handling, truncation, $HOME redaction, and periodic auto-flush. Lint, typecheck, build, and format all pass across the SDK, CLI, MCP, and VS Code extension packages.

## Dependencies

- [x] No net-new third-party dependencies were added

This PR **removes** a third-party dependency (`applicationinsights`) and its ~270-package transitive tree; the replacement uses only Node built-ins (`fetch`, `crypto`, `fs`, `path`).

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
