### PR TITLE
docs(cap): refocus Commerce Apps guide on CLI + recommend agent skills

### DIFF
--- a/.changeset/cap-guide-agent-skills.md
+++ b/.changeset/cap-guide-agent-skills.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/b2c-dx-docs': patch
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Refocus the Commerce Apps (CAP) documentation on the B2C CLI workflow and recommend the `b2c-cli`, `b2c`, and `cap-dev` agent skills plugins (the latter from the `SalesforceCommerceCloud/commerce-apps` marketplace). The guide now links to the official Commerce Apps ISV Developer Guide as the authoritative spec rather than duplicating it, and corrects several details against canon and the CLI source: the tax extension point is `sfcc.app.tax.calculate`, the install upload path is `Impex/commerce-apps/`, the lifecycle states are `INSTALLING → INSTALLED → NOT_CONFIGURED → CONFIGURING → CONFIGURED`, and `cap package` produces `{id}-v{version}.zip`. The `b2c-cap` skill and CAP CLI reference gain WebDAV auth, icon-naming, and registry-vs-local-validation clarifications.

--- a/docs/cli/cap.md
+++ b/docs/cli/cap.md
@@ -20,11 +20,13 @@ Install, uninstall, list, and tasks commands require OAuth authentication with O
 
 Configure these resources in Business Manager under **Administration** > **Site Development** > **Open Commerce API Settings**:
 
-| Resource | Methods | Commands |
-|----------|---------|----------|
-| `/jobs/*/executions` | POST | `cap install`, `cap uninstall`, `cap list`, `cap tasks` |
-| `/jobs/*/executions/*` | GET | `cap install`, `cap uninstall`, `cap list`, `cap tasks` |
-| `/sites` | GET | `cap list` (when no `--site-id` specified) |
+| Resource               | Methods | Commands                                                |
+| ---------------------- | ------- | ------------------------------------------------------- |
+| `/jobs/*/executions`   | POST    | `cap install`, `cap uninstall`, `cap list`, `cap tasks` |
+| `/jobs/*/executions/*` | GET     | `cap install`, `cap uninstall`, `cap list`, `cap tasks` |
+| `/sites`               | GET     | `cap list` (when no `--site-id` specified)              |
+
+The `cap` commands poll job status via `GET /jobs/*/executions/*`. The official [Commerce Apps reference](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/reference.html) also lists `/job_execution_search` (POST) under the permissions for Commerce App job execution; the `cap` commands don't call it, but granting it lets a single OCAPI client match the full reference set.
 
 ### WebDAV Access
 
@@ -44,14 +46,14 @@ b2c cap validate PATH
 
 ### Arguments
 
-| Argument | Description |
-|----------|-------------|
-| `PATH` | Path to a CAP directory or `.zip` file |
+| Argument | Description                            |
+| -------- | -------------------------------------- |
+| `PATH`   | Path to a CAP directory or `.zip` file |
 
 ### Flags
 
-| Flag | Description |
-|------|-------------|
+| Flag     | Description           |
+| -------- | --------------------- |
 | `--json` | Output result as JSON |
 
 ### Validation Checks
@@ -71,8 +73,10 @@ b2c cap validate PATH
 
 **Warnings** (advisory):
 
-- `icons/icon.png` is recommended for marketplace listing
+- A marketplace icon is recommended. The command looks specifically for `icons/icon.png`; note that the Commerce Apps registry expects the icon to be named after the ISV (`icons/{isv-name}.{ext}`, where `{ext}` is `png`, `svg`, `jpg`, or `jpeg`), so a registry-ready CAP may still warn here.
 - `impex/uninstall/` is recommended for clean removal
+
+> **Note:** `b2c cap validate` performs **local structural checks only** (the items above). It enforces the manifest fields the CLI itself relies on — `id`, `name`, `version`, and `domain` — but the Commerce Apps registry additionally requires `description` and a `publisher` object (`publisher.name`, `publisher.url`, `publisher.support`). A CAP can therefore pass `b2c cap validate` and still be rejected by the registry. For registry-grade validation (manifest completeness, SHA-256, Storefront Next locale coverage, IMPEX install/uninstall pairing), use the `cap-dev` skills' `/validate-app` and the [Testing & Validation guide](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/testing-validation.html).
 
 ### Examples
 
