### PR TITLE
@W-23237062 feat(telemetry): surface failure detail, add config-error hint, classify errors

### DIFF
--- a/.changeset/config-hint-and-error-classification.md
+++ b/.changeset/config-hint-and-error-classification.md
@@ -1,0 +1,10 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+'@salesforce/b2c-cli': patch
+---
+
+Improve "configuration required" errors and error telemetry:
+
+- When a command needs instance/auth configuration but no source is found at all (no flags, environment variables, or dw.json), the error now points to the configuration guide (https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/configuration.html) so first-time users know where to start. When a config source is present, the existing message (which lists the specific flag/env var to set) is unchanged.
+- Command-error telemetry now tags each error with a category (`validation`, `guardrail`, or `runtime`) so expected user/config errors and safety-guard blocks can be separated from genuine runtime failures when measuring reliability.
+- All telemetry events now include an `isCI` flag indicating whether they originated from a CI/automation environment, so automation traffic can be distinguished from interactive developer usage.

--- a/.changeset/telemetry-error-visibility.md
+++ b/.changeset/telemetry-error-visibility.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/b2c-dx-mcp': patch
+'b2c-vs-extension': patch
+---
+
+Telemetry for MCP tool failures and VS Code extension activation failures now records the underlying error message (and cause, when present), instead of an empty value. Previously these failure events carried no error detail, which made it impossible to diagnose why a tool call or activation failed. No new data beyond the error text is collected, matching what the CLI already reports for command errors.

--- a/packages/b2c-cli/src/commands/auth/login.ts
+++ b/packages/b2c-cli/src/commands/auth/login.ts
@@ -4,7 +4,7 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 import {Args, Flags} from '@oclif/core';
-import {BaseCommand, loadConfig} from '@salesforce/b2c-tooling-sdk/cli';
+import {BaseCommand, ERROR_CODE, loadConfig} from '@salesforce/b2c-tooling-sdk/cli';
 import {ImplicitOAuthStrategy, setStoredSession, decodeJWT} from '@salesforce/b2c-tooling-sdk/auth';
 import {DEFAULT_ACCOUNT_MANAGER_HOST} from '@salesforce/b2c-tooling-sdk';
 import {t, withDocs} from '../../i18n/index.js';
@@ -67,7 +67,8 @@ export default class AuthLogin extends BaseCommand<typeof AuthLogin> {
         t(
           'error.oauthClientIdRequired',
           'OAuth client ID required. Provide a client ID argument or set SFCC_CLIENT_ID.',
-        ),
+        ) + this.configDocsHint(),
+        {code: ERROR_CODE.VALIDATION},
       );
     }
 

--- a/packages/b2c-cli/src/utils/cip/command.ts
+++ b/packages/b2c-cli/src/utils/cip/command.ts
@@ -12,7 +12,7 @@ import {
   DEFAULT_CIP_STAGING_HOST,
   type CipClient,
 } from '@salesforce/b2c-tooling-sdk/clients';
-import {extractOAuthFlags, loadConfig, OAuthCommand} from '@salesforce/b2c-tooling-sdk/cli';
+import {ERROR_CODE, extractOAuthFlags, loadConfig, OAuthCommand} from '@salesforce/b2c-tooling-sdk/cli';
 import type {ResolvedB2CConfig} from '@salesforce/b2c-tooling-sdk/config';
 import {t} from '../../i18n/index.js';
 
@@ -144,6 +144,7 @@ export abstract class CipCommand<T extends typeof Command> extends OAuthCommand<
           'error.cipAuthMethodNotSupported',
           'CIP only supports client-credentials auth. Remove --user-auth/--auth-methods overrides and provide --client-id and --client-secret.',
         ),
+        {code: ERROR_CODE.VALIDATION},
       );
     }
   }

--- a/packages/b2c-cli/src/utils/ecdn/base-command.ts
+++ b/packages/b2c-cli/src/utils/ecdn/base-command.ts
@@ -4,7 +4,7 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 import {Command} from '@oclif/core';
-import {OAuthCommand} from '@salesforce/b2c-tooling-sdk/cli';
+import {ERROR_CODE, OAuthCommand} from '@salesforce/b2c-tooling-sdk/cli';
 import {createCdnZonesClient, type CdnZonesClient} from '@salesforce/b2c-tooling-sdk/clients';
 import {t} from '../../i18n/index.js';
 
