### PR TITLE
docs(debug): trim Script Debugger guide of implementation detail

### DIFF
--- a/.changeset/trim-script-debugger-guide.md
+++ b/.changeset/trim-script-debugger-guide.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-dx-docs': patch
+---
+
+Trim the Script Debugger guide to remove implementation detail (internal API name, `client_id`, transport plumbing, roadmap note) and a duplicated interface list, keeping it focused on what users need to debug.

--- a/docs/guide/script-debugger.md
+++ b/docs/guide/script-debugger.md
@@ -4,44 +4,28 @@ description: Debug server-side B2C Commerce scripts (controllers, hooks, jobs, c
 
 # Script Debugger
 
-The B2C Commerce **Script Debugger** lets you set breakpoints, step through code, and inspect variables in server-side scripts — SFRA controllers, hooks, jobs, custom SCAPI endpoints, or any `dw/*` cartridge code — running live on an instance. The tooling connects to the instance's Script Debugger API (SDAPI) and surfaces it several ways:
-
-- **VS Code (recommended)** — the [B2C DX VS Code Extension](/vscode-extension/#b2c-script-debugger) provides the full graphical debugger: breakpoints, log points, watch expressions, and step controls, just like any other Node project. This is the primary interface for interactive debugging.
-- **Other IDEs (JetBrains, etc.)** via the [Debug Adapter Protocol (DAP)](https://microsoft.github.io/debug-adapter-protocol/) adapter — `b2c debug`.
-- **AI-agent debugging** via the [MCP diagnostics tools](/mcp/tools/diagnostics) — `debug_start_session`, `debug_set_breakpoints`, etc.
-
-The CLI's DAP debug adapter (`b2c debug`) also offers a headless terminal mode for scripting; see [Debug Commands](/cli/debug) for details.
+The B2C Commerce **Script Debugger** lets you set breakpoints, step through code, and inspect variables in server-side scripts — SFRA controllers, hooks, jobs, custom SCAPI endpoints, or any `dw/*` cartridge code — running live on an instance. You can drive it from the VS Code extension, another IDE, the CLI, or an AI agent.
 
 ## Requirements
 
 The debugger needs two things:
 
 1. **The Script Debugger enabled on the instance.** In Business Manager: **Administration → Development Configuration → Script Debugger → Enable**.
-2. **Basic auth credentials** — a Business Manager username and a WebDAV / UX Studio access key (used as the password). OAuth/client credentials are **not** sufficient for the SDAPI.
+2. **Basic auth credentials** — a Business Manager username and a WebDAV access key (used as the password). OAuth/client credentials are **not** sufficient.
 
-> The access key is the same kind of WebDAV access key used by UX Studio and other code-upload tooling. Generate one in Business Manager under your account's access keys. See the [Authentication Guide](/guide/authentication#webdav-access) for details.
-
-Only one debug client per `client_id` may be attached to a host at a time. Starting a new session with the same `client_id` takes over (replaces) any prior one — a useful safety net for orphaned sessions.
-
-## Configuration
-
-The debugger reads the same resolved configuration as the rest of the CLI. Provide the hostname and Basic auth credentials via any of (highest priority first):
-
-- Flags — `--username` / `--password` (and the active instance for the hostname)
-- Environment variables — `SFCC_SERVER`, `SFCC_USERNAME`, `SFCC_PASSWORD`
-- `dw.json` — `hostname`, `username`, `password` fields
-
-See [CLI Configuration](/guide/configuration) for the full resolution order and multi-instance setup.
+The debugger uses the same resolved credentials as the rest of the CLI (flags, `SFCC_*` environment variables, or `dw.json`). See the [Authentication Guide](/guide/authentication#webdav-access) for access key setup and [CLI Configuration](/guide/configuration) for how credentials are resolved.
 
 ## Choosing an interface
 
-| Use case                           | Interface                                  | Reference                                                   |
-| ---------------------------------- | ------------------------------------------ | ----------------------------------------------------------- |
-| Debug from VS Code (recommended)   | B2C DX VS Code Extension                   | [VS Code Extension](/vscode-extension/#b2c-script-debugger) |
-| Debug from another IDE (JetBrains) | `b2c debug` (DAP debug adapter over stdio) | [Debug Commands](/cli/debug#b2c-debug)                      |
-| Let an AI agent drive the debugger | MCP diagnostics tools                      | [Diagnostics Tools](/mcp/tools/diagnostics)                 |
+| Use case                           | Interface                       | Reference                                                   |
+| ---------------------------------- | ------------------------------- | ----------------------------------------------------------- |
+| Debug from VS Code (recommended)   | B2C DX VS Code Extension        | [VS Code Extension](/vscode-extension/#b2c-script-debugger) |
+| Debug from another IDE (JetBrains) | `b2c debug` (DAP debug adapter) | [Debug Commands](/cli/debug#b2c-debug)                      |
+| Let an AI agent drive the debugger | MCP diagnostics tools           | [Diagnostics Tools](/mcp/tools/diagnostics)                 |
 
-They all share the same underlying workflow: connect a session, set breakpoints (by local file path, cartridge-prefixed path, or server path), trigger the code on the instance, then inspect the halted thread.
+The **VS Code extension is the recommended interface** for interactive debugging — it provides the full graphical debugger (breakpoints, log points, watch expressions, step controls), just like any other Node project. The CLI's DAP debug adapter (`b2c debug`) also offers a headless terminal mode for scripting; see [Debug Commands](/cli/debug) for details.
+
+They all share the same workflow: connect a session, set breakpoints (by local file path, cartridge-prefixed path, or server path), trigger the code on the instance, then inspect the halted thread.
 
 ## Server affinity (hitting breakpoints)
 
@@ -49,13 +33,13 @@ A breakpoint only fires when the code runs on the **same application server** th
 
 > **Sandboxes (ODS) are single-app-server and are not affected.** This only matters on certain multi-app-server PIG environments.
 
-To pin a triggering request to the correct app server, route it with the debugger's session cookie (`dwsid`). The CLI and SDK manage this cookie automatically for the debugger's own requests — so the way you obtain the value depends on the interface:
+To pin a triggering request to the correct app server, send it with the debugger's session cookie (`dwsid`). How you obtain the value depends on the interface:
 
-- **MCP:** `debug_start_session` and `debug_list_sessions` return a `session_cookie` (`{name, value}`). This is the most direct source. See [Diagnostics Tools → Server affinity](/mcp/tools/diagnostics#server-affinity-hitting-breakpoints).
+- **MCP:** `debug_start_session` and `debug_list_sessions` return a `session_cookie` (`{name, value}`). See [Diagnostics Tools → Server affinity](/mcp/tools/diagnostics#server-affinity-hitting-breakpoints).
 - **VS Code:** the cookie is logged to the **B2C DX** output channel when the session connects, and the **Copy Debugger Session ID (dwsid)** command copies it to your clipboard.
-- **CLI:** the cookie is logged at info level when the session connects (`Debug session cookie: dwsid=…`).
+- **CLI:** the cookie is logged when the session connects (`Debug session cookie: dwsid=…`).
 
-Once you have the value, send the request that triggers your code — a browser session, `curl`, an integration test — with that cookie:
+Send the request that triggers your code — a browser session, `curl`, an integration test — with that cookie:
 
 ```
 Cookie: dwsid=<value>
@@ -69,12 +53,10 @@ sfdc_dwsid: <value>
 
 If you cannot set the cookie or header on the triggering request, you may need to retry until the load balancer happens to route to the attached app server.
 
-> A future enhancement will let the VS Code extension launch a browser pre-seeded with the debug session's cookie, removing this manual step.
-
 ## See Also
 
 - [VS Code Extension](/vscode-extension/#b2c-script-debugger) — the recommended graphical debugger
-- [Debug Commands](/cli/debug) — `b2c debug` DAP debug adapter reference
+- [Debug Commands](/cli/debug) — `b2c debug` DAP debug adapter and `b2c debug cli` reference
 - [Diagnostics Tools](/mcp/tools/diagnostics) — MCP tools for agent-driven debugging
 - [Authentication Setup](/guide/authentication) — WebDAV access key configuration
 - [IDE Integration](/guide/ide-integration) — connecting other IDEs to your CLI configuration


### PR DESCRIPTION
## What

Trims the Script Debugger guide (`docs/guide/script-debugger.md`) to focus on what a reader needs, removing implementation detail that leaked through.

## Changes

- **Removed `client_id` mechanics** — the "one client per `client_id`" SDAPI detail is internal; it stays in the MCP diagnostics page where orphaned-session recovery is discussed.
- **Dropped the internal API name (SDAPI)** — the product is the "Script Debugger"; readers don't need the API acronym.
- **Removed "over stdio"** transport plumbing from the JetBrains row.
- **Removed the roadmap note** about a future browser-launch feature (tracked separately; roadmap promises age badly in docs).
- **Folded the generic Configuration section into Requirements** — it was standard CLI credential resolution already covered by the linked guides.
- **Dropped the duplicate interface list** in the intro — the "Choosing an interface" table already covers it.
- Reframed the affinity intro around the user's triggering request rather than how our client manages its own cookie.

Net: ~1/3 shorter, no loss of anything a reader needs. The `sfdc_dwsid` headless guidance, the server-affinity explanation, and all interface references are retained.

## Verification

- prettier clean
- `docs:build` reports 0 errors (all cross-reference anchors resolve)

Doc-only changeset (`@salesforce/b2c-dx-docs: patch`).