@@ -101,16 +105,16 @@ b2c cap package PATH [--output PATH]
 
 ### Arguments
 
-| Argument | Description |
-|----------|-------------|
-| `PATH` | Path to the CAP source directory |
+| Argument | Description                      |
+| -------- | -------------------------------- |
+| `PATH`   | Path to the CAP source directory |
 
 ### Flags
 
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--output PATH` | `-o` | Output path (directory or `.zip` filename). Defaults to current directory. |
-| `--json` | | Output result as JSON |
+| Flag            | Short | Description                                                                |
+| --------------- | ----- | -------------------------------------------------------------------------- |
+| `--output PATH` | `-o`  | Output path (directory or `.zip` filename). Defaults to current directory. |
+| `--json`        |       | Output result as JSON                                                      |
 
 ### Examples
 
@@ -139,20 +143,20 @@ b2c cap install PATH --site-id SITE_ID
 
 ### Arguments
 
-| Argument | Description |
-|----------|-------------|
-| `PATH` | Path to a CAP directory or `.zip` file |
+| Argument | Description                            |
+| -------- | -------------------------------------- |
+| `PATH`   | Path to a CAP directory or `.zip` file |
 
 ### Flags
 
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--site-id SITE_ID` | `-s` | **Required.** Site ID to install the app on |
-| `--clean-archive` | | Delete the uploaded zip from the instance after install |
-| `--timeout SECONDS` | `-t` | Timeout in seconds (default: no timeout) |
-| `--skip-validate` | | Skip CAP structure validation before install |
-| `--create-pr` | | Create a pull request against the Storefront Next storefront when the app includes storefront content and a repository is connected to the storefront (default: off) |
-| `--json` | | Output result as JSON |
+| Flag                | Short | Description                                                                                                                                                          |
+| ------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--site-id SITE_ID` | `-s`  | **Required.** Site ID to install the app on                                                                                                                          |
+| `--clean-archive`   |       | Delete the uploaded zip from the instance after install                                                                                                              |
+| `--timeout SECONDS` | `-t`  | Timeout in seconds (default: no timeout)                                                                                                                             |
+| `--skip-validate`   |       | Skip CAP structure validation before install                                                                                                                         |
+| `--create-pr`       |       | Create a pull request against the Storefront Next storefront when the app includes storefront content and a repository is connected to the storefront (default: off) |
+| `--json`            |       | Output result as JSON                                                                                                                                                |
 
 ### Install Process
 
@@ -206,17 +210,17 @@ b2c cap uninstall APP_NAME --site-id SITE_ID
 
 ### Arguments
 
-| Argument | Description |
-|----------|-------------|
+| Argument   | Description                                                                     |
+| ---------- | ------------------------------------------------------------------------------- |
 | `APP_NAME` | App ID to uninstall (from `commerce-app.json` `"id"` field, e.g. `avalara-tax`) |
 
 ### Flags
 
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--site-id SITE_ID` | `-s` | **Required.** Site ID to uninstall the app from |
-| `--timeout SECONDS` | `-t` | Timeout in seconds (default: no timeout) |
-| `--json` | | Output result as JSON |
+| Flag                | Short | Description                                     |
+| ------------------- | ----- | ----------------------------------------------- |
+| `--site-id SITE_ID` | `-s`  | **Required.** Site ID to uninstall the app from |
+| `--timeout SECONDS` | `-t`  | Timeout in seconds (default: no timeout)        |
+| `--json`            |       | Output result as JSON                           |
 
 ### Examples
 