@@ -57,7 +57,8 @@ export abstract class EcdnCommand<T extends typeof Command> extends OAuthCommand
         t(
           'error.shortCodeRequired',
           'SCAPI short code required. Provide --short-code, set SFCC_SHORTCODE, or configure short-code in dw.json.',
-        ),
+        ) + this.configDocsHint(),
+        {code: ERROR_CODE.VALIDATION},
       );
     }
     if (!tenantId) {
@@ -65,7 +66,8 @@ export abstract class EcdnCommand<T extends typeof Command> extends OAuthCommand
         t(
           'error.tenantIdRequired',
           'tenant-id is required. Provide via --tenant-id flag, SFCC_TENANT_ID env var, or tenant-id in dw.json.',
-        ),
+        ) + this.configDocsHint(),
+        {code: ERROR_CODE.VALIDATION},
       );
     }
     return {shortCode, tenantId};

--- a/packages/b2c-cli/src/utils/scapi/schemas.ts
+++ b/packages/b2c-cli/src/utils/scapi/schemas.ts
@@ -4,7 +4,7 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 import {Command} from '@oclif/core';
-import {OAuthCommand} from '@salesforce/b2c-tooling-sdk/cli';
+import {ERROR_CODE, OAuthCommand} from '@salesforce/b2c-tooling-sdk/cli';
 import {createScapiSchemasClient, type ScapiSchemasClient} from '@salesforce/b2c-tooling-sdk/clients';
 import {t} from '../../i18n/index.js';
 
@@ -28,7 +28,8 @@ export abstract class ScapiSchemasCommand<T extends typeof Command> extends OAut
         t(
           'error.shortCodeRequired',
           'SCAPI short code required. Provide --short-code, set SFCC_SHORTCODE, or configure short-code in dw.json.',
-        ),
+        ) + this.configDocsHint(),
+        {code: ERROR_CODE.VALIDATION},
       );
     }
     if (!tenantId) {
@@ -36,7 +37,8 @@ export abstract class ScapiSchemasCommand<T extends typeof Command> extends OAut
         t(
           'error.tenantIdRequired',
           'tenant-id is required. Provide via --tenant-id flag, SFCC_TENANT_ID env var, or tenant-id in dw.json.',
-        ),
+        ) + this.configDocsHint(),
+        {code: ERROR_CODE.VALIDATION},
       );
     }
 

