### PR TITLE
feat(debug): honor + expose SDAPI session cookie (dwsid) for server affinity

### DIFF
--- a/.changeset/debug-session-cookie-expose.md
+++ b/.changeset/debug-session-cookie-expose.md
@@ -1,7 +1,14 @@
 ---
 '@salesforce/b2c-tooling-sdk': minor
 '@salesforce/b2c-dx-mcp': minor
+'b2c-vs-extension': minor
 '@salesforce/b2c-agent-plugins': patch
 ---
 
-Expose the script debugger session cookie (`dwsid`). The SDK now provides `SdapiClient.getCookie(name)` and `DebugSessionManager.getSessionCookie()`, and the `debug_start_session` and `debug_list_sessions` MCP tools now return a `session_cookie` field. Send a triggering request (storefront page load, SCAPI/OCAPI call) with this cookie so it lands on the same app server holding the debug session — required to reliably hit breakpoints on multi-app-server instances.
+Expose the script debugger session cookie (`dwsid`) so you can route a triggering request to the same app server holding the debug session — required to reliably hit breakpoints on multi-app-server instances.
+
+- **SDK:** new `SdapiClient.getCookie(name)` and `DebugSessionManager.getSessionCookie()`; the cookie is also logged at info level when the session connects.
+- **MCP:** `debug_start_session` and `debug_list_sessions` now return a `session_cookie` field.
+- **VS Code:** a new **Copy Debugger Session ID (dwsid)** command (available while a debug session is active) copies the cookie to the clipboard.
+
+Send your triggering request (storefront page load, SCAPI/OCAPI call) with `Cookie: dwsid=<value>`.

--- a/.changeset/debug-session-cookie-expose.md
+++ b/.changeset/debug-session-cookie-expose.md
@@ -1,0 +1,7 @@
+---
+'@salesforce/b2c-tooling-sdk': minor
+'@salesforce/b2c-dx-mcp': minor
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Expose the script debugger session cookie (`dwsid`). The SDK now provides `SdapiClient.getCookie(name)` and `DebugSessionManager.getSessionCookie()`, and the `debug_start_session` and `debug_list_sessions` MCP tools now return a `session_cookie` field. Send a triggering request (storefront page load, SCAPI/OCAPI call) with this cookie so it lands on the same app server holding the debug session — required to reliably hit breakpoints on multi-app-server instances.