@@ -239,27 +243,27 @@ b2c cap list [--site-id SITE_IDS]
 
 ### Flags
 
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--site-id SITE_IDS` | `-s` | Site IDs to query (comma-separated). If omitted, queries all sites. |
-| `--timeout SECONDS` | `-t` | Timeout in seconds (default: no timeout) |
-| `--local` | `-l` | List locally detected Commerce App Packages (no instance required) |
-| `--columns COLS` | `-c` | Columns to display (comma-separated). Available columns: `path`, `id`, `name`, `version`, `domain`, `siteId`, `featureName`, `featureType`, `featureSource`, `installStatus`, `configStatus`, `installedAt` |
-| `--extended` | `-x` | Show all columns including extended fields |
-| `--json` | | Output result as JSON |
+| Flag                 | Short | Description                                                                                                                                                                                                 |
+| -------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--site-id SITE_IDS` | `-s`  | Site IDs to query (comma-separated). If omitted, queries all sites.                                                                                                                                         |
+| `--timeout SECONDS`  | `-t`  | Timeout in seconds (default: no timeout)                                                                                                                                                                    |
+| `--local`            | `-l`  | List locally detected Commerce App Packages (no instance required)                                                                                                                                          |
+| `--columns COLS`     | `-c`  | Columns to display (comma-separated). Available columns: `path`, `id`, `name`, `version`, `domain`, `siteId`, `featureName`, `featureType`, `featureSource`, `installStatus`, `configStatus`, `installedAt` |
+| `--extended`         | `-x`  | Show all columns including extended fields                                                                                                                                                                  |
+| `--json`             |       | Output result as JSON                                                                                                                                                                                       |
 
 ### Table Columns
 
-| Column | Description |
-|--------|-------------|
-| Site ID | Site the feature is installed on (includes `Sites-` prefix) |
-| Name | Feature name (e.g. `avalara-tax`) |
-| Type | `ISV_APP`, `NATIVE_APP`, `NATIVE_FEATURE`, or `CUSTOM_FEATURE` |
-| Source | `CUSTOM` (uploaded via WebDAV) or `REGISTRY` (from App Registry) |
-| Install Status | e.g. `INSTALLED` |
-| Config Status | e.g. `NOT_CONFIGURED`, `CONFIGURED` |
-| Version | Feature version if available |
-| Installed At | Installation timestamp |
+| Column         | Description                                                      |
+| -------------- | ---------------------------------------------------------------- |
+| Site ID        | Site the feature is installed on (includes `Sites-` prefix)      |
+| Name           | Feature name (e.g. `avalara-tax`)                                |
+| Type           | `ISV_APP`, `NATIVE_APP`, `NATIVE_FEATURE`, or `CUSTOM_FEATURE`   |
+| Source         | `CUSTOM` (uploaded via WebDAV) or `REGISTRY` (from App Registry) |
+| Install Status | e.g. `INSTALLED`                                                 |
+| Config Status  | e.g. `NOT_CONFIGURED`, `CONFIGURED`                              |
+| Version        | Feature version if available                                     |
+| Installed At   | Installation timestamp                                           |
 
 ### JSON Output
 
@@ -295,17 +299,17 @@ b2c cap tasks APP_NAME --site-id SITE_ID
 
 ### Arguments
 
-| Argument | Description |
-|----------|-------------|
+| Argument   | Description                                    |
+| ---------- | ---------------------------------------------- |
 | `APP_NAME` | Commerce App feature name (e.g. `avalara-tax`) |
 
 ### Flags
 
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--site-id SITE_ID` | `-s` | **Required.** Site ID to query |
-| `--timeout SECONDS` | `-t` | Timeout in seconds (default: no timeout) |
-| `--json` | | Output result as JSON |
+| Flag                | Short | Description                              |
+| ------------------- | ----- | ---------------------------------------- |
+| `--site-id SITE_ID` | `-s`  | **Required.** Site ID to query           |
+| `--timeout SECONDS` | `-t`  | Timeout in seconds (default: no timeout) |
+| `--json`            |       | Output result as JSON                    |
 
 ### Examples
 
@@ -333,18 +337,18 @@ b2c cap pull [APP_NAME] [--site-id SITE_ID] [--output DIR]
 
 ### Arguments
 
-| Argument | Description |
-|----------|-------------|
-| `APP_NAME` | *(optional)* Commerce App feature name to pull (e.g. `avalara-tax`). If omitted, pulls all registry apps. |
+| Argument   | Description                                                                                               |
+| ---------- | --------------------------------------------------------------------------------------------------------- |
+| `APP_NAME` | _(optional)_ Commerce App feature name to pull (e.g. `avalara-tax`). If omitted, pulls all registry apps. |
 
 ### Flags
 
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--site-id SITE_ID` | `-s` | Site ID to query for installed apps. If omitted, queries all sites. |
-| `--output DIR` | `-o` | Output directory (default: `./commerce-apps`) |
-| `--timeout SECONDS` | `-t` | Timeout in seconds (default: no timeout) |
-| `--json` | | Output result as JSON |
+| Flag                | Short | Description                                                         |
+| ------------------- | ----- | ------------------------------------------------------------------- |
+| `--site-id SITE_ID` | `-s`  | Site ID to query for installed apps. If omitted, queries all sites. |
+| `--output DIR`      | `-o`  | Output directory (default: `./commerce-apps`)                       |
+| `--timeout SECONDS` | `-t`  | Timeout in seconds (default: no timeout)                            |
+| `--json`            |       | Output result as JSON                                               |
 
 ### Examples
 