--- a/packages/b2c-dx-mcp/src/server.ts
+++ b/packages/b2c-dx-mcp/src/server.ts
@@ -84,11 +84,15 @@ export class B2CDxMcpServer extends McpServer {
         const result = await handler(args);
         const runTimeMs = Date.now() - startTime;
 
+        // Extract error message from CallToolResult content when isError is true
+        const errorMessage = result.isError ? result.content?.find((c) => c.type === 'text')?.text : undefined;
+
         await this.telemetry
           ?.sendEventAndFlush('TOOL_CALLED', {
             toolName: name,
             runTimeMs,
             isError: result.isError ?? false,
+            ...(errorMessage ? {errorMessage} : {}),
           })
           .catch((error_: unknown) => {
             getLogger().debug({err: error_, toolName: name}, '[mcp] telemetry sendEventAndFlush failed');
@@ -103,6 +107,8 @@ export class B2CDxMcpServer extends McpServer {
             toolName: name,
             runTimeMs,
             isError: true,
+            errorMessage: error instanceof Error ? error.message : String(error),
+            ...(error instanceof Error && error.cause ? {errorCause: String(error.cause)} : {}),
           })
           .catch((error_: unknown) => {
             getLogger().debug({err: error_, toolName: name}, '[mcp] telemetry sendEventAndFlush failed');

--- a/packages/b2c-dx-mcp/test/server.test.ts
+++ b/packages/b2c-dx-mcp/test/server.test.ts
@@ -314,6 +314,7 @@ describe('B2CDxMcpServer', () => {
       expect(mockTelemetry.events[0].attributes.toolName).to.equal('test_tool');
       expect(mockTelemetry.events[0].attributes.isError).to.equal(false);
       expect(mockTelemetry.events[0].attributes.runTimeMs).to.be.a('number');
+      expect(mockTelemetry.events[0].attributes.errorMessage).to.be.undefined;
     });
 
     it('should send TOOL_CALLED event with isError=true when tool returns error', async () => {
@@ -327,6 +328,7 @@ describe('B2CDxMcpServer', () => {
       expect(mockTelemetry.events[0].name).to.equal('TOOL_CALLED');
       expect(mockTelemetry.events[0].attributes.toolName).to.equal('error_tool');
       expect(mockTelemetry.events[0].attributes.isError).to.equal(true);
+      expect(mockTelemetry.events[0].attributes.errorMessage).to.equal('error occurred');
     });
 
     it('should send TOOL_CALLED event with isError=true when tool throws', async () => {
@@ -345,6 +347,32 @@ describe('B2CDxMcpServer', () => {
       expect(mockTelemetry.events[0].name).to.equal('TOOL_CALLED');
       expect(mockTelemetry.events[0].attributes.toolName).to.equal('throwing_tool');
       expect(mockTelemetry.events[0].attributes.isError).to.equal(true);
+      expect(mockTelemetry.events[0].attributes.errorMessage).to.equal('Tool execution failed');
+    });
+
+    it('should send TOOL_CALLED event with errorCause when tool throws error with cause', async () => {
+      const server = createServerWithHandlerCapture();
+
+      const handlerWithCause = async (): Promise<{content: Array<{type: 'text'; text: string}>}> => {
+        const innerError = new Error('Inner error');
+        throw new Error('Tool execution failed', {cause: innerError});
+      };
+
+      server.addTool('throwing_tool_with_cause', 'Throwing tool with cause', {}, handlerWithCause);
+
+      try {
+        await capturedHandler!({}, {});
+        expect.fail('Should have thrown');
+      } catch {
+        // Expected
+      }
+
+      expect(mockTelemetry.events).to.have.lengthOf(1);
+      expect(mockTelemetry.events[0].name).to.equal('TOOL_CALLED');
+      expect(mockTelemetry.events[0].attributes.toolName).to.equal('throwing_tool_with_cause');
+      expect(mockTelemetry.events[0].attributes.isError).to.equal(true);
+      expect(mockTelemetry.events[0].attributes.errorMessage).to.equal('Tool execution failed');
+      expect(mockTelemetry.events[0].attributes.errorCause).to.include('Error: Inner error');
     });
 
     it('should measure runTimeMs accurately', async () => {

--- a/packages/b2c-tooling-sdk/src/cli/base-command.ts
+++ b/packages/b2c-tooling-sdk/src/cli/base-command.ts
@@ -41,6 +41,52 @@ export type Args<T extends typeof Command> = Interfaces.InferredArgs<T['args']>;
 const LOG_LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'silent'] as const;
 
 /**
+ * Stable error-code values passed to oclif's `this.error(msg, {code})` so that
+ * {@link classifyError} can categorize the resulting telemetry without parsing
+ * error messages.
+ *
+ * - `VALIDATION` — user/config input error (missing flag, bad value). Expected,
+ *   not a reliability defect.
+ * - `GUARDRAIL` — blocked by the user's own safety configuration. Working as
+ *   intended, not a failure of the tool.
+ */
+export const ERROR_CODE = {
+  VALIDATION: 'VALIDATION',
+  GUARDRAIL: 'GUARDRAIL',
+} as const;
+
+/** Telemetry category recorded on COMMAND_ERROR (see {@link classifyError}). */
+export type ErrorCategory = 'guardrail' | 'runtime' | 'validation';
+
+/** Base URL for the online documentation site. */
+const DOCS_BASE_URL = 'https://salesforcecommercecloud.github.io/b2c-developer-tooling';
+
+/** Configuration guide — how to point the CLI at an instance and authenticate. */
+const DOCS_CONFIGURATION_URL = `${DOCS_BASE_URL}/guide/configuration.html`;
+
+/**
+ * Classify a thrown command error for telemetry so analytics can exclude
+ * expected validation/guardrail errors from reliability (defect-rate) metrics.
+ *
+ * Resolution order:
+ * 1. An explicit oclif `code` of {@link ERROR_CODE.VALIDATION} / `GUARDRAIL`
+ *    (set at the throw site via `this.error(msg, {code})`).
+ * 2. Safety error class names thrown from HTTP/auth middleware that do not flow
+ *    through `this.error` (`SafetyBlockedError`, `SafetyConfirmationRequired`).
+ * 3. Everything else is a genuine `runtime` error (the reliability signal).
+ */
+export function classifyError(err: unknown): ErrorCategory {
+  const code = (err as {code?: unknown} | undefined)?.code;
+  if (code === ERROR_CODE.VALIDATION) return 'validation';
+  if (code === ERROR_CODE.GUARDRAIL) return 'guardrail';
+
+  const name = (err as {name?: unknown} | undefined)?.name;
+  if (name === 'SafetyBlockedError' || name === 'SafetyConfirmationRequired') return 'guardrail';
+
+  return 'runtime';
+}
+
+/**
  * Type for oclif pjson custom telemetry config.
  */
 interface TelemetryConfig {
@@ -423,6 +469,30 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
   }
 
   /**
+   * Build a suffix appended to "X is required" config errors.
+   *
+   * When NO config source contributed any values (no dw.json found, no env
+   * vars, no flags — the dominant cause of these errors in telemetry), the user
+   * is almost certainly unconfigured rather than missing one specific field, so
+   * we point them at the configuration guide. When a source DID load, we stay
+   * quiet: the existing message already lists the precise flag/env var to set.
+   *
+   * @returns A "\n\nSee: <url>" suffix, or '' when config is already partially present.
+   */
+  protected configDocsHint(): string {
+    // resolvedConfig may be unset if the error is thrown before loadConfiguration().
+    const sources = this.resolvedConfig?.sources;
+    if (sources && sources.length === 0) {
+      return t(
+        'base.configDocsHint',
+        '\n\nNo configuration was found. See the configuration guide to connect an instance: {{url}}',
+        {url: DOCS_CONFIGURATION_URL},
+      );
+    }
+    return '';
+  }
+
+  /**
    * Collects config sources from plugins via the `b2c:config-sources` hook.
    *
    * This method is called during command initialization, after flags are parsed
@@ -566,15 +636,17 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
   protected async catch(err: Error & {exitCode?: number}): Promise<never> {
     const exitCode = err.exitCode ?? 1;
     const duration = this.commandStartTime ? Date.now() - this.commandStartTime : undefined;
+    const errorCategory = classifyError(err);
 
     // Send exception and COMMAND_ERROR event so the error appears in custom events (same view as COMMAND_START)
     // Flush explicitly before stop to ensure events are sent before process exits
     if (this.telemetry) {
-      this.telemetry.sendException(err, {command: this.id, exitCode, duration});
+      this.telemetry.sendException(err, {command: this.id, errorCategory, exitCode, duration});
       this.telemetry.sendEvent('COMMAND_ERROR', {
         command: this.id,
         exitCode,
         duration,
+        errorCategory,
         errorMessage: err.message,
         ...(err.cause ? {errorCause: String(err.cause)} : {}),
       });
@@ -675,7 +747,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
           description: describeSafetyLevel(safetyLevel),
         },
       ),
-      {exit: 1},
+      {code: ERROR_CODE.GUARDRAIL, exit: 1},
     );
   }
 
@@ -776,7 +848,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     });
 
     if (evaluation.action === 'block' && evaluation.rule) {
-      this.error(evaluation.reason, {exit: 1});
+      this.error(evaluation.reason, {code: ERROR_CODE.GUARDRAIL, exit: 1});
     }
     if (evaluation.action === 'confirm' && evaluation.rule) {
       await this.confirmOrBlock(evaluation);
@@ -798,7 +870,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
         `Your safety configuration requires confirmation for this operation, ` +
           `but no interactive session is available.\n\n  ${evaluation.reason}\n\n` +
           `To change this, update the "safety" section in your dw.json or the SFCC_SAFETY_CONFIRM environment variable.`,
-        {exit: 1},
+        {code: ERROR_CODE.GUARDRAIL, exit: 1},
       );
     }
 
@@ -806,7 +878,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       `Your safety configuration requires confirmation for this operation:\n  ${evaluation.reason}\n  Proceed?`,
     );
     if (!confirmed) {
-      this.error('Operation cancelled.', {exit: 1});
+      this.error('Operation cancelled.', {code: ERROR_CODE.GUARDRAIL, exit: 1});
     }
   }
 

--- a/packages/b2c-tooling-sdk/src/cli/index.ts
+++ b/packages/b2c-tooling-sdk/src/cli/index.ts
@@ -91,8 +91,8 @@
  */
 
 // Base command classes
-export {BaseCommand} from './base-command.js';
-export type {Flags, Args} from './base-command.js';
+export {BaseCommand, ERROR_CODE, classifyError} from './base-command.js';
+export type {Flags, Args, ErrorCategory} from './base-command.js';
 export {OAuthCommand} from './oauth-command.js';
 export {InstanceCommand} from './instance-command.js';
 export {CartridgeCommand} from './cartridge-command.js';

--- a/packages/b2c-tooling-sdk/src/cli/instance-command.ts
+++ b/packages/b2c-tooling-sdk/src/cli/instance-command.ts
@@ -5,6 +5,7 @@
  */
 import {Command, Flags} from '@oclif/core';
 import {OAuthCommand} from './oauth-command.js';
+import {ERROR_CODE} from './base-command.js';
 import {loadConfig, extractInstanceFlags} from './config.js';
 import type {ResolvedB2CConfig} from '../config/index.js';
 import type {B2CInstance} from '../instance/index.js';
@@ -218,7 +219,11 @@ export abstract class InstanceCommand<T extends typeof Command> extends OAuthCom
    */
   protected requireServer(): void {
     if (!this.resolvedConfig.hasB2CInstanceConfig()) {
-      this.error(t('error.serverRequired', 'Server is required. Set via --server, SFCC_SERVER env var, or dw.json.'));
+      this.error(
+        t('error.serverRequired', 'Server is required. Set via --server, SFCC_SERVER env var, or dw.json.') +
+          this.configDocsHint(),
+        {code: ERROR_CODE.VALIDATION},
+      );
     }
   }
 
@@ -231,7 +236,8 @@ export abstract class InstanceCommand<T extends typeof Command> extends OAuthCom
         t(
           'error.codeVersionRequired',
           'Code version is required. Set via --code-version, SFCC_CODE_VERSION env var, or dw.json.',
-        ),
+        ) + this.configDocsHint(),
+        {code: ERROR_CODE.VALIDATION},
       );
     }
   }
@@ -245,7 +251,8 @@ export abstract class InstanceCommand<T extends typeof Command> extends OAuthCom
         t(
           'error.webdavCredentialsRequiredShort',
           'WebDAV credentials required. Provide --username/--password or --client-id/--client-secret, or set corresponding SFCC_* env vars.',
-        ),
+        ) + this.configDocsHint(),
+        {code: ERROR_CODE.VALIDATION},
       );
     }
   }

--- a/packages/b2c-tooling-sdk/src/cli/oauth-command.ts
+++ b/packages/b2c-tooling-sdk/src/cli/oauth-command.ts
@@ -4,7 +4,7 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 import {Command, Flags} from '@oclif/core';
-import {BaseCommand} from './base-command.js';
+import {BaseCommand, ERROR_CODE} from './base-command.js';
 import {loadConfig, extractOAuthFlags, ALL_AUTH_METHODS} from './config.js';
 import type {AuthMethod} from './config.js';
 import type {ResolvedB2CConfig} from '../config/index.js';
@@ -331,7 +331,9 @@ export abstract class OAuthCommand<T extends typeof Command> extends BaseCommand
   protected requireOAuthCredentials(): void {
     if (!this.hasOAuthCredentials()) {
       this.error(
-        t('error.oauthClientIdRequired', 'OAuth client ID required. Provide --client-id or set SFCC_CLIENT_ID.'),
+        t('error.oauthClientIdRequired', 'OAuth client ID required. Provide --client-id or set SFCC_CLIENT_ID.') +
+          this.configDocsHint(),
+        {code: ERROR_CODE.VALIDATION},
       );
     }
   }
@@ -348,7 +350,8 @@ export abstract class OAuthCommand<T extends typeof Command> extends BaseCommand
         t(
           'error.tenantIdRequired',
           'tenant-id is required. Provide via --tenant-id flag, SFCC_TENANT_ID env var, or tenant-id in dw.json.',
-        ),
+        ) + this.configDocsHint(),
+        {code: ERROR_CODE.VALIDATION},
       );
     }
     return normalizeTenantId(tenantId);