--- a/.changeset/sdapi-trace-headers.md
+++ b/.changeset/sdapi-trace-headers.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+Script debugger (SDAPI) client now honors session cookies (e.g. `dwsid`) returned by the server, replaying them on subsequent requests. This is required for server affinity on multi-app-server instances so debugger requests reach the app server holding the session. The client also now logs full request and response headers, status, and body at trace level, matching the rest of the HTTP clients.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -68,6 +68,7 @@ const guidesSidebar = [
       {text: 'Account Manager', link: '/guide/account-manager'},
       {text: 'Analytics Reports (CIP/CCAC)', link: '/guide/analytics-reports-cip-ccac'},
       {text: 'IDE Integration', link: '/guide/ide-integration'},
+      {text: 'Script Debugger', link: '/guide/script-debugger'},
       {text: 'Scaffolding', link: '/guide/scaffolding'},
       {text: 'Safety Mode', link: '/guide/safety'},
       {text: 'Security', link: '/guide/security'},
@@ -215,7 +216,8 @@ document.addEventListener('click', (e) => {
 
 export default defineConfig({
   title: 'B2C Developer Toolkit',
-  description: 'Agentic B2C Developer Toolkit — CLI, Agent Skills, MCP Server, SDK, and the B2C DX VS Code Extension for Salesforce B2C Commerce',
+  description:
+    'Agentic B2C Developer Toolkit — CLI, Agent Skills, MCP Server, SDK, and the B2C DX VS Code Extension for Salesforce B2C Commerce',
   base: basePath,
 
   head: [['script', {}, versionSwitchScript]],

--- a/docs/guide/script-debugger.md
+++ b/docs/guide/script-debugger.md
@@ -61,7 +61,13 @@ Once you have the value, send the request that triggers your code — a browser 
 Cookie: dwsid=<value>
 ```
 
-If you cannot set the cookie on the triggering request, you may need to retry until the load balancer happens to route to the attached app server.
+For headless requests where you can't (or don't want to) set a cookie — server-to-server calls that trigger hooks, custom APIs, or SCAPI/OCAPI endpoints — pass the same value as the `sfdc_dwsid` request header instead:
+
+```
+sfdc_dwsid: <value>
+```
+
+If you cannot set the cookie or header on the triggering request, you may need to retry until the load balancer happens to route to the attached app server.
 
 > A future enhancement will let the VS Code extension launch a browser pre-seeded with the debug session's cookie, removing this manual step.
 

--- a/docs/guide/script-debugger.md
+++ b/docs/guide/script-debugger.md
@@ -1,5 +1,5 @@
 ---
-description: Debug server-side B2C Commerce scripts (controllers, hooks, jobs, custom APIs) with the Script Debugger — via the VS Code extension, the CLI DAP adapter and REPL, or the MCP diagnostics tools.
+description: Debug server-side B2C Commerce scripts (controllers, hooks, jobs, custom APIs) with the Script Debugger — via the VS Code extension, the CLI DAP debug adapter, or the MCP diagnostics tools.
 ---
 
 # Script Debugger
@@ -8,8 +8,9 @@ The B2C Commerce **Script Debugger** lets you set breakpoints, step through code
 
 - **VS Code (recommended)** — the [B2C DX VS Code Extension](/vscode-extension/#b2c-script-debugger) provides the full graphical debugger: breakpoints, log points, watch expressions, and step controls, just like any other Node project. This is the primary interface for interactive debugging.
 - **Other IDEs (JetBrains, etc.)** via the [Debug Adapter Protocol (DAP)](https://microsoft.github.io/debug-adapter-protocol/) adapter — `b2c debug`.
-- **Headless/terminal debugging** via an interactive REPL or JSONL-over-stdio RPC — `b2c debug cli`.
 - **AI-agent debugging** via the [MCP diagnostics tools](/mcp/tools/diagnostics) — `debug_start_session`, `debug_set_breakpoints`, etc.
+
+The CLI's DAP debug adapter (`b2c debug`) also offers a headless terminal mode for scripting; see [Debug Commands](/cli/debug) for details.
 
 ## Requirements
 
@@ -34,12 +35,11 @@ See [CLI Configuration](/guide/configuration) for the full resolution order and 
 
 ## Choosing an interface
 
-| Use case                            | Interface                            | Reference                                                   |
-| ----------------------------------- | ------------------------------------ | ----------------------------------------------------------- |
-| Debug from VS Code (recommended)    | B2C DX VS Code Extension             | [VS Code Extension](/vscode-extension/#b2c-script-debugger) |
-| Debug from another IDE (JetBrains)  | `b2c debug` (DAP adapter over stdio) | [Debug Commands](/cli/debug#b2c-debug)                      |
-| Debug from the terminal or a script | `b2c debug cli` (REPL or JSONL RPC)  | [Debug Commands](/cli/debug#b2c-debug-cli)                  |
-| Let an AI agent drive the debugger  | MCP diagnostics tools                | [Diagnostics Tools](/mcp/tools/diagnostics)                 |
+| Use case                           | Interface                                  | Reference                                                   |
+| ---------------------------------- | ------------------------------------------ | ----------------------------------------------------------- |
+| Debug from VS Code (recommended)   | B2C DX VS Code Extension                   | [VS Code Extension](/vscode-extension/#b2c-script-debugger) |
+| Debug from another IDE (JetBrains) | `b2c debug` (DAP debug adapter over stdio) | [Debug Commands](/cli/debug#b2c-debug)                      |
+| Let an AI agent drive the debugger | MCP diagnostics tools                      | [Diagnostics Tools](/mcp/tools/diagnostics)                 |
 
 They all share the same underlying workflow: connect a session, set breakpoints (by local file path, cartridge-prefixed path, or server path), trigger the code on the instance, then inspect the halted thread.
 
@@ -59,7 +59,7 @@ If you cannot control the cookie on the triggering request, you may need to retr
 ## See Also
 
 - [VS Code Extension](/vscode-extension/#b2c-script-debugger) — the recommended graphical debugger
-- [Debug Commands](/cli/debug) — `b2c debug` DAP adapter and `b2c debug cli` REPL/RPC reference
+- [Debug Commands](/cli/debug) — `b2c debug` DAP debug adapter reference
 - [Diagnostics Tools](/mcp/tools/diagnostics) — MCP tools for agent-driven debugging
 - [Authentication Setup](/guide/authentication) — WebDAV access key configuration
 - [IDE Integration](/guide/ide-integration) — connecting other IDEs to your CLI configuration

--- a/docs/guide/script-debugger.md
+++ b/docs/guide/script-debugger.md
@@ -47,14 +47,23 @@ They all share the same underlying workflow: connect a session, set breakpoints 
 
 A breakpoint only fires when the code runs on the **same application server** the debugger is attached to. On a single-app-server environment this is automatic. But some **Production Instance Group (PIG)** environments run **multiple application servers** behind a load balancer — there, a request that triggers your code may land on a different app server than the debugger, and the breakpoint never fires.
 
-> **Sandboxes (ODS) are single-app-server and are not affected.** This only matters on multi-app-server PIG environments (typically staging/production).
+> **Sandboxes (ODS) are single-app-server and are not affected.** This only matters on certain multi-app-server PIG environments.
 
-To pin a triggering request to the correct app server, route it with the debugger's session cookie (`dwsid`). The CLI and SDK manage this cookie automatically for the debugger's own requests; to apply it to **your** triggering request:
+To pin a triggering request to the correct app server, route it with the debugger's session cookie (`dwsid`). The CLI and SDK manage this cookie automatically for the debugger's own requests — so the way you obtain the value depends on the interface:
 
-- **MCP:** `debug_start_session` and `debug_list_sessions` return a `session_cookie` (`{name, value}`). Send your storefront page load or SCAPI/OCAPI call with `Cookie: dwsid=<value>` so it reaches the right app server. See [Diagnostics Tools → Server affinity](/mcp/tools/diagnostics#server-affinity-hitting-breakpoints).
-- **General:** any request you make to trigger the breakpoint — a browser session, `curl`, an integration test — must carry the same `dwsid` cookie value.
+- **MCP:** `debug_start_session` and `debug_list_sessions` return a `session_cookie` (`{name, value}`). This is the most direct source. See [Diagnostics Tools → Server affinity](/mcp/tools/diagnostics#server-affinity-hitting-breakpoints).
+- **VS Code:** the cookie is logged to the **B2C DX** output channel when the session connects, and the **Copy Debugger Session ID (dwsid)** command copies it to your clipboard.
+- **CLI:** the cookie is logged at info level when the session connects (`Debug session cookie: dwsid=…`).
 
-If you cannot control the cookie on the triggering request, you may need to retry until the load balancer happens to route to the attached app server.
+Once you have the value, send the request that triggers your code — a browser session, `curl`, an integration test — with that cookie:
+
+```
+Cookie: dwsid=<value>
+```
+
+If you cannot set the cookie on the triggering request, you may need to retry until the load balancer happens to route to the attached app server.
+
+> A future enhancement will let the VS Code extension launch a browser pre-seeded with the debug session's cookie, removing this manual step.
 
 ## See Also
 

--- a/docs/guide/script-debugger.md
+++ b/docs/guide/script-debugger.md
@@ -1,12 +1,13 @@
 ---
-description: Debug server-side B2C Commerce scripts (controllers, hooks, jobs, custom APIs) with the Script Debugger via the CLI DAP adapter, interactive REPL, or MCP diagnostics tools.
+description: Debug server-side B2C Commerce scripts (controllers, hooks, jobs, custom APIs) with the Script Debugger — via the VS Code extension, the CLI DAP adapter and REPL, or the MCP diagnostics tools.
 ---
 
 # Script Debugger
 
-The B2C Commerce **Script Debugger** lets you set breakpoints, step through code, and inspect variables in server-side scripts — SFRA controllers, hooks, jobs, custom SCAPI endpoints, or any `dw/*` cartridge code — running live on an instance. The tooling connects to the instance's Script Debugger API (SDAPI) and surfaces it three ways:
+The B2C Commerce **Script Debugger** lets you set breakpoints, step through code, and inspect variables in server-side scripts — SFRA controllers, hooks, jobs, custom SCAPI endpoints, or any `dw/*` cartridge code — running live on an instance. The tooling connects to the instance's Script Debugger API (SDAPI) and surfaces it several ways:
 
-- **IDE debugging** via a [Debug Adapter Protocol (DAP)](https://microsoft.github.io/debug-adapter-protocol/) adapter — `b2c debug`.
+- **VS Code (recommended)** — the [B2C DX VS Code Extension](/vscode-extension/#b2c-script-debugger) provides the full graphical debugger: breakpoints, log points, watch expressions, and step controls, just like any other Node project. This is the primary interface for interactive debugging.
+- **Other IDEs (JetBrains, etc.)** via the [Debug Adapter Protocol (DAP)](https://microsoft.github.io/debug-adapter-protocol/) adapter — `b2c debug`.
 - **Headless/terminal debugging** via an interactive REPL or JSONL-over-stdio RPC — `b2c debug cli`.
 - **AI-agent debugging** via the [MCP diagnostics tools](/mcp/tools/diagnostics) — `debug_start_session`, `debug_set_breakpoints`, etc.
 
@@ -33,13 +34,14 @@ See [CLI Configuration](/guide/configuration) for the full resolution order and 
 
 ## Choosing an interface
 
-| Use case                            | Interface                            | Reference                                   |
-| ----------------------------------- | ------------------------------------ | ------------------------------------------- |
-| Debug from VS Code / JetBrains      | `b2c debug` (DAP adapter over stdio) | [Debug Commands](/cli/debug#b2c-debug)      |
-| Debug from the terminal or a script | `b2c debug cli` (REPL or JSONL RPC)  | [Debug Commands](/cli/debug#b2c-debug-cli)  |
-| Let an AI agent drive the debugger  | MCP diagnostics tools                | [Diagnostics Tools](/mcp/tools/diagnostics) |
+| Use case                            | Interface                            | Reference                                                   |
+| ----------------------------------- | ------------------------------------ | ----------------------------------------------------------- |
+| Debug from VS Code (recommended)    | B2C DX VS Code Extension             | [VS Code Extension](/vscode-extension/#b2c-script-debugger) |
+| Debug from another IDE (JetBrains)  | `b2c debug` (DAP adapter over stdio) | [Debug Commands](/cli/debug#b2c-debug)                      |
+| Debug from the terminal or a script | `b2c debug cli` (REPL or JSONL RPC)  | [Debug Commands](/cli/debug#b2c-debug-cli)                  |
+| Let an AI agent drive the debugger  | MCP diagnostics tools                | [Diagnostics Tools](/mcp/tools/diagnostics)                 |
 
-All three share the same underlying workflow: connect a session, set breakpoints (by local file path, cartridge-prefixed path, or server path), trigger the code on the instance, then inspect the halted thread.
+They all share the same underlying workflow: connect a session, set breakpoints (by local file path, cartridge-prefixed path, or server path), trigger the code on the instance, then inspect the halted thread.
 
 ## Server affinity (hitting breakpoints)
 
@@ -56,7 +58,8 @@ If you cannot control the cookie on the triggering request, you may need to retr
 
 ## See Also
 
+- [VS Code Extension](/vscode-extension/#b2c-script-debugger) — the recommended graphical debugger
 - [Debug Commands](/cli/debug) — `b2c debug` DAP adapter and `b2c debug cli` REPL/RPC reference
 - [Diagnostics Tools](/mcp/tools/diagnostics) — MCP tools for agent-driven debugging
 - [Authentication Setup](/guide/authentication) — WebDAV access key configuration
-- [IDE Integration](/guide/ide-integration) — connecting IDEs to your CLI configuration
+- [IDE Integration](/guide/ide-integration) — connecting other IDEs to your CLI configuration

--- a/docs/guide/script-debugger.md
+++ b/docs/guide/script-debugger.md
@@ -1,0 +1,62 @@
+---
+description: Debug server-side B2C Commerce scripts (controllers, hooks, jobs, custom APIs) with the Script Debugger via the CLI DAP adapter, interactive REPL, or MCP diagnostics tools.
+---
+
+# Script Debugger
+
+The B2C Commerce **Script Debugger** lets you set breakpoints, step through code, and inspect variables in server-side scripts — SFRA controllers, hooks, jobs, custom SCAPI endpoints, or any `dw/*` cartridge code — running live on an instance. The tooling connects to the instance's Script Debugger API (SDAPI) and surfaces it three ways:
+
+- **IDE debugging** via a [Debug Adapter Protocol (DAP)](https://microsoft.github.io/debug-adapter-protocol/) adapter — `b2c debug`.
+- **Headless/terminal debugging** via an interactive REPL or JSONL-over-stdio RPC — `b2c debug cli`.
+- **AI-agent debugging** via the [MCP diagnostics tools](/mcp/tools/diagnostics) — `debug_start_session`, `debug_set_breakpoints`, etc.
+
+## Requirements
+
+The debugger needs two things:
+
+1. **The Script Debugger enabled on the instance.** In Business Manager: **Administration → Development Configuration → Script Debugger → Enable**.
+2. **Basic auth credentials** — a Business Manager username and a WebDAV / UX Studio access key (used as the password). OAuth/client credentials are **not** sufficient for the SDAPI.
+
+> The access key is the same kind of WebDAV access key used by UX Studio and other code-upload tooling. Generate one in Business Manager under your account's access keys. See the [Authentication Guide](/guide/authentication#webdav-access) for details.
+
+Only one debug client per `client_id` may be attached to a host at a time. Starting a new session with the same `client_id` takes over (replaces) any prior one — a useful safety net for orphaned sessions.
+
+## Configuration
+
+The debugger reads the same resolved configuration as the rest of the CLI. Provide the hostname and Basic auth credentials via any of (highest priority first):
+
+- Flags — `--username` / `--password` (and the active instance for the hostname)
+- Environment variables — `SFCC_SERVER`, `SFCC_USERNAME`, `SFCC_PASSWORD`
+- `dw.json` — `hostname`, `username`, `password` fields
+
+See [CLI Configuration](/guide/configuration) for the full resolution order and multi-instance setup.
+
+## Choosing an interface
+
+| Use case                            | Interface                            | Reference                                   |
+| ----------------------------------- | ------------------------------------ | ------------------------------------------- |
+| Debug from VS Code / JetBrains      | `b2c debug` (DAP adapter over stdio) | [Debug Commands](/cli/debug#b2c-debug)      |
+| Debug from the terminal or a script | `b2c debug cli` (REPL or JSONL RPC)  | [Debug Commands](/cli/debug#b2c-debug-cli)  |
+| Let an AI agent drive the debugger  | MCP diagnostics tools                | [Diagnostics Tools](/mcp/tools/diagnostics) |
+
+All three share the same underlying workflow: connect a session, set breakpoints (by local file path, cartridge-prefixed path, or server path), trigger the code on the instance, then inspect the halted thread.
+
+## Server affinity (hitting breakpoints)
+
+A breakpoint only fires when the code runs on the **same application server** the debugger is attached to. On a single-app-server environment this is automatic. But some **Production Instance Group (PIG)** environments run **multiple application servers** behind a load balancer — there, a request that triggers your code may land on a different app server than the debugger, and the breakpoint never fires.
+
+> **Sandboxes (ODS) are single-app-server and are not affected.** This only matters on multi-app-server PIG environments (typically staging/production).
+
+To pin a triggering request to the correct app server, route it with the debugger's session cookie (`dwsid`). The CLI and SDK manage this cookie automatically for the debugger's own requests; to apply it to **your** triggering request:
+
+- **MCP:** `debug_start_session` and `debug_list_sessions` return a `session_cookie` (`{name, value}`). Send your storefront page load or SCAPI/OCAPI call with `Cookie: dwsid=<value>` so it reaches the right app server. See [Diagnostics Tools → Server affinity](/mcp/tools/diagnostics#server-affinity-hitting-breakpoints).
+- **General:** any request you make to trigger the breakpoint — a browser session, `curl`, an integration test — must carry the same `dwsid` cookie value.
+
+If you cannot control the cookie on the triggering request, you may need to retry until the load balancer happens to route to the attached app server.
+
+## See Also
+
+- [Debug Commands](/cli/debug) — `b2c debug` DAP adapter and `b2c debug cli` REPL/RPC reference
+- [Diagnostics Tools](/mcp/tools/diagnostics) — MCP tools for agent-driven debugging
+- [Authentication Setup](/guide/authentication) — WebDAV access key configuration
+- [IDE Integration](/guide/ide-integration) — connecting IDEs to your CLI configuration

--- a/docs/mcp/tools/diagnostics.md
+++ b/docs/mcp/tools/diagnostics.md
@@ -80,6 +80,12 @@ Send your triggering request — a storefront page load, a SCAPI/OCAPI call, etc
 Cookie: dwsid=abc123...
 ```
 
+For headless server-to-server requests that trigger hooks, custom APIs, or SCAPI/OCAPI endpoints — where setting a cookie is awkward — pass the same value as the `sfdc_dwsid` request header instead:
+
+```
+sfdc_dwsid: abc123...
+```
+
 If `session_cookie` is `null`, the debugger did not establish a session cookie; a warning is included and breakpoints may not be reliably hit on multi-app-server instances.
 
 ---

--- a/docs/mcp/tools/diagnostics.md
+++ b/docs/mcp/tools/diagnostics.md
@@ -11,6 +11,7 @@ MCP tools for connecting to the B2C Commerce Script Debugger API (SDAPI), settin
 Requires **Basic Auth** credentials only. OAuth is not supported by the SDAPI.
 
 **Required:**
+
 - **Basic Auth** - `hostname`, `username`, and `password` (WebDAV access key) for a Business Manager user with the `WebDAV_Manage_Customization` permission.
 
 **Configuration priority:** Flags → Environment variables → `dw.json` config file
@@ -39,27 +40,47 @@ Start a new script debugger session. Connects to the SDAPI, discovers cartridge 
 
 > **Warning:** Debug sessions can halt remote request threads on the instance. Use `debug_end_session` to cleanly disconnect when done.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `cartridge_directory` | string | No | Project directory | Path to directory containing cartridges |
-| `client_id` | string | No | `b2c-cli` | Client ID for the debugger API. Use a different ID for concurrent sessions on the same host. |
+| Parameter             | Type   | Required | Default           | Description                                                                                  |
+| --------------------- | ------ | -------- | ----------------- | -------------------------------------------------------------------------------------------- |
+| `cartridge_directory` | string | No       | Project directory | Path to directory containing cartridges                                                      |
+| `client_id`           | string | No       | `b2c-cli`         | Client ID for the debugger API. Use a different ID for concurrent sessions on the same host. |
 
-**Returns:** `session_id`, `hostname`, discovered `cartridges`, and `warnings`.
+**Returns:** `session_id`, `hostname`, discovered `cartridges`, `session_cookie` (see [Server affinity](#server-affinity-hitting-breakpoints)), and `warnings`.
 
 ### debug_end_session
 
 End a script debugger session. Disconnects from the SDAPI, stops polling, and cleans up resources.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `session_id` | string | Yes | | Session ID from `debug_start_session` |
-| `clear_breakpoints` | boolean | No | `false` | Delete all breakpoints before disconnecting |
+| Parameter           | Type    | Required | Default | Description                                 |
+| ------------------- | ------- | -------- | ------- | ------------------------------------------- |
+| `session_id`        | string  | Yes      |         | Session ID from `debug_start_session`       |
+| `clear_breakpoints` | boolean | No       | `false` | Delete all breakpoints before disconnecting |
 
 ### debug_list_sessions
 
-List all active debug sessions. Returns session IDs, connected hostnames, and any currently halted threads.
+List all active debug sessions. Returns session IDs, connected hostnames, any currently halted threads, armed breakpoints, and each session's `session_cookie` (see [Server affinity](#server-affinity-hitting-breakpoints)).
 
 No parameters.
+
+---
+
+## Server affinity (hitting breakpoints)
+
+B2C Commerce instances may run multiple application servers behind a load balancer. The debugger attaches to **one** app server, and a breakpoint only fires when your code executes on that same server.
+
+To pin the triggering request to the correct app server, both `debug_start_session` and `debug_list_sessions` return a `session_cookie`:
+
+```json
+{"name": "dwsid", "value": "abc123..."}
+```
+
+Send your triggering request — a storefront page load, a SCAPI/OCAPI call, etc. — with this cookie so it lands on the app server holding the debug session:
+
+```
+Cookie: dwsid=abc123...
+```
+
+If `session_cookie` is `null`, the debugger did not establish a session cookie; a warning is included and breakpoints may not be reliably hit on multi-app-server instances.
 
 ---
 
@@ -71,18 +92,18 @@ Set breakpoints in a debug session. **Replaces** all previously set breakpoints.
 
 Accepts local file paths (mapped to server paths via cartridge discovery), cartridge-prefixed paths (e.g. `app_storefront/cartridge/controllers/Cart.js`), or server paths starting with `/`.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `session_id` | string | Yes | Session ID from `debug_start_session` |
-| `breakpoints` | array | Yes | Array of `{file, line, condition?}` objects |
+| Parameter     | Type   | Required | Description                                 |
+| ------------- | ------ | -------- | ------------------------------------------- |
+| `session_id`  | string | Yes      | Session ID from `debug_start_session`       |
+| `breakpoints` | array  | Yes      | Array of `{file, line, condition?}` objects |
 
 Each breakpoint object:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `file` | string | Yes | Local file path, cartridge-prefixed path, or server script path |
-| `line` | number | Yes | Line number |
-| `condition` | string | No | Conditional expression — breakpoint only triggers when true |
+| Field       | Type   | Required | Description                                                     |
+| ----------- | ------ | -------- | --------------------------------------------------------------- |
+| `file`      | string | Yes      | Local file path, cartridge-prefixed path, or server script path |
+| `line`      | number | Yes      | Line number                                                     |
+| `condition` | string | No       | Conditional expression — breakpoint only triggers when true     |
 
 ---
 
@@ -92,10 +113,10 @@ Each breakpoint object:
 
 Wait for a thread to halt at a breakpoint or step. Returns immediately if a thread is already halted. Otherwise **blocks** until a halt occurs or the timeout expires — the user or an external process must trigger a request on the instance while this tool is waiting.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `session_id` | string | Yes | | Session ID |
-| `timeout_ms` | number | No | 30000 | Timeout in milliseconds (max 120000) |
+| Parameter    | Type   | Required | Default | Description                          |
+| ------------ | ------ | -------- | ------- | ------------------------------------ |
+| `session_id` | string | Yes      |         | Session ID                           |
+| `timeout_ms` | number | No       | 30000   | Timeout in milliseconds (max 120000) |
 
 **Returns:** `{halted, thread_id, location}` or `{halted: false, timed_out: true}`.
 
@@ -103,37 +124,37 @@ Wait for a thread to halt at a breakpoint or step. Returns immediately if a thre
 
 Resume execution of a halted thread.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `session_id` | string | Yes | Session ID |
-| `thread_id` | number | Yes | Thread ID of the halted thread |
+| Parameter    | Type   | Required | Description                    |
+| ------------ | ------ | -------- | ------------------------------ |
+| `session_id` | string | Yes      | Session ID                     |
+| `thread_id`  | number | Yes      | Thread ID of the halted thread |
 
 ### debug_step_over
 
 Step to the next line in the current function. Follow with `debug_wait_for_stop`.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `session_id` | string | Yes | Session ID |
-| `thread_id` | number | Yes | Thread ID |
+| Parameter    | Type   | Required | Description |
+| ------------ | ------ | -------- | ----------- |
+| `session_id` | string | Yes      | Session ID  |
+| `thread_id`  | number | Yes      | Thread ID   |
 
 ### debug_step_into
 
 Step into the function call on the current line. Follow with `debug_wait_for_stop`.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `session_id` | string | Yes | Session ID |
-| `thread_id` | number | Yes | Thread ID |
+| Parameter    | Type   | Required | Description |
+| ------------ | ------ | -------- | ----------- |
+| `session_id` | string | Yes      | Session ID  |
+| `thread_id`  | number | Yes      | Thread ID   |
 
 ### debug_step_out
 
 Step out of the current function, returning to the caller. Follow with `debug_wait_for_stop`.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `session_id` | string | Yes | Session ID |
-| `thread_id` | number | Yes | Thread ID |
+| Parameter    | Type   | Required | Description |
+| ------------ | ------ | -------- | ----------- |
+| `session_id` | string | Yes      | Session ID  |
+| `thread_id`  | number | Yes      | Thread ID   |
 
 ---
 
@@ -143,22 +164,22 @@ Step out of the current function, returning to the caller. Follow with `debug_wa
 
 Get the call stack for a halted thread. Returns stack frames with mapped local file paths and server script paths.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `session_id` | string | Yes | Session ID |
-| `thread_id` | number | Yes | Thread ID |
+| Parameter    | Type   | Required | Description |
+| ------------ | ------ | -------- | ----------- |
+| `session_id` | string | Yes      | Session ID  |
+| `thread_id`  | number | Yes      | Thread ID   |
 
 ### debug_get_variables
 
 Get variables for a stack frame in a halted thread.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `session_id` | string | Yes | | Session ID |
-| `thread_id` | number | Yes | | Thread ID |
-| `frame_index` | number | No | `0` | Stack frame index (0 = top frame) |
-| `scope` | string | No | All scopes | Filter by `local`, `closure`, or `global` |
-| `object_path` | string | No | | Dot-delimited path to drill into an object (e.g. `request.httpParameters`) |
+| Parameter     | Type   | Required | Default    | Description                                                                |
+| ------------- | ------ | -------- | ---------- | -------------------------------------------------------------------------- |
+| `session_id`  | string | Yes      |            | Session ID                                                                 |
+| `thread_id`   | number | Yes      |            | Thread ID                                                                  |
+| `frame_index` | number | No       | `0`        | Stack frame index (0 = top frame)                                          |
+| `scope`       | string | No       | All scopes | Filter by `local`, `closure`, or `global`                                  |
+| `object_path` | string | No       |            | Dot-delimited path to drill into an object (e.g. `request.httpParameters`) |
 
 ### debug_evaluate
 
@@ -166,12 +187,12 @@ Evaluate an expression in the context of a halted thread and stack frame.
 
 > **Warning:** Expressions can have side effects (modify variables, call functions). Use with care.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `session_id` | string | Yes | | Session ID |
-| `thread_id` | number | Yes | | Thread ID |
-| `frame_index` | number | No | `0` | Stack frame index |
-| `expression` | string | Yes | | JavaScript expression to evaluate |
+| Parameter     | Type   | Required | Default | Description                       |
+| ------------- | ------ | -------- | ------- | --------------------------------- |
+| `session_id`  | string | Yes      |         | Session ID                        |
+| `thread_id`   | number | Yes      |         | Thread ID                         |
+| `frame_index` | number | No       | `0`     | Stack frame index                 |
+| `expression`  | string | Yes      |         | JavaScript expression to evaluate |
 
 ---
 
@@ -183,15 +204,15 @@ Set a breakpoint, wait for it to be hit, and capture a diagnostic snapshot — s
 
 > **Important:** This tool **blocks** until the breakpoint is hit or the timeout expires. The user or an external process must trigger a request on the instance while this tool is waiting.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `session_id` | string | Yes | | Session ID |
-| `file` | string | Yes | | File path for the breakpoint |
-| `line` | number | Yes | | Line number |
-| `condition` | string | No | | Conditional expression |
-| `expressions` | string[] | No | | Expressions to evaluate when hit |
-| `timeout_ms` | number | No | 30000 | Timeout waiting for the breakpoint (max 120000) |
-| `auto_continue` | boolean | No | `false` | Resume the thread after capturing |
+| Parameter       | Type     | Required | Default | Description                                     |
+| --------------- | -------- | -------- | ------- | ----------------------------------------------- |
+| `session_id`    | string   | Yes      |         | Session ID                                      |
+| `file`          | string   | Yes      |         | File path for the breakpoint                    |
+| `line`          | number   | Yes      |         | Line number                                     |
+| `condition`     | string   | No       |         | Conditional expression                          |
+| `expressions`   | string[] | No       |         | Expressions to evaluate when hit                |
+| `timeout_ms`    | number   | No       | 30000   | Timeout waiting for the breakpoint (max 120000) |
+| `auto_continue` | boolean  | No       | `false` | Resume the thread after capturing               |
 
 ---
 

--- a/docs/vscode-extension/index.md
+++ b/docs/vscode-extension/index.md
@@ -34,6 +34,8 @@ Step through anything that runs server-side: cartridge controllers, jobs, custom
 
 [![B2C Script Debugger](./images/script-debugger.png)](./images/script-debugger.png)
 
+On multi-app-server environments, a breakpoint only fires when the triggering request reaches the app server the debugger is attached to. While a debug session is active, run **B2C DX: Copy Debugger Session ID (dwsid)** from the Command Palette to copy the session cookie, then send your triggering request (e.g. in the browser) with `Cookie: dwsid=<value>`. See the [Script Debugger guide](../guide/script-debugger#server-affinity-hitting-breakpoints) for details.
+
 ### Cartridge Management and Code Watch/Upload
 
 Edit cartridges locally and have changes show up on your sandbox automatically. Deploy on demand, diff against the active code version, and manage code versions without leaving the editor.

--- a/packages/b2c-dx-mcp/src/tools/diagnostics/debug-list-sessions.ts
+++ b/packages/b2c-dx-mcp/src/tools/diagnostics/debug-list-sessions.ts
@@ -18,6 +18,7 @@ interface ListSessionsOutput {
     client_id: string;
     halted_threads: number[];
     breakpoints: MappedBreakpoint[];
+    session_cookie: null | {name: string; value: string};
     created_at: string;
     last_activity_at: string;
   }>;
@@ -31,26 +32,30 @@ export function createDebugListSessionsTool(
     {
       name: 'debug_list_sessions',
       description:
-        'List active script debugger sessions with their breakpoints and any halted threads. ' +
-        'Use this to discover orphaned sessions, check whether breakpoints are armed, and poll for halted threads in the non-blocking debug workflow.',
+        'List active script debugger sessions with their breakpoints, any halted threads, and the session_cookie (e.g. dwsid). ' +
+        'Use this to discover orphaned sessions, check whether breakpoints are armed, poll for halted threads in the non-blocking debug workflow, and retrieve the session cookie to pin a triggering request (Cookie: <name>=<value>) to the app server holding the session.',
       toolsets: ['CARTRIDGES', 'DIAGNOSTICS', 'SCAPI'],
       inputSchema: {},
       async execute(_args, context) {
         const registry = getRegistry(context);
         const entries = registry.listSessions();
         return {
-          sessions: entries.map((entry) => ({
-            session_id: entry.sessionId,
-            hostname: entry.hostname,
-            client_id: entry.clientId,
-            halted_threads: entry.manager
-              .getKnownThreads()
-              .filter((t) => t.status === 'halted')
-              .map((t) => t.id),
-            breakpoints: entry.breakpoints.map((bp) => projectBreakpoint(bp, entry.sourceMapper)),
-            created_at: new Date(entry.createdAt).toISOString(),
-            last_activity_at: new Date(entry.lastActivityAt).toISOString(),
-          })),
+          sessions: entries.map((entry) => {
+            const dwsid = entry.manager.getSessionCookie();
+            return {
+              session_id: entry.sessionId,
+              hostname: entry.hostname,
+              client_id: entry.clientId,
+              halted_threads: entry.manager
+                .getKnownThreads()
+                .filter((t) => t.status === 'halted')
+                .map((t) => t.id),
+              breakpoints: entry.breakpoints.map((bp) => projectBreakpoint(bp, entry.sourceMapper)),
+              session_cookie: dwsid ? {name: 'dwsid', value: dwsid} : null,
+              created_at: new Date(entry.createdAt).toISOString(),
+              last_activity_at: new Date(entry.lastActivityAt).toISOString(),
+            };
+          }),
         };
       },
       formatOutput: (output) => jsonResult(output),

--- a/packages/b2c-dx-mcp/src/tools/diagnostics/debug-start-session.ts
+++ b/packages/b2c-dx-mcp/src/tools/diagnostics/debug-start-session.ts
@@ -28,6 +28,7 @@ interface StartSessionOutput {
   hostname: string;
   cartridges: string[];
   cartridge_mappings: Record<string, string>;
+  session_cookie: null | {name: string; value: string};
   warnings: string[];
 }
 
@@ -41,6 +42,7 @@ export function createDebugStartSessionTool(
       description:
         'Start a script debugger session on a B2C Commerce instance to debug SFRA controllers, custom API scripts, hooks, jobs, or any server-side script. ' +
         'Returns a session_id for use with other debug tools, plus discovered cartridge mappings. ' +
+        'Also returns session_cookie (e.g. dwsid): to reliably hit a breakpoint on a multi-app-server instance, send the request that triggers your code (storefront page load, SCAPI/OCAPI call) with this cookie (Cookie: <name>=<value>) so it lands on the same app server holding the debug session. ' +
         'WARNING: Debug sessions halt remote request threads on the instance. Always call debug_end_session when finished. ' +
         'Requires Basic auth credentials (username/password) and the script debugger enabled in Business Manager.',
       toolsets: ['CARTRIDGES', 'DIAGNOSTICS', 'SCAPI'],
@@ -103,11 +105,19 @@ export function createDebugStartSessionTool(
         const cartridgeMappings: Record<string, string> = {};
         for (const c of cartridges) cartridgeMappings[c.name] = c.src;
 
+        const dwsid = manager.getSessionCookie();
+        if (!dwsid) {
+          warnings.push(
+            'No session cookie (dwsid) was returned by the debugger. Requests cannot be pinned to this app server; breakpoints may not be hit on multi-app-server instances.',
+          );
+        }
+
         return {
           session_id: entry.sessionId,
           hostname,
           cartridges: cartridges.map((c) => c.name),
           cartridge_mappings: cartridgeMappings,
+          session_cookie: dwsid ? {name: 'dwsid', value: dwsid} : null,
           warnings,
         };
       },

--- a/packages/b2c-dx-mcp/test/tools/diagnostics/debug-tools.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/diagnostics/debug-tools.test.ts
@@ -83,6 +83,7 @@ function createMockManager(overrides?: Record<string, unknown>): MockDebugSessio
     stepInto: sinon.stub().resolves(),
     stepOut: sinon.stub().resolves(),
     getKnownThreads: sinon.stub().returns([]),
+    getSessionCookie: sinon.stub().returns('dwsid-value-123'),
     ...overrides,
   } as unknown as MockDebugSessionManager;
 }
@@ -151,13 +152,35 @@ describe('tools/diagnostics', () => {
       const tool = createDebugListSessionsTool(loadServices, serverContext);
       const result = await tool.handler({});
       const json = getResultJson<{
-        sessions: Array<{session_id: string; halted_threads: number[]; breakpoints: unknown[]}>;
+        sessions: Array<{
+          session_id: string;
+          halted_threads: number[];
+          breakpoints: unknown[];
+          session_cookie: null | {name: string; value: string};
+        }>;
       }>(result);
 
       expect(json.sessions).to.have.lengthOf(1);
       expect(json.sessions[0].session_id).to.equal(entry.sessionId);
       expect(json.sessions[0].halted_threads).to.deep.equal([5]);
       expect(json.sessions[0].breakpoints).to.have.lengthOf(1);
+      expect(json.sessions[0].session_cookie).to.deep.equal({name: 'dwsid', value: 'dwsid-value-123'});
+    });
+
+    it('should report session_cookie as null when no dwsid is set', async () => {
+      const manager = createMockManager({getSessionCookie: sinon.stub().returns(undefined)});
+      serverContext.debugSessions.registerSession({
+        hostname: 'host.example.com',
+        clientId: 'c1',
+        manager,
+        sourceMapper: createMockSourceMapper(),
+        cartridges: [],
+      });
+
+      const tool = createDebugListSessionsTool(loadServices, serverContext);
+      const result = await tool.handler({});
+      const json = getResultJson<{sessions: Array<{session_cookie: unknown}>}>(result);
+      expect(json.sessions[0].session_cookie).to.be.null;
     });
 
     it('should error when server context is missing', async () => {
@@ -1027,6 +1050,7 @@ describe('tools/diagnostics', () => {
       // Stub the manager's network calls
       connectStub = sinon.stub(DebugSessionManager.prototype, 'connect').resolves();
       sinon.stub(DebugSessionManager.prototype, 'disconnect').resolves();
+      sinon.stub(DebugSessionManager.prototype, 'getSessionCookie').returns('dwsid-abc');
     });
 
     afterEach(() => {
@@ -1044,6 +1068,7 @@ describe('tools/diagnostics', () => {
         hostname: string;
         cartridges: string[];
         cartridge_mappings: Record<string, string>;
+        session_cookie: null | {name: string; value: string};
         warnings: string[];
       }>(result);
 
@@ -1051,7 +1076,18 @@ describe('tools/diagnostics', () => {
       expect(json.hostname).to.equal('test.example.com');
       expect(json.cartridges).to.deep.equal(['app_test']);
       expect(json.cartridge_mappings).to.have.property('app_test');
+      expect(json.session_cookie).to.deep.equal({name: 'dwsid', value: 'dwsid-abc'});
       expect(connectStub.calledOnce).to.be.true;
+    });
+
+    it('should return null session_cookie and warn when no dwsid is set', async () => {
+      (DebugSessionManager.prototype.getSessionCookie as sinon.SinonStub).returns(undefined);
+      const tool = createDebugStartSessionTool(loadServices, serverContext);
+      const result = await tool.handler({cartridge_directory: tmpDir});
+
+      const json = getResultJson<{session_cookie: unknown; warnings: string[]}>(result);
+      expect(json.session_cookie).to.be.null;
+      expect(json.warnings.some((w) => w.includes('dwsid'))).to.be.true;
     });
 
     it('should warn when no cartridges found', async () => {

--- a/packages/b2c-tooling-sdk/src/operations/debug/dap-adapter.ts
+++ b/packages/b2c-tooling-sdk/src/operations/debug/dap-adapter.ts
@@ -215,6 +215,24 @@ export class B2CScriptDebugAdapter extends LoggingDebugSession {
     this.sendResponse(response);
   }
 
+  /**
+   * Custom DAP requests not part of the base protocol.
+   *
+   * - `b2c/sessionCookie`: returns `{name, value}` for the debugger's session
+   *   cookie (`dwsid`), or `{name, value: null}` if not connected. Used by the
+   *   VS Code extension to let users copy the cookie and route a triggering
+   *   request to the same app server (server affinity).
+   */
+  protected override customRequest(command: string, response: DebugProtocol.Response, args: unknown): void {
+    if (command === 'b2c/sessionCookie') {
+      const value = this.session?.getSessionCookie() ?? null;
+      response.body = {name: 'dwsid', value};
+      this.sendResponse(response);
+      return;
+    }
+    super.customRequest(command, response, args);
+  }
+
   // -----------------------------------------------------------------------
   // Breakpoints
   // -----------------------------------------------------------------------

--- a/packages/b2c-tooling-sdk/src/operations/debug/debug-session.ts
+++ b/packages/b2c-tooling-sdk/src/operations/debug/debug-session.ts
@@ -75,6 +75,18 @@ export class DebugSessionManager {
       this.pollTimer = setInterval(() => void this.pollThreads(), pollInterval);
 
       this.logger.debug('Script debugger connected');
+
+      // Surface the session cookie at info level so users driving the debugger
+      // from the CLI or VS Code (B2C DX output channel) can route a triggering
+      // request to the same app server — required to hit breakpoints on
+      // multi-app-server PIG environments. See getSessionCookie().
+      const dwsid = this.client.getCookie('dwsid');
+      if (dwsid) {
+        this.logger.info(
+          `Debug session cookie: dwsid=${dwsid} — send your triggering request (storefront page, SCAPI/OCAPI call) with this cookie to hit breakpoints on multi-app-server instances.`,
+        );
+      }
+
       this.callbacks.onConnected?.(this.config.hostname);
     } catch (err) {
       // Ensure timers are cleared if anything (incl. onConnected callback) throws

--- a/packages/b2c-tooling-sdk/src/operations/debug/debug-session.ts
+++ b/packages/b2c-tooling-sdk/src/operations/debug/debug-session.ts
@@ -154,6 +154,17 @@ export class DebugSessionManager {
     return [...this.knownThreads.values()];
   }
 
+  /**
+   * Returns the session cookie (`dwsid`) established with the debugger, or
+   * `undefined` if not yet connected. This cookie pins requests to the app
+   * server holding the debugger session; callers can use it to route an
+   * external request (e.g. a storefront browser) to the same app server so
+   * breakpoints are hit.
+   */
+  getSessionCookie(name = 'dwsid'): string | undefined {
+    return this.client.getCookie(name);
+  }
+
   // -----------------------------------------------------------------------
   // Internal
   // -----------------------------------------------------------------------

--- a/packages/b2c-tooling-sdk/src/operations/debug/sdapi-client.ts
+++ b/packages/b2c-tooling-sdk/src/operations/debug/sdapi-client.ts
@@ -274,6 +274,16 @@ export class SdapiClient {
   }
 
   /**
+   * Returns the value of a stored session cookie, or `undefined` if it has not
+   * been set yet. The session cookie (`dwsid`) pins requests to the app server
+   * holding the debugger session — callers may need it to route external
+   * requests (e.g. a storefront browser) to the same app server.
+   */
+  getCookie(name: string): string | undefined {
+    return this.cookies.get(name);
+  }
+
+  /**
    * Builds the `Cookie` request header from stored session cookies, or an empty
    * object if none have been set yet.
    */

--- a/packages/b2c-tooling-sdk/src/operations/debug/sdapi-client.ts
+++ b/packages/b2c-tooling-sdk/src/operations/debug/sdapi-client.ts
@@ -25,6 +25,17 @@ import type {
 } from './types.js';
 
 /**
+ * Converts a Headers object to a plain object for trace logging.
+ */
+function headersToObject(headers: Headers): Record<string, string> {
+  const result: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}
+
+/**
  * Error thrown when the SDAPI returns a fault response.
  */
 export class SdapiError extends Error {
@@ -57,6 +68,17 @@ export class SdapiClient {
   private readonly baseUrl: string;
   private readonly headers: Record<string, string>;
   private readonly logger = getLogger();
+  /**
+   * Cookies (name -> value) returned by the SDAPI via Set-Cookie, replayed on
+   * subsequent requests. The debugger establishes a session (e.g. `dwsid`) on
+   * the first request that must be honored for the lifetime of this client.
+   *
+   * Replaying these cookies is required for server affinity: in multi-app
+   * server instances/environments the `dwsid` pins the session to the app
+   * server that holds the debugger state, so without it subsequent requests may
+   * be routed to a different app server with no knowledge of the session.
+   */
+  private readonly cookies = new Map<string, string>();
 
   constructor(config: SdapiClientConfig) {
     this.baseUrl = `https://${config.hostname}/s/-/dw/debugger/v2_0`;
@@ -205,13 +227,20 @@ export class SdapiClient {
 
   private async request<T>(method: string, path: string, options?: {body?: unknown; expect204?: boolean}): Promise<T> {
     const url = `${this.baseUrl}${path}`;
-    this.logger.trace({method, path}, 'SDAPI request');
+    const headers = {...this.headers, ...this.cookieHeader()};
+    this.logger.trace({method, url, headers, body: options?.body}, `[SDAPI REQ] ${method} ${url}`);
 
     const response = await fetch(url, {
       method,
-      headers: this.headers,
+      headers,
       body: options?.body ? JSON.stringify(options.body) : undefined,
     });
+
+    this.storeCookies(response.headers);
+    this.logger.trace(
+      {method, url, status: response.status, headers: headersToObject(response.headers)},
+      `[SDAPI RESP] ${method} ${url} ${response.status}`,
+    );
 
     if (options?.expect204) {
       if (!response.ok) {
@@ -242,5 +271,40 @@ export class SdapiClient {
       fault = {_v: '2.0', type: 'UnknownError', message: `HTTP ${response.status} ${response.statusText}`};
     }
     throw new SdapiError(fault, response.status);
+  }
+
+  /**
+   * Builds the `Cookie` request header from stored session cookies, or an empty
+   * object if none have been set yet.
+   */
+  private cookieHeader(): Record<string, string> {
+    if (this.cookies.size === 0) {
+      return {};
+    }
+    const cookie = Array.from(this.cookies, ([name, value]) => `${name}=${value}`).join('; ');
+    return {Cookie: cookie};
+  }
+
+  /**
+   * Parses `Set-Cookie` headers from a response and stores them for replay on
+   * subsequent requests (only the name=value pair is retained, attributes are
+   * ignored). Uses `Headers.getSetCookie()` so multiple cookies are not
+   * collapsed into a single comma-joined value.
+   */
+  private storeCookies(headers: Headers): void {
+    const setCookies = typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : ([] as string[]);
+    for (const setCookie of setCookies) {
+      const pair = setCookie.split(';', 1)[0]?.trim();
+      if (!pair) {
+        continue;
+      }
+      const eq = pair.indexOf('=');
+      if (eq <= 0) {
+        continue;
+      }
+      const name = pair.slice(0, eq).trim();
+      const value = pair.slice(eq + 1).trim();
+      this.cookies.set(name, value);
+    }
   }
 }

--- a/packages/b2c-tooling-sdk/test/operations/debug/dap-adapter.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/debug/dap-adapter.test.ts
@@ -219,6 +219,45 @@ describe('operations/debug/dap-adapter (integration)', () => {
     });
   });
 
+  describe('b2c/sessionCookie custom request', () => {
+    it('returns the dwsid cookie established on connect', async () => {
+      server.use(
+        http.delete(`${BASE_URL}/client`, () => new HttpResponse(null, {status: 204})),
+        http.post(
+          `${BASE_URL}/client`,
+          () => new HttpResponse(null, {status: 204, headers: {'Set-Cookie': 'dwsid=affinity-xyz; Path=/; HttpOnly'}}),
+        ),
+        http.get(`${BASE_URL}/threads`, () => HttpResponse.json({_v: '2.0', script_threads: []})),
+      );
+
+      const adapter = new B2CScriptDebugAdapter(makeConfig());
+      const client = createDAPClient(adapter);
+
+      await client.send('initialize', {adapterID: 'b2c-script', pathFormat: 'path'});
+      await client.send('launch', {});
+
+      const response = await client.send('b2c/sessionCookie');
+      expect(response.success).to.be.true;
+      expect(response.body).to.deep.equal({name: 'dwsid', value: 'affinity-xyz'});
+
+      await client.send('disconnect', {});
+      client.dispose();
+    });
+
+    it('returns a null value when not connected', async () => {
+      const adapter = new B2CScriptDebugAdapter(makeConfig());
+      const client = createDAPClient(adapter);
+
+      await client.send('initialize', {adapterID: 'b2c-script', pathFormat: 'path'});
+
+      const response = await client.send('b2c/sessionCookie');
+      expect(response.success).to.be.true;
+      expect(response.body).to.deep.equal({name: 'dwsid', value: null});
+
+      client.dispose();
+    });
+  });
+
   describe('breakpoints', () => {
     it('sets breakpoints and returns verified results', async () => {
       server.use(

--- a/packages/b2c-tooling-sdk/test/operations/debug/sdapi-client.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/debug/sdapi-client.test.ts
@@ -6,6 +6,7 @@
 import {expect} from 'chai';
 import {http, HttpResponse} from 'msw';
 import {setupServer} from 'msw/node';
+import sinon from 'sinon';
 import {SdapiClient, SdapiError} from '@salesforce/b2c-tooling-sdk/operations/debug';
 
 const TEST_HOST = 'test.demandware.net';
@@ -241,6 +242,63 @@ describe('operations/debug/sdapi-client', () => {
 
       const result = await client.evaluate(1, 0, 'basket.getProductLineItems().size()');
       expect(result.result).to.equal('3');
+    });
+  });
+
+  // These tests stub `fetch` directly rather than going through MSW: MSW
+  // maintains its own tough-cookie jar that auto-replays Set-Cookie values
+  // (with attributes) on subsequent requests, which would mask what the client
+  // itself sends. Stubbing fetch isolates the client's cookie handling.
+  describe('session cookies', () => {
+    afterEach(() => sinon.restore());
+
+    function stubFetch(responses: Array<{setCookie?: string; status?: number; body?: unknown}>): {
+      cookieHeaders: (string | null)[];
+    } {
+      const cookieHeaders: (string | null)[] = [];
+      let call = 0;
+      sinon.stub(globalThis, 'fetch').callsFake(async (_url, init) => {
+        const headers = new Headers((init as RequestInit | undefined)?.headers);
+        cookieHeaders.push(headers.get('Cookie'));
+        const spec = responses[call++] ?? {};
+        const respHeaders = new Headers();
+        if (spec.setCookie) {
+          respHeaders.append('Set-Cookie', spec.setCookie);
+        }
+        const status = spec.status ?? 200;
+        const body = spec.body === undefined ? null : JSON.stringify(spec.body);
+        return new Response(body, {status, headers: respHeaders});
+      });
+      return {cookieHeaders};
+    }
+
+    it('replays Set-Cookie values on subsequent requests for server affinity', async () => {
+      const {cookieHeaders} = stubFetch([
+        {setCookie: 'dwsid=abc123; Path=/; HttpOnly', status: 204},
+        {body: {_v: '2.0', script_threads: []}},
+      ]);
+
+      await client.createClient();
+      await client.getThreads();
+
+      // First request has no cookie; second replays the dwsid from the response.
+      expect(cookieHeaders[0]).to.equal(null);
+      expect(cookieHeaders[1]).to.equal('dwsid=abc123');
+    });
+
+    it('updates a stored cookie when the server sets a new value', async () => {
+      const {cookieHeaders} = stubFetch([
+        {setCookie: 'dwsid=first; Path=/', status: 204},
+        {setCookie: 'dwsid=second; Path=/', body: {_v: '2.0', script_threads: []}},
+        {body: {_v: '2.0', script_threads: []}},
+      ]);
+
+      await client.createClient();
+      await client.getThreads();
+      await client.getThreads();
+
+      expect(cookieHeaders[1]).to.equal('dwsid=first');
+      expect(cookieHeaders[2]).to.equal('dwsid=second');
     });
   });
 

--- a/packages/b2c-tooling-sdk/test/operations/debug/sdapi-client.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/debug/sdapi-client.test.ts
@@ -286,6 +286,15 @@ describe('operations/debug/sdapi-client', () => {
       expect(cookieHeaders[1]).to.equal('dwsid=abc123');
     });
 
+    it('exposes a stored cookie value via getCookie', async () => {
+      stubFetch([{setCookie: 'dwsid=abc123; Path=/; HttpOnly', status: 204}]);
+
+      expect(client.getCookie('dwsid')).to.be.undefined;
+      await client.createClient();
+      expect(client.getCookie('dwsid')).to.equal('abc123');
+      expect(client.getCookie('missing')).to.be.undefined;
+    });
+
     it('updates a stored cookie when the server sets a new value', async () => {
       const {cookieHeaders} = stubFetch([
         {setCookie: 'dwsid=first; Path=/', status: 204},

--- a/packages/b2c-vs-extension/package.json
+++ b/packages/b2c-vs-extension/package.json
@@ -241,6 +241,11 @@
     ],
     "commands": [
       {
+        "command": "b2c-dx.debug.copySessionCookie",
+        "title": "Copy Debugger Session ID (dwsid)",
+        "category": "B2C DX"
+      },
+      {
         "command": "b2c-dx.promptAgent",
         "title": "Prompt Agent",
         "category": "B2C DX"
@@ -909,6 +914,10 @@
         }
       ],
       "commandPalette": [
+        {
+          "command": "b2c-dx.debug.copySessionCookie",
+          "when": "inDebugMode && debugType == 'b2c-script'"
+        },
         {
           "command": "b2c-dx.apiBrowser.openSwagger",
           "when": "false"

--- a/packages/b2c-vs-extension/src/debugger/index.ts
+++ b/packages/b2c-vs-extension/src/debugger/index.ts
@@ -57,7 +57,44 @@ class B2CDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {
   }
 }
 
+/**
+ * Copies the active debug session's `dwsid` cookie to the clipboard so the user
+ * can send a triggering request (storefront page, SCAPI/OCAPI call) on the same
+ * app server holding the debug session — required to hit breakpoints on
+ * multi-app-server PIG environments.
+ */
+async function copySessionCookie(): Promise<void> {
+  const session = vscode.debug.activeDebugSession;
+  if (!session || session.type !== DEBUG_TYPE) {
+    void vscode.window.showWarningMessage('B2C Script Debugger: no active debug session. Start a debug session first.');
+    return;
+  }
+
+  let value: string | null = null;
+  try {
+    const result = (await session.customRequest('b2c/sessionCookie')) as {value?: string | null} | undefined;
+    value = result?.value ?? null;
+  } catch {
+    // Falls through to the not-available message below.
+  }
+
+  if (!value) {
+    void vscode.window.showWarningMessage(
+      'B2C Script Debugger: no session cookie (dwsid) is available yet. Wait for the debugger to connect.',
+    );
+    return;
+  }
+
+  await vscode.env.clipboard.writeText(value);
+  void vscode.window.showInformationMessage(
+    `B2C Script Debugger: copied dwsid to clipboard. Send your triggering request with "Cookie: dwsid=${value}".`,
+  );
+}
+
 export function registerDebugger(context: vscode.ExtensionContext, configProvider: B2CExtensionConfig): void {
   const factory = new B2CDebugAdapterFactory(configProvider);
-  context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory(DEBUG_TYPE, factory));
+  context.subscriptions.push(
+    vscode.debug.registerDebugAdapterDescriptorFactory(DEBUG_TYPE, factory),
+    vscode.commands.registerCommand('b2c-dx.debug.copySessionCookie', () => copySessionCookie()),
+  );
 }

--- a/skills/b2c-cli/skills/b2c-debug/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-debug/SKILL.md
@@ -5,7 +5,11 @@ description: Debug B2C Commerce server-side scripts using the b2c CLI. Use this 
 
 # B2C Debug Skill
 
-Use the `b2c` CLI to debug server-side scripts on Salesforce B2C Commerce instances. The `debug cli` command provides an interactive REPL for terminal debugging, with an `--rpc` mode for headless/programmatic use.
+Debug server-side scripts on Salesforce B2C Commerce instances — set breakpoints, step through code, and inspect variables in SFRA controllers, hooks, jobs, and custom APIs.
+
+> **Prefer the MCP diagnostics tools when available.** If the B2C DX MCP server is installed (tools named `debug_start_session`, `debug_set_breakpoints`, `debug_wait_for_stop`, `debug_capture_at_breakpoint`, etc.), **use them instead of the RPC-based `b2c debug cli --rpc` workflow.** The MCP tools manage session state for you, return structured JSON, and support a non-blocking poll workflow (`debug_list_sessions` / `debug_wait_for_stop`) that is far more reliable for agents than driving JSONL over stdio. Only fall back to `b2c debug cli` (REPL or `--rpc`) when the MCP server is not installed, or when a human wants an interactive terminal session.
+
+The `b2c debug cli` command provides an interactive REPL for terminal debugging, with an `--rpc` mode for headless/programmatic use. `b2c debug` provides a DAP adapter for IDEs.
 
 > **Tip:** If `b2c` is not installed globally, use `npx @salesforce/b2c-cli` instead (e.g., `npx @salesforce/b2c-cli debug cli`).
 
@@ -125,6 +129,19 @@ b2c debug
 ```
 
 This starts a DAP adapter over stdio, used by IDE launch configurations.
+
+## Server Affinity (Hitting Breakpoints)
+
+A breakpoint only fires when the triggering code runs on the **same application server** the debugger is attached to. Some **Production Instance Group (PIG)** environments run **multiple application servers** behind a load balancer, so a request that should hit your breakpoint may land on a different app server and the breakpoint never fires.
+
+> **Sandboxes (ODS) are single-app-server and are not affected.** This only matters on multi-app-server PIG environments (typically staging/production). If breakpoints are not hitting on a sandbox, the cause is something else (wrong path mapping, code version, or the code simply not running).
+
+To pin a triggering request to the correct app server, send it with the debugger's session cookie (`dwsid`):
+
+- **MCP:** `debug_start_session` and `debug_list_sessions` return a `session_cookie` (`{name, value}`). Send the request that triggers your code (storefront page load, SCAPI/OCAPI call) with `Cookie: dwsid=<value>`.
+- **Any trigger:** whatever issues the request — a browser, `curl`, an integration test — must carry the same `dwsid` value.
+
+If the cookie cannot be set on the triggering request, retry until the load balancer routes to the attached app server.
 
 ## Related Skills
 

--- a/skills/b2c-cli/skills/b2c-debug/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-debug/SKILL.md
@@ -134,7 +134,7 @@ This starts a DAP debug adapter over stdio, used by IDE launch configurations.
 
 A breakpoint only fires when the triggering code runs on the **same application server** the debugger is attached to. Some **Production Instance Group (PIG)** environments run **multiple application servers** behind a load balancer, so a request that should hit your breakpoint may land on a different app server and the breakpoint never fires.
 
-> **Sandboxes (ODS) are single-app-server and are not affected.** This only matters on multi-app-server PIG environments (typically staging/production). If breakpoints are not hitting on a sandbox, the cause is something else (wrong path mapping, code version, or the code simply not running).
+> **Sandboxes (ODS) are single-app-server and are not affected.** This only matters on certain multi-app-server PIG environments. If breakpoints are not hitting on a sandbox, the cause is something else (wrong path mapping, code version, or the code simply not running).
 
 To pin a triggering request to the correct app server, send it with the debugger's session cookie (`dwsid`):
 

--- a/skills/b2c-cli/skills/b2c-debug/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-debug/SKILL.md
@@ -9,7 +9,7 @@ Debug server-side scripts on Salesforce B2C Commerce instances — set breakpoin
 
 > **Prefer the MCP diagnostics tools when available.** If the B2C DX MCP server is installed (tools named `debug_start_session`, `debug_set_breakpoints`, `debug_wait_for_stop`, `debug_capture_at_breakpoint`, etc.), **use them instead of the RPC-based `b2c debug cli --rpc` workflow.** The MCP tools manage session state for you, return structured JSON, and support a non-blocking poll workflow (`debug_list_sessions` / `debug_wait_for_stop`) that is far more reliable for agents than driving JSONL over stdio. Only fall back to `b2c debug cli` (REPL or `--rpc`) when the MCP server is not installed, or when a human wants an interactive terminal session.
 
-The `b2c debug cli` command provides an interactive REPL for terminal debugging, with an `--rpc` mode for headless/programmatic use. `b2c debug` provides a DAP adapter for IDEs.
+`b2c debug` provides a Debug Adapter Protocol (DAP) debug adapter for IDEs. For terminal or headless use without the MCP tools, `b2c debug cli` also offers an interactive REPL and a JSONL `--rpc` mode.
 
 > **Tip:** If `b2c` is not installed globally, use `npx @salesforce/b2c-cli` instead (e.g., `npx @salesforce/b2c-cli debug cli`).
 
@@ -128,7 +128,7 @@ For VS Code and other DAP-compatible IDEs:
 b2c debug
 ```
 
-This starts a DAP adapter over stdio, used by IDE launch configurations.
+This starts a DAP debug adapter over stdio, used by IDE launch configurations.
 
 ## Server Affinity (Hitting Breakpoints)
 

--- a/skills/b2c-cli/skills/b2c-debug/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-debug/SKILL.md
@@ -140,8 +140,9 @@ To pin a triggering request to the correct app server, send it with the debugger
 
 - **MCP:** `debug_start_session` and `debug_list_sessions` return a `session_cookie` (`{name, value}`). Send the request that triggers your code (storefront page load, SCAPI/OCAPI call) with `Cookie: dwsid=<value>`.
 - **Any trigger:** whatever issues the request — a browser, `curl`, an integration test — must carry the same `dwsid` value.
+- **Headless requests (hooks, custom APIs, server-to-server SCAPI/OCAPI):** instead of a cookie, pass the value as the `sfdc_dwsid` request header (`sfdc_dwsid: <value>`).
 
-If the cookie cannot be set on the triggering request, retry until the load balancer routes to the attached app server.
+If the cookie or header cannot be set on the triggering request, retry until the load balancer routes to the attached app server.
 
 ## Related Skills
 


### PR DESCRIPTION
## What

The script debugger (SDAPI) integration now correctly handles the session cookie (`dwsid`) the server issues, and exposes it so callers can route the *triggering* request to the right app server. The work spans the SDK, the MCP diagnostics tools, docs, and the agent skill.

**1. Honor session cookies (bugfix)**
- The SDAPI client persists `Set-Cookie` values returned by the server and replays them on subsequent requests for the lifetime of the client.
- Without this, follow-up debugger requests could be routed to a different app server with no knowledge of the session.

**2. Full trace logging (bugfix)**
- The SDAPI client now logs full request/response headers, status, and body at trace level (`[SDAPI REQ]` / `[SDAPI RESP]`), matching the rest of the SDK's HTTP clients. Previously it bypassed the shared logging middleware and only logged `{method, path}` — the original report that trace logs were missing headers.

**3. Expose the session cookie (feature)**
- SDK: `SdapiClient.getCookie(name)` and `DebugSessionManager.getSessionCookie()`.
- MCP: `debug_start_session` and `debug_list_sessions` now return a `session_cookie` (`{name, value} | null`), with affinity guidance in the tool descriptions and a warning when no `dwsid` is established.

**4. Docs & skill**
- New **Script Debugger** guide (`docs/guide/script-debugger.md`) covering the interfaces (VS Code extension first, then CLI DAP debug adapter, then MCP), requirements (Script Debugger enabled + WebDAV/UX Studio access key), config, and server affinity. Added to the sidebar.
- New "Server affinity" section in the MCP diagnostics docs.
- Updated the `b2c-debug` skill to **prefer the MCP tools over RPC-based CLI debugging** and document affinity.

## Why: server affinity

A breakpoint only fires when the triggering code runs on the **same app server** the debugger is attached to. On multi-app-server **PIG** environments (load-balanced) a request may land elsewhere and the breakpoint never fires. Exposing `dwsid` lets the caller send the storefront/SCAPI/OCAPI request with `Cookie: dwsid=<value>` to pin it to the correct server. **Sandboxes (ODS) are single-app-server and unaffected** — called out throughout the docs/skill.

## How

- Per-client cookie store (`Map<string,string>`); parse `Set-Cookie` via `Headers.getSetCookie()` (avoids comma-collapsing), keep only `name=value`, attach a `Cookie` header on subsequent requests.
- Getter chain `SdapiClient.getCookie` → `DebugSessionManager.getSessionCookie` → MCP tool output.

## Tests

- SDK: session-cookie replay + `getCookie` cases. These stub `fetch` directly rather than using MSW — MSW maintains its own tough-cookie jar that auto-replays `Set-Cookie` (with attributes), which real undici fetch does not and would mask what the client sends.
- MCP: positive and null-cookie cases for both `debug_start_session` and `debug_list_sessions`.

Verification: typecheck + lint clean; SDK **1813 passing**, MCP **830 passing**; `docs:build` reports 0 errors.

## Changesets

- `@salesforce/b2c-tooling-sdk: patch` — honor cookies + trace logging
- `@salesforce/b2c-tooling-sdk: minor`, `@salesforce/b2c-dx-mcp: minor`, `@salesforce/b2c-agent-plugins: patch` — expose the cookie + skill update