--- a/docs/guide/commerce-apps.md
+++ b/docs/guide/commerce-apps.md
@@ -1,140 +1,101 @@
 ---
-description: How to validate, package, install, and uninstall Commerce App Packages (CAPs) with the B2C CLI and VS Code extension.
+description: Use the B2C CLI and agent skills to validate, package, install, uninstall, and pull Commerce App Packages (CAPs). Links to the official Commerce Apps ISV Developer Guide for the full specification.
 ---
 
 # Commerce Apps (CAPs)
 
-Commerce App Packages (CAPs) are the standard format for distributing B2C Commerce integrations. A CAP bundles cartridges, IMPEX configuration data, and Storefront Next UI extensions into a single installable unit.
+Commerce App Packages (CAPs) are the standard format for distributing B2C Commerce integrations. A CAP bundles back-end cartridges, IMPEX configuration data, and Storefront Next UI extensions into a single installable unit, deployed to an instance with a platform job.
 
-## What Is a Commerce App Package?
+This page covers what the **B2C CLI** does for CAPs and the **agent skills** we recommend. It is intentionally brief: the [Commerce Apps ISV Developer Guide](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/commerce-apps-overview.html) on Salesforce Developers is the authoritative source for the CAP format, manifest schema, architectures, domains and extension points, the installation state machine, and the submission/registry process. Use this page for the CLI workflow; follow the links for the spec.
 
-A CAP can contain any combination of:
+## Develop CAPs with AI Agent Skills
 
-- **Back-end cartridges** — site cartridges implementing extension points (e.g., `sf.commerce.app.tax.calculate`) and BM cartridges for admin UI
-- **IMPEX data** — services, site preferences, custom object definitions, and uninstall cleanup scripts
-- **Storefront Next extensions** — React components injected into the storefront via UI targets
-- **App configuration** — `tasksList.json` defining the post-install setup wizard in Business Manager
+If you build CAPs with an AI coding agent, install the agent skills so it understands the CAP format, the `b2c cap` commands, and the scaffolding/packaging/submission workflow. We recommend three plugins:
 
-## CAP Directory Structure
+- **`b2c-cli`** — the `b2c cap` commands (validate, package, install, uninstall, list, tasks, pull) and the rest of the CLI.
+- **`b2c`** — the B2C Commerce development patterns CAPs are built from (cartridges, hooks, metadata, Custom APIs, Storefront Next extensions).
+- **`cap-dev`** — scaffolding, generating IMPEX, validating, and submitting CAPs to the registry.
 