--- a/packages/b2c-tooling-sdk/src/telemetry/telemetry.ts
+++ b/packages/b2c-tooling-sdk/src/telemetry/telemetry.ts
@@ -14,6 +14,38 @@ import {getLogger, type Logger} from '../logging/index.js';
 const generateRandomId = (): string => randomBytes(20).toString('hex');
 
 /**
+ * Best-effort detection of a CI / non-interactive automation environment.
+ *
+ * Telemetry analysis showed a small number of automation installs can account
+ * for a large share of events, skewing blended KPIs (e.g. error rates). Tagging
+ * every event with `isCI` lets analytics separate human-developer traffic from
+ * CI without resorting to fragile cliId/IP heuristics after the fact.
+ *
+ * Recognizes the generic `CI` convention plus common provider-specific vars.
+ */
+function detectCI(): boolean {
+  const env = process.env;
+  // Generic convention honored by most CI providers (GitHub Actions, GitLab,
+  // CircleCI, Travis, etc.). `CI=false`/`CI=0`/empty explicitly opt out.
+  if (env.CI !== undefined && env.CI !== 'false' && env.CI !== '0' && env.CI !== '') {
+    return true;
+  }
+  return Boolean(
+    env.CONTINUOUS_INTEGRATION ||
+    env.BUILD_NUMBER ||
+    env.GITHUB_ACTIONS ||
+    env.GITLAB_CI ||
+    env.CIRCLECI ||
+    env.TRAVIS ||
+    env.JENKINS_URL ||
+    env.TEAMCITY_VERSION ||
+    env.TF_BUILD ||
+    env.BITBUCKET_BUILD_NUMBER ||
+    env.CODEBUILD_BUILD_ID,
+  );
+}
+
+/**
  * Sanitize attributes to only include string, number, boolean (App Insights–safe).
  * Aligns with sf CLI telemetry record() validation.
  */
