### PR TITLE
fix(ci): include changelog in agent-plugins release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -477,6 +477,8 @@ jobs:
           {
             echo "Agent skills plugin artifacts for b2c-agent-plugins v${PLUGINS_VERSION}. Download the \`*-skills.zip\` files below."
             echo ""
+            echo "See the [Agent Skills & Plugins guide](https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/agent-skills.html) for installation and usage."
+            echo ""
             if [ -n "$PLUGINS_CHANGELOG" ]; then
               echo "### Changelog"
               echo ""

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -462,15 +462,42 @@ jobs:
       - name: Upload skills to release
         if: steps.release-type.outputs.type == 'stable' && steps.changesets.outputs.skip != 'true' && steps.quick-check.outputs.skip != 'true' && steps.packages.outputs.publish_plugins == 'true'
         run: |
-          RELEASE_TAG="b2c-agent-plugins@${{ steps.packages.outputs.version_plugins }}"
+          RELEASE_TAG="b2c-agent-plugins@${PLUGINS_VERSION}"
 
-          gh release create "$RELEASE_TAG" \
-            --title "Agent Plugins ${{ steps.packages.outputs.version_plugins }}" \
-            --notes "Skills artifacts for b2c-agent-plugins v${{ steps.packages.outputs.version_plugins }}"
+          # Extract this version's changelog section for the dedicated release
+          extract_latest() {
+            awk '
+              /^## / { if (found) exit; found=1; next }
+              found { print }
+            ' "$1"
+          }
 
-          gh release upload "$RELEASE_TAG" ${{ steps.package-skills.outputs.zips }}
+          PLUGINS_CHANGELOG=$(extract_latest skills/CHANGELOG.md)
+
+          {
+            echo "Agent skills plugin artifacts for b2c-agent-plugins v${PLUGINS_VERSION}. Download the \`*-skills.zip\` files below."
+            echo ""
+            if [ -n "$PLUGINS_CHANGELOG" ]; then
+              echo "### Changelog"
+              echo ""
+              echo "$PLUGINS_CHANGELOG"
+            fi
+          } > /tmp/plugins-release-notes.md
+
+          # Idempotent on re-runs: reuse an existing release rather than failing
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists, uploading artifacts to it"
+          else
+            gh release create "$RELEASE_TAG" \
+              --title "Agent Plugins ${PLUGINS_VERSION}" \
+              --latest=false \
+              --notes-file /tmp/plugins-release-notes.md
+          fi
+
+          gh release upload "$RELEASE_TAG" ${{ steps.package-skills.outputs.zips }} --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PLUGINS_VERSION: ${{ steps.packages.outputs.version_plugins }}
 
       - name: Create VS Code extension release
         if: >-


### PR DESCRIPTION
## Problem

The dedicated GitHub release for agent plugins ships with no real notes — see [`b2c-agent-plugins@1.4.3`](https://github.com/SalesforceCommerceCloud/b2c-developer-tooling/releases/tag/b2c-agent-plugins%401.4.3). The "Upload skills to release" step in `publish.yml` used a static `--notes "Skills artifacts for b2c-agent-plugins v..."` string and never read `skills/CHANGELOG.md`.

This is inconsistent with the VS Code extension release step, which extracts its changelog (`extract_latest packages/b2c-vs-extension/CHANGELOG.md`) and uses `--notes-file`. The plugins changelog content already exists and is even extracted into the *main* combined release notes — it just was never wired into the plugins release itself.

## Fix

- Extract the current version's section from `skills/CHANGELOG.md` (same `extract_latest` awk helper used elsewhere) and pass it via `--notes-file`, with a short artifacts header.
- Make the release create idempotent on re-runs (reuse an existing release instead of failing) and `--clobber` re-uploaded artifacts — mirroring the VS Code extension step.
- Pass the version through `env:` rather than inlining the `${{ }}` expression in the shell script (workflow-injection hardening).

## Already done out-of-band

Backfilled the existing public `b2c-agent-plugins@1.4.3` release notes with its changelog so it's no longer blank. This PR ensures every future plugins release gets notes automatically.

## Verification

- `publish.yml` passes YAML validation.
- Notes generation verified locally against `skills/CHANGELOG.md` (produces the 1.4.3 changelog section).

No changeset — workflow-only change, consistent with prior `ci:`/`fix(ci):` commits.