-```
-commerce-{app}-v{version}/
-├── commerce-app.json          # Required: app manifest (id, name, version, domain)
-├── README.md                  # Required: documentation
-├── app-configuration/
-│   └── tasksList.json         # Required: post-install configuration wizard
-├── cartridges/
-│   ├── bm_cartridges/         # Business Manager cartridges (may have controllers/)
-│   └── site_cartridges/       # Site cartridges (no controllers/, no pipelines)
-├── icons/
-│   └── icon.png               # Recommended: marketplace icon
-├── impex/
-│   ├── install/               # Data imported on install
-│   └── uninstall/             # Recommended: cleanup data for removal
-└── storefront-next/
-    └── src/extensions/        # React components and target-config.json
-```
+`b2c-cli` and `b2c` ship in the [B2C Developer Tooling marketplace](/guide/agent-skills); `cap-dev` ships separately from the [`SalesforceCommerceCloud/commerce-apps`](https://github.com/SalesforceCommerceCloud/commerce-apps) registry repository.
 
-## Development Workflow
-
-### 1. Build and Organize Your CAP
-
-Structure your project following the CAP layout above. The `commerce-app.json` manifest is required:
-
-```json
-{
-  "id": "my-integration",
-  "name": "My Integration",
-  "version": "1.0.0",
-  "domain": "tax",
-  "description": "Automated tax compliance",
-  "publisher": {
-    "name": "My Company",
-    "url": "https://example.com"
-  }
-}
-```
-
-### 2. Validate
-
-Run validation before packaging or installing to catch structural issues early:
+### Claude Code
 
 ```bash
-b2c cap validate ./commerce-my-integration-v1.0.0
+# B2C Developer Tooling skills (the CLI + platform development patterns)
+claude plugin marketplace add SalesforceCommerceCloud/b2c-developer-tooling
+claude plugin install b2c-cli
+claude plugin install b2c
+
+# CAP authoring skills (separate marketplace)
+claude plugin marketplace add SalesforceCommerceCloud/commerce-apps
+claude plugin install cap-dev --scope project
 ```
 
-Validation checks include:
-- Required files (`commerce-app.json`, `README.md`, `tasksList.json`)
-- Valid manifest schema and semver version
-- No pipelines or `.ds` files (not supported in CAPs)
-- Site cartridges must not have `controllers/` (use extension points instead)
+Add `--scope project` to any install to scope it to the current project instead of your user profile. The `b2c-cli` and `b2c` skills also install via `b2c setup skills`, and the `cap-dev` skills via `b2c setup skills cap-dev` for other agents (Cursor, Codex, Copilot). For full plugin management — listing, updating, and uninstalling — see the [Agent Skills & Plugins guide](/guide/agent-skills).
 
-### 3. Package (Optional)
+> **Which tool for what?** Use the `cap-dev` skills to **author** a CAP (scaffold the structure, generate IMPEX, validate against the registry rules, and open a submission PR). Use the **B2C CLI** to **operate** on a CAP against an instance (validate locally, package, install, uninstall, list, and pull).
 
-Create a distributable zip for CI/CD pipelines or registry submission:
+## CLI Workflow
+
+The B2C CLI provides the `cap` topic for working with Commerce App Packages. The commands accept a CAP **directory** or a packaged **`.zip`**.
 
 ```bash
-b2c cap package ./commerce-my-integration-v1.0.0 --output ./dist
-```
+# Validate structure locally (no instance required)
+b2c cap validate ./commerce-my-integration-app-v1.0.0
 
-This creates `dist/my-integration-v1.0.0.zip` with the correct root directory structure.
+# Package into a distributable zip (no instance required)
+b2c cap package ./commerce-my-integration-app-v1.0.0 --output ./dist
 
-### 4. Install on a Sandbox
+# Install on a sandbox (uploads via WebDAV, then runs the install job)
+b2c cap install ./commerce-my-integration-app-v1.0.0 --site RefArch
 
-Install the CAP on a sandbox instance for testing. Provide the local directory or zip:
-
-```bash
-# From a directory
-b2c cap install ./commerce-my-integration-v1.0.0 --site RefArch
-
-# From a zip
+# Install a pre-built zip
 b2c cap install ./dist/my-integration-v1.0.0.zip --site RefArch
+
+# List apps installed on an instance (add --local to list CAP directories on disk)
+b2c cap list --site RefArch
+
+# View post-install configuration tasks (with Business Manager deep links)
+b2c cap tasks my-integration --site RefArch
+
+# Pull installed app sources for cartridge or Storefront Next development
+b2c cap pull my-integration --site RefArch
+
+# Uninstall (the app's domain is discovered automatically)
+b2c cap uninstall my-integration --site RefArch
 ```
 
-The CLI uploads the package to WebDAV (`Temp/`) and triggers the `sfcc-install-commerce-app` platform job, which deploys cartridges and imports IMPEX data.
+`validate` and `package` (and `list --local`) are local-only and need no credentials, which makes them well-suited to CI. `install`, `uninstall`, `tasks`, `pull`, and remote `list` run a system job and/or query the instance, so they require authentication — see [Authentication Requirements](#authentication-requirements). On `install`, the CLI uploads the package via WebDAV to `Impex/commerce-apps/` and triggers the `sfcc-install-commerce-app` platform job, which deploys cartridges and imports IMPEX data.
+
+See the [CAP CLI reference](/cli/cap) for every command, flag, and option.
 
 ### Creating a Storefront Pull Request
 
-If a CAP includes Storefront Next content, pass `--create-pr` to have the install job automatically open a pull request against the related Storefront Next storefront — provided a repository is also connected to the storefront:
+If a CAP includes Storefront Next content, pass `--create-pr` on `install` to have the install job automatically open a pull request against the related Storefront Next storefront — provided a repository is also connected to the storefront:
 
 ```bash
-b2c cap install ./commerce-my-integration-v1.0.0 --site RefArch --create-pr
+b2c cap install ./commerce-my-integration-app-v1.0.0 --site RefArch --create-pr
 ```
 
 The pull request contains the storefront changes the app provides, so a developer can review and merge them rather than having them applied directly. The flag is **off by default**; if the app has no storefront content or no repository is connected to the storefront, it has no effect.
 
-### 5. Complete Configuration Tasks
+### Inspecting Installed State
 
-After install, complete the setup wizard tasks in Business Manager or via CLI. Installed apps transition through:
-
-`INSTALLING` → `INSTALLED` → `CONFIGURING` → `ACTIVE`
-
-### 6. Uninstall
-
-To remove an installed app:
-
-```bash
-b2c cap uninstall my-integration --site RefArch
-```
+After install, complete the setup wizard tasks in Business Manager or follow the deep links from `b2c cap tasks`. `b2c cap list` reports each installed app's **install status** and **configuration status** per site. For the full installation state machine (the `INSTALLING → INSTALLED → NOT_CONFIGURED → CONFIGURING → CONFIGURED` happy path plus the error and uninstall flows), see the [Architecture guide](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/architecture.html).
 
 ## VS Code Extension Integration
 
 The B2C DX VS Code extension provides Commerce App support directly in the file explorer.
 
-### CAP Directory Detection
-
-Any directory containing a `commerce-app.json` file is automatically decorated with a **CA** badge in the VS Code explorer, making CAP directories easy to identify.
-
-### Install from the Explorer
-
-Right-click any CAP directory in the VS Code explorer and choose **B2C-DX → Install Commerce App (CAP)**. You will be prompted for the target site ID.
+- **CAP detection** — any directory containing a `commerce-app.json` file is decorated with a **CA** badge in the explorer, making CAP directories easy to identify.
+- **Install from the explorer** — right-click a CAP directory and choose **B2C-DX → Install Commerce App (CAP)**. You will be prompted for the target site ID.
 
 ## Authentication Requirements
 
-Install and uninstall commands require:
+The remote `cap` commands (`install`, `uninstall`, `tasks`, `pull`, and remote `list`) require both:
 
-- **OAuth credentials** (`SFCC_CLIENT_ID`, `SFCC_CLIENT_SECRET`) — for running the system job
-- **WebDAV credentials** (`SFCC_USERNAME`, `SFCC_PASSWORD`) — for uploading the CAP zip
+- **OAuth credentials** (`SFCC_CLIENT_ID`, `SFCC_CLIENT_SECRET`) — for running the system job via OCAPI
+- **WebDAV credentials** (`SFCC_USERNAME`, `SFCC_PASSWORD`) — for uploading the CAP zip (there is no SCAPI substitute for the WebDAV upload)
 
 ```bash
 export SFCC_SERVER=my-instance.commercecloud.salesforce.com
@@ -144,21 +105,21 @@ export SFCC_USERNAME=your-bm-username
 export SFCC_PASSWORD=your-webdav-access-key
 ```
 
-See the [Authentication Guide](/guide/authentication) for complete setup instructions.
+You can also authenticate WebDAV interactively in the browser with `--user-auth`. The local-only commands (`validate`, `package`, `list --local`) need no credentials. See the [Authentication Guide](/guide/authentication) for complete setup, including Account Manager OAuth clients with WebDAV permissions.
 
 ## CI/CD Integration
 
-A typical CI/CD pipeline for Commerce App deployment:
+Because `validate` and `package` are local-only, a typical pipeline validates and packages on every change and installs to a dedicated sandbox on promotion. All `cap` commands accept `--json` for machine-readable output.
 
 ```yaml
 - name: Validate CAP
-  run: b2c cap validate ./commerce-my-integration-v${{ env.VERSION }}
+  run: b2c cap validate ./commerce-my-integration-app-v${{ env.VERSION }} --json
 
 - name: Package CAP
-  run: b2c cap package ./commerce-my-integration-v${{ env.VERSION }} --output ./dist
+  run: b2c cap package ./commerce-my-integration-app-v${{ env.VERSION }} --output ./dist --json
 
 - name: Install CAP
-  run: b2c cap install ./dist/my-integration-v${{ env.VERSION }}.zip --site ${{ env.SITE_ID }}
+  run: b2c cap install ./dist/my-integration-v${{ env.VERSION }}.zip --site ${{ env.SITE_ID }} --json
   env:
     SFCC_SERVER: ${{ secrets.SFCC_SERVER }}
     SFCC_CLIENT_ID: ${{ secrets.SFCC_CLIENT_ID }}
@@ -169,5 +130,9 @@ A typical CI/CD pipeline for Commerce App deployment:
 
 ## Reference
 
-- [CAP CLI Commands](/cli/cap) — full command reference
-- [ISV Developer Guide](https://developer.salesforce.com) — CAP structure specification and domain extension points
+- [CAP CLI Commands](/cli/cap) — full `b2c cap` command and flag reference
+- [Commerce Apps ISV Developer Guide](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/commerce-apps-overview.html) — the authoritative CAP specification, covering:
+  - [Architecture](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/architecture.html) — the three app architectures, extension points (e.g. `sfcc.app.tax.calculate`), UI targets, CAP directory structure, and the installation state machine
+  - [Development environment](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/development-environment.html) — sandbox setup, the `cap-dev` Claude Code skills, and the end-to-end lifecycle
+  - [Packaging](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/packaging.html) — required files, the `commerce-app.json` manifest, and zip layout
+  - [Testing & validation](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/testing-validation.html) and [submission & review](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/submission-review.html) — the registry review checklist and submission process

--- a/skills/b2c-cli/skills/b2c-cap/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-cap/SKILL.md
@@ -15,6 +15,10 @@ The CLI auto-discovers the target instance and credentials from `SFCC_*` environ
 
 Run `b2c setup inspect` to see the resolved configuration and which source provided each value (use `--json` for scripting, `--unmask` to reveal secrets). For precedence rules and troubleshooting, see the `b2c-cli:b2c-config` skill.
 
+The remote commands (`cap install`, `cap uninstall`, `cap tasks`, `cap pull`, and `cap list` without `--local`) require **both** OCAPI access (for running the system job) and **WebDAV** access (for uploading/downloading archives). WebDAV authenticates via `SFCC_USERNAME`/`SFCC_PASSWORD` (BM username + WebDAV access key), `--user-auth` for interactive browser login, or an Account Manager OAuth client granted WebDAV permissions on the `/impex` path; SCAPI is not a substitute for the WebDAV upload. The local-only commands (`cap validate`, `cap package`, and `cap list --local`) need no credentials.
+
+> **Authoring vs. operating:** This skill covers **operating** on existing CAPs against an instance (validate, package, install, uninstall, list, tasks, pull). To **author** a new CAP — scaffold the structure, generate IMPEX, run registry-grade validation, or submit to the registry — install the `cap-dev` skills with `b2c setup skills cap-dev`, or via the commerce-apps marketplace: `claude plugin marketplace add SalesforceCommerceCloud/commerce-apps` then `claude plugin install cap-dev`.
+
 ## Examples
 
 ### List Installed Features
@@ -35,7 +39,7 @@ b2c cap list --local
 
 ### Pull App Sources
 
-Pull installed Commerce App source packages for cartridge deployment or Storefront Next (`sfnext`) development. Pulled apps are extracted into `./commerce-apps/{name}/` and contain cartridges, IMPEX data, and `storefront-next/` extensions ready for use with the `sfnext` CLI.
+Pull installed Commerce App source packages for cartridge deployment or Storefront Next (`sfnext`) development. Pulled apps are extracted into `./commerce-apps/{name}/`. Depending on the app's architecture, a package may contain `cartridges/` and `impex/` data (backend or fullstack apps) and/or `storefront-next/` extensions (UI-only or fullstack apps) ready for use with the `sfnext` CLI.
 
 ```bash
 # pull all registry apps to ./commerce-apps
@@ -67,8 +71,8 @@ b2c cap tasks avalara-tax --site-id RefArch --json
 # validate a local CAP directory
 b2c cap validate ./commerce-avalara-tax-app-v0.2.5
 
-# validate a CAP zip file
-b2c cap validate ./commerce-avalara-tax-app-v0.2.5.zip
+# validate a CAP zip file (cap package produces {id}-v{version}.zip)
+b2c cap validate ./avalara-tax-v0.2.5.zip
 
 # validate with JSON output
 b2c cap validate ./commerce-avalara-tax-app-v0.2.5 --json
@@ -91,7 +95,7 @@ b2c cap package ./commerce-avalara-tax-app-v0.2.5 --output ./dist/my-app.zip
 b2c cap install ./commerce-avalara-tax-app-v0.2.5 --site-id RefArch
 
 # install a pre-packaged zip
-b2c cap install ./commerce-avalara-tax-app-v0.2.5.zip --site-id RefArch
+b2c cap install ./avalara-tax-v0.2.5.zip --site-id RefArch
 
 # install with a timeout
 b2c cap install ./commerce-avalara-tax-app-v0.2.5 --site-id RefArch --timeout 600


### PR DESCRIPTION
## Summary

Refocuses the Commerce Apps (CAP) documentation on the **B2C CLI workflow** and links to the official [Commerce Apps ISV Developer Guide](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/commerce-apps-overview.html) as the authoritative spec rather than duplicating it. Recommends the three agent skills plugins for building CAPs with an AI coding agent.

### Agent skills recommendation
- **`b2c-cli`** and **`b2c`** — ship in the B2C Developer Tooling marketplace
- **`cap-dev`** — ships separately from the `SalesforceCommerceCloud/commerce-apps` marketplace (scaffolding / IMPEX generation / registry submission)

### Corrections against canon + CLI source
- Tax extension point is `sfcc.app.tax.calculate`
- Install upload path is `Impex/commerce-apps/`
- Lifecycle: `INSTALLING → INSTALLED → NOT_CONFIGURED → CONFIGURING → CONFIGURED`
- `cap package` produces `{id}-v{version}.zip`
- Added WebDAV auth, icon-naming, and registry-vs-local-validation clarifications to the `b2c-cap` skill and CAP CLI reference

## Files
- `docs/guide/commerce-apps.md` — trimmed/refocused guide (links to canon, recommends plugins)
- `docs/cli/cap.md` — icon-naming, registry-vs-local validation, `/job_execution_search` notes
- `skills/b2c-cli/skills/b2c-cap/SKILL.md` — WebDAV auth + authoring-vs-operating clarifications
- `.changeset/cap-guide-agent-skills.md` — `@salesforce/b2c-dx-docs` + `@salesforce/b2c-agent-plugins` patch

## Test plan
- [x] `pnpm run lint:agent` passes
- [x] `prettier --check` passes on all changed files
- [x] Docs build validates no dead internal links (verified locally, EXIT 0)