@@ -123,6 +155,7 @@ export class Telemetry {
   private traceLog: Logger | undefined;
   private flushIntervalMs: number | undefined;
   private flushTimer: ReturnType<typeof setInterval> | undefined;
+  private isCI: boolean;
 
   /**
    * Check if telemetry is disabled via environment variables.
@@ -152,6 +185,7 @@ export class Telemetry {
     this.started = false;
     this.version = options.version ?? '0.0.0';
     this.flushIntervalMs = options.flushIntervalMs;
+    this.isCI = detectCI();
 
     if (process.env.SFCC_TELEMETRY_LOG === 'true') {
       this.traceLog = getLogger().child({component: 'telemetry'});
@@ -298,6 +332,7 @@ export class Telemetry {
       date: new Date().toUTCString(),
       timestamp: String(Date.now()),
       processUptime: process.uptime() * 1000,
+      isCI: this.isCI,
     };
   }
 

--- a/packages/b2c-tooling-sdk/src/telemetry/types.ts
+++ b/packages/b2c-tooling-sdk/src/telemetry/types.ts
@@ -37,6 +37,12 @@ export interface TelemetryEventProperties extends TelemetryAttributes {
   timestamp: string;
   /** Process uptime in milliseconds */
   processUptime: number;
+  /**
+   * Whether the event originated from a CI / automation environment.
+   * Allows analytics to separate human-developer traffic from CI runs, which
+   * can otherwise dominate volume and skew blended KPIs.
+   */
+  isCI: boolean;
 }
 
 /**

--- a/packages/b2c-tooling-sdk/test/cli/base-command.test.ts
+++ b/packages/b2c-tooling-sdk/test/cli/base-command.test.ts
@@ -6,7 +6,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import {Config} from '@oclif/core';
-import {BaseCommand} from '@salesforce/b2c-tooling-sdk/cli';
+import {BaseCommand, ERROR_CODE, classifyError} from '@salesforce/b2c-tooling-sdk/cli';
 import {globalMiddlewareRegistry} from '@salesforce/b2c-tooling-sdk/clients';
 import {Telemetry} from '@salesforce/b2c-tooling-sdk/telemetry';
 import {isolateConfig, restoreConfig} from '@salesforce/b2c-tooling-sdk/test-utils';
@@ -48,6 +48,10 @@ class TestBaseCommand extends BaseCommand<typeof TestBaseCommand> {
 
   public testAddTelemetryContext() {
     return this.addTelemetryContext();
+  }
+
+  public testConfigDocsHint() {
+    return this.configDocsHint();
   }
 }
 
@@ -462,7 +466,81 @@ describe('cli/base-command', () => {
           command: 'test:base',
           exitCode: 42,
           errorMessage: 'Test error',
+          // A plain Error has no classification code, so it is a genuine runtime error.
+          errorCategory: 'runtime',
         });
+      });
+
+      it('classifies a VALIDATION-coded error as a validation category in COMMAND_ERROR', async () => {
+        const telemetry = new Telemetry({project: 'test', appInsightsKey: 'test-key'});
+        (command as unknown as {telemetry: Telemetry}).telemetry = telemetry;
+
+        stubParse(command, {json: false});
+        await command.init();
+
+        sinon.stub(command, 'error').throws(new Error('Expected error'));
+
+        const error = new Error('tenant-id is required.') as Error & {code?: string; exitCode?: number};
+        error.code = ERROR_CODE.VALIDATION;
+        error.exitCode = 1;
+
+        try {
+          await command.testCatch(error);
+        } catch {
+          // Expected
+        }
+
+        const commandErrorCall = telemetrySendEventStub.getCalls().find((c) => c.args[0] === 'COMMAND_ERROR');
+        expect(commandErrorCall).to.not.be.undefined;
+        expect(commandErrorCall!.args[1]).to.include({errorCategory: 'validation'});
+      });
+    });
+
+    describe('classifyError()', () => {
+      it('returns "validation" for a VALIDATION-coded error', () => {
+        const err = Object.assign(new Error('x'), {code: ERROR_CODE.VALIDATION});
+        expect(classifyError(err)).to.equal('validation');
+      });
+
+      it('returns "guardrail" for a GUARDRAIL-coded error', () => {
+        const err = Object.assign(new Error('x'), {code: ERROR_CODE.GUARDRAIL});
+        expect(classifyError(err)).to.equal('guardrail');
+      });
+
+      it('returns "guardrail" for a SafetyBlockedError by name', () => {
+        const err = new Error('blocked');
+        err.name = 'SafetyBlockedError';
+        expect(classifyError(err)).to.equal('guardrail');
+      });
+
+      it('returns "runtime" for a plain error', () => {
+        expect(classifyError(new Error('boom'))).to.equal('runtime');
+      });
+
+      it('returns "runtime" for non-error values', () => {
+        expect(classifyError(undefined)).to.equal('runtime');
+        expect(classifyError('a string')).to.equal('runtime');
+      });
+    });
+
+    describe('configDocsHint()', () => {
+      it('returns a docs link when no config source loaded', () => {
+        command.setResolvedConfig({sources: []} as unknown as ReturnType<typeof command.getResolvedConfig>);
+        const hint = command.testConfigDocsHint();
+        expect(hint).to.include('configuration.html');
+        expect(hint).to.include('No configuration was found');
+      });
+
+      it('returns empty string when a config source contributed', () => {
+        command.setResolvedConfig({
+          sources: [{name: 'DwJsonSource'}],
+        } as unknown as ReturnType<typeof command.getResolvedConfig>);
+        expect(command.testConfigDocsHint()).to.equal('');
+      });
+
+      it('returns empty string when resolvedConfig is unset', () => {
+        command.setResolvedConfig(undefined as unknown as ReturnType<typeof command.getResolvedConfig>);
+        expect(command.testConfigDocsHint()).to.equal('');
       });
     });
 

--- a/packages/b2c-tooling-sdk/test/cli/oauth-command.test.ts
+++ b/packages/b2c-tooling-sdk/test/cli/oauth-command.test.ts
@@ -140,6 +140,9 @@ describe('cli/oauth-command', () => {
       }
 
       expect(errorStub.called).to.be.true;
+      // Classified as a validation error so analytics can exclude it from reliability metrics.
+      const opts = errorStub.firstCall.args[1] as {code?: string} | undefined;
+      expect(opts?.code).to.equal('VALIDATION');
     });
 
     it('does not throw when clientId is set', async () => {
@@ -210,6 +213,27 @@ describe('cli/oauth-command', () => {
       }
 
       expect(errorStub.called).to.be.true;
+      const opts = errorStub.firstCall.args[1] as {code?: string} | undefined;
+      expect(opts?.code).to.equal('VALIDATION');
+    });
+
+    it('appends a docs-link hint when no config source contributed', async () => {
+      // With no flags/env/dw.json, no config source loads — point the user at the guide.
+      stubParse(command);
+      await command.init();
+
+      const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
+
+      try {
+        command.testRequireTenantId();
+      } catch {
+        // Expected
+      }
+
+      const message = errorStub.firstCall.args[0] as string;
+      expect(message).to.include('tenant-id is required');
+      expect(message).to.include('No configuration was found');
+      expect(message).to.include('guide/configuration.html');
     });
   });
 

--- a/packages/b2c-tooling-sdk/test/telemetry/telemetry.test.ts
+++ b/packages/b2c-tooling-sdk/test/telemetry/telemetry.test.ts
@@ -307,7 +307,71 @@ describe('telemetry/telemetry', () => {
       expect(properties.cliId).to.be.a('string');
       expect(properties.date).to.be.a('string');
       expect(properties.timestamp).to.be.a('string');
+      expect(properties.isCI).to.be.oneOf(['true', 'false']);
       expect(measurements.processUptime).to.be.a('number');
+    });
+
+    describe('isCI envelope tag', () => {
+      const CI_VARS = [
+        'CI',
+        'CONTINUOUS_INTEGRATION',
+        'BUILD_NUMBER',
+        'GITHUB_ACTIONS',
+        'GITLAB_CI',
+        'CIRCLECI',
+        'TRAVIS',
+        'JENKINS_URL',
+        'TEAMCITY_VERSION',
+        'TF_BUILD',
+        'BITBUCKET_BUILD_NUMBER',
+        'CODEBUILD_BUILD_ID',
+      ];
+      let saved: Record<string, string | undefined>;
+
+      beforeEach(() => {
+        saved = {};
+        for (const v of CI_VARS) {
+          saved[v] = process.env[v];
+          delete process.env[v];
+        }
+      });
+
+      afterEach(() => {
+        for (const v of CI_VARS) {
+          if (saved[v] === undefined) delete process.env[v];
+          else process.env[v] = saved[v];
+        }
+      });
+
+      async function isCIForEvent(): Promise<string> {
+        const telemetry = new Telemetry({
+          project: 'test-project',
+          appInsightsKey: 'InstrumentationKey=00000000-0000-0000-0000-000000000000',
+        });
+        await telemetry.start();
+        telemetry.sendEvent('TEST_EVENT');
+        const {properties} = trackEventStub.lastCall.args[0];
+        return properties.isCI as string;
+      }
+
+      it('is "false" when no CI env vars are present', async () => {
+        expect(await isCIForEvent()).to.equal('false');
+      });
+
+      it('is "true" when CI=true', async () => {
+        process.env.CI = 'true';
+        expect(await isCIForEvent()).to.equal('true');
+      });
+
+      it('is "false" when CI=false (explicit opt-out)', async () => {
+        process.env.CI = 'false';
+        expect(await isCIForEvent()).to.equal('false');
+      });
+
+      it('is "true" when a provider-specific var is present (GITHUB_ACTIONS)', async () => {
+        process.env.GITHUB_ACTIONS = 'true';
+        expect(await isCIForEvent()).to.equal('true');
+      });
     });
 
     it('includes initial attributes in events', async () => {

--- a/packages/b2c-vs-extension/src/extension.ts
+++ b/packages/b2c-vs-extension/src/extension.ts
@@ -91,7 +91,11 @@ export async function activate(context: vscode.ExtensionContext) {
     if (stack) log.appendLine(stack);
     console.error('B2C DX extension activation failed:', err);
     if (err instanceof Error) sendException(err, {phase: 'activate'});
-    sendEvent('ACTIVATION_FAILED');
+    sendEvent('ACTIVATION_FAILED', {
+      phase: 'activate',
+      errorMessage: message,
+      ...(err instanceof Error && err.cause ? {errorCause: String(err.cause)} : {}),
+    });
     vscode.window.showErrorMessage(`B2C DX: Extension failed to activate. See Output > B2C DX. Error: ${message}`);
     const showActivationError = () => {
       log.show();


### PR DESCRIPTION
## Summary

Telemetry improvements driven by analysis of a production snapshot (~60k events across the CLI, MCP server, and VS Code extension). Three independent changes, all additive and best-effort (telemetry never affects command behavior):

### 1. Surface failure detail on MCP + VS Code errors
MCP tool-call failures (`TOOL_CALLED` with `isError`) and VS Code extension activation failures (`ACTIVATION_FAILED`) were emitting **empty error messages** — every one of them — which made server-side and extension failures impossible to root-cause. Both now record `errorMessage` (and `errorCause` when present), matching the CLI's existing `COMMAND_ERROR` convention.

### 2. Docs-link hint when no config source is present
When a command requires instance/auth configuration but **no source is found at all** (no flags, env vars, or dw.json — the dominant cause of "X is required" errors), the error now points to the [configuration guide](https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/configuration.html). When a config source is partially present, the existing message (which lists the specific flag/env var) is unchanged.

### 3. Error classification + CI tagging for reliability KPIs
- `COMMAND_ERROR` events now carry an `errorCategory` (`validation` / `guardrail` / `runtime`).
- All telemetry events now carry an `isCI` flag.

Together these let analytics separate expected user/config errors and CI traffic from genuine runtime failures when measuring reliability.

## Notes
- The OAuth `EADDRINUSE` port error was reviewed; it already names the `SFCC_OAUTH_LOCAL_PORT` override env var, so no change was needed there.
- Changesets included for `@salesforce/b2c-tooling-sdk`, `@salesforce/b2c-cli`, `@salesforce/b2c-dx-mcp`, and `b2c-vs-extension`.