### PR TITLE
@W-23178876 fix(actions): preserve credentials containing $ in setup action env vars

### DIFF
--- a/.changeset/setup-action-credential-dollar-expansion.md
+++ b/.changeset/setup-action-credential-dollar-expansion.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-dx-docs': patch
+---
+
+Fix the `setup` GitHub Action silently corrupting any credential that contains a `$` (for example an auto-generated WebDAV access key like `abc$FOO123`). The action wrote credentials to the job environment with an inline-interpolated `echo`, so bash re-expanded `$WORD` sequences and stripped them — the altered credential then failed downstream WebDAV auth with an unexplained 401. Credentials are now passed through the step's `env` block and written with GitHub's heredoc env syntax, so values containing `$`, quotes, backticks, `$(...)`, `=`, or even newlines reach the CLI byte-for-byte. No workflow changes are required; re-run with the fixed action version.

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -45,6 +45,65 @@ jobs:
           [ "$NO_COLOR" = "1" ] || (echo "NO_COLOR not set" && exit 1)
           echo "All environment variables verified"
 
+  # Regression test for W-23178876: credentials containing shell-significant
+  # sequences ($WORD, $$, $(...), backticks, quotes) must reach $GITHUB_ENV
+  # byte-for-byte. The old `echo "VAR=${{ inputs.* }}"` pattern let bash re-expand
+  # those sequences, silently corrupting credentials (e.g. a WebDAV access key
+  # with `$`) and surfacing later as an unexplained 401.
+  setup-special-char-credentials:
+    name: 'Setup (credentials with $ / special chars)'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run setup action with shell-significant credentials
+        uses: ./actions/setup
+        with:
+          # All single-quoted YAML scalars → passed to the action verbatim.
+          # short-code and tenant-id are included so the renamed-input mapping
+          # (short-code → SFCC_SHORTCODE) is exercised, not just same-name inputs.
+          client-id: 'client$ID123'
+          client-secret: 'sec$(echo INJECTED)ret'
+          username: 'user$HOME_name'
+          password: 'pa$$key$FOO123$end'
+          certificate-passphrase: 'pass`id`phrase'
+          short-code: 'short$CODE_xyz'
+          tenant-id: 'bbsv_$PRD123'
+
+      - name: Verify credentials round-tripped intact
+        # Expected values are injected through this step's env block (literal, not
+        # shell-evaluated), so the assertions themselves are immune to the very
+        # expansion bug they guard against. Each EXPECTED_* must match the `with:`
+        # value above exactly.
+        env:
+          EXPECTED_CLIENT_ID: 'client$ID123'
+          EXPECTED_CLIENT_SECRET: 'sec$(echo INJECTED)ret'
+          EXPECTED_USERNAME: 'user$HOME_name'
+          EXPECTED_PASSWORD: 'pa$$key$FOO123$end'
+          EXPECTED_CERTIFICATE_PASSPHRASE: 'pass`id`phrase'
+          EXPECTED_SHORTCODE: 'short$CODE_xyz'
+          EXPECTED_TENANT_ID: 'bbsv_$PRD123'
+        run: |
+          fail=0
+          check() {
+            # $1 = env var name, $2 = actual value, $3 = expected value
+            if [ "$2" != "$3" ]; then
+              printf 'MISMATCH %s: got [%s] expected [%s]\n' "$1" "$2" "$3"
+              fail=1
+            else
+              printf 'OK %s\n' "$1"
+            fi
+          }
+          check SFCC_CLIENT_ID "$SFCC_CLIENT_ID" "$EXPECTED_CLIENT_ID"
+          check SFCC_CLIENT_SECRET "$SFCC_CLIENT_SECRET" "$EXPECTED_CLIENT_SECRET"
+          check SFCC_USERNAME "$SFCC_USERNAME" "$EXPECTED_USERNAME"
+          check SFCC_PASSWORD "$SFCC_PASSWORD" "$EXPECTED_PASSWORD"
+          check SFCC_CERTIFICATE_PASSPHRASE "$SFCC_CERTIFICATE_PASSPHRASE" "$EXPECTED_CERTIFICATE_PASSPHRASE"
+          check SFCC_SHORTCODE "$SFCC_SHORTCODE" "$EXPECTED_SHORTCODE"
+          check SFCC_TENANT_ID "$SFCC_TENANT_ID" "$EXPECTED_TENANT_ID"
+          [ "$fail" -eq 0 ] || { echo "Credential corruption detected"; exit 1; }
+          echo "All credentials preserved verbatim"
+
   setup-nightly:
     name: 'Setup (nightly)'
     runs-on: ubuntu-latest

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -118,65 +118,85 @@ runs:
 
     - name: Set environment variables
       shell: bash
+      # Inputs are forwarded through this step's env block — NOT interpolated
+      # directly into the script body below. GitHub injects env values into the
+      # process verbatim, so a credential is never re-parsed by the shell. If we
+      # inlined `${{ inputs.password }}` into a double-quoted `echo`, the runner
+      # would expand the expression into the literal credential text first, then
+      # bash would perform its OWN expansion on that text: any `$WORD` (e.g. in a
+      # WebDAV access key like `abc$FOO123`) would be stripped to empty, silently
+      # corrupting the credential and surfacing later as an unexplained 401. The
+      # same inlining would also let metacharacters (`"`, backtick, `$(...)`) run
+      # as code. Routing through env + a heredoc write avoids both. (W-23178876)
+      env:
+        IN_CLIENT_ID: ${{ inputs.client-id }}
+        IN_CLIENT_SECRET: ${{ inputs.client-secret }}
+        IN_SERVER: ${{ inputs.server }}
+        IN_CODE_VERSION: ${{ inputs.code-version }}
+        IN_USERNAME: ${{ inputs.username }}
+        IN_PASSWORD: ${{ inputs.password }}
+        IN_SHORT_CODE: ${{ inputs.short-code }}
+        IN_TENANT_ID: ${{ inputs.tenant-id }}
+        IN_MRT_API_KEY: ${{ inputs.mrt-api-key }}
+        IN_MRT_PROJECT: ${{ inputs.mrt-project }}
+        IN_MRT_ENVIRONMENT: ${{ inputs.mrt-environment }}
+        IN_ACCOUNT_MANAGER_HOST: ${{ inputs.account-manager-host }}
+        IN_WEBDAV_SERVER: ${{ inputs.webdav-server }}
+        IN_CERTIFICATE: ${{ inputs.certificate }}
+        IN_CERTIFICATE_PASSPHRASE: ${{ inputs.certificate-passphrase }}
+        IN_SELFSIGNED: ${{ inputs.selfsigned }}
+        IN_LOG_LEVEL: ${{ inputs.log-level }}
       run: |
         # CI defaults
         echo "NO_COLOR=1" >> "$GITHUB_ENV"
 
+        # A random delimiter for the heredoc form below. Generated per-run so a
+        # credential value can never accidentally contain (and thus prematurely
+        # close) the delimiter line.
+        ENV_DELIMITER="__B2C_ENV_$(openssl rand -hex 16 2>/dev/null || date +%s%N)__"
+
+        # Append a value to $GITHUB_ENV, but only when it is non-empty. Uses
+        # GitHub's documented multiline heredoc syntax (NAME<<DELIM ... DELIM) —
+        # the same mechanism @actions/core uses. The value is emitted via printf
+        # as an ARGUMENT (never spliced into the format string or script text), so
+        # it is written byte-for-byte: `$`, `%`, quotes, backticks AND embedded
+        # newlines or `=` are all preserved literally, with no shell, printf, or
+        # $GITHUB_ENV-format reinterpretation.
+        set_env() {
+          # $1 = target env var name, $2 = value
+          if [ -n "$2" ]; then
+            {
+              printf '%s<<%s\n' "$1" "$ENV_DELIMITER"
+              printf '%s\n' "$2"
+              printf '%s\n' "$ENV_DELIMITER"
+            } >> "$GITHUB_ENV"
+          fi
+        }
+
         # Auth and config — only set if provided
-        if [ -n "${{ inputs.client-id }}" ]; then
-          echo "SFCC_CLIENT_ID=${{ inputs.client-id }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.client-secret }}" ]; then
-          echo "SFCC_CLIENT_SECRET=${{ inputs.client-secret }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.server }}" ]; then
-          echo "SFCC_SERVER=${{ inputs.server }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.code-version }}" ]; then
-          echo "SFCC_CODE_VERSION=${{ inputs.code-version }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.username }}" ]; then
-          echo "SFCC_USERNAME=${{ inputs.username }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.password }}" ]; then
-          echo "SFCC_PASSWORD=${{ inputs.password }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.short-code }}" ]; then
-          echo "SFCC_SHORTCODE=${{ inputs.short-code }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.tenant-id }}" ]; then
-          echo "SFCC_TENANT_ID=${{ inputs.tenant-id }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.mrt-api-key }}" ]; then
-          echo "MRT_API_KEY=${{ inputs.mrt-api-key }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.mrt-project }}" ]; then
-          echo "MRT_PROJECT=${{ inputs.mrt-project }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.mrt-environment }}" ]; then
-          echo "MRT_ENVIRONMENT=${{ inputs.mrt-environment }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.account-manager-host }}" ]; then
-          echo "SFCC_ACCOUNT_MANAGER_HOST=${{ inputs.account-manager-host }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.webdav-server }}" ]; then
-          echo "SFCC_WEBDAV_SERVER=${{ inputs.webdav-server }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.certificate }}" ]; then
-          echo "SFCC_CERTIFICATE=${{ inputs.certificate }}" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.certificate-passphrase }}" ]; then
-          echo "SFCC_CERTIFICATE_PASSPHRASE=${{ inputs.certificate-passphrase }}" >> "$GITHUB_ENV"
-        fi
+        set_env SFCC_CLIENT_ID "$IN_CLIENT_ID"
+        set_env SFCC_CLIENT_SECRET "$IN_CLIENT_SECRET"
+        set_env SFCC_SERVER "$IN_SERVER"
+        set_env SFCC_CODE_VERSION "$IN_CODE_VERSION"
+        set_env SFCC_USERNAME "$IN_USERNAME"
+        set_env SFCC_PASSWORD "$IN_PASSWORD"
+        set_env SFCC_SHORTCODE "$IN_SHORT_CODE"
+        set_env SFCC_TENANT_ID "$IN_TENANT_ID"
+        set_env MRT_API_KEY "$IN_MRT_API_KEY"
+        set_env MRT_PROJECT "$IN_MRT_PROJECT"
+        set_env MRT_ENVIRONMENT "$IN_MRT_ENVIRONMENT"
+        set_env SFCC_ACCOUNT_MANAGER_HOST "$IN_ACCOUNT_MANAGER_HOST"
+        set_env SFCC_WEBDAV_SERVER "$IN_WEBDAV_SERVER"
+        set_env SFCC_CERTIFICATE "$IN_CERTIFICATE"
+        set_env SFCC_CERTIFICATE_PASSPHRASE "$IN_CERTIFICATE_PASSPHRASE"
+        set_env SFCC_LOG_LEVEL "$IN_LOG_LEVEL"
+
         # Only export SFCC_SELFSIGNED when explicitly truthy. The SDK's env-var
         # source treats only "true"/"1" as enabling self-signed mode, but oclif
         # boolean flags map any non-empty env value to true. Skipping export for
         # other values avoids that asymmetry — leaving the flag at its default.
-        if [ "${{ inputs.selfsigned }}" = "true" ] || [ "${{ inputs.selfsigned }}" = "1" ]; then
+        if [ "$IN_SELFSIGNED" = "true" ] || [ "$IN_SELFSIGNED" = "1" ]; then
           echo "SFCC_SELFSIGNED=true" >> "$GITHUB_ENV"
-        fi
-        if [ -n "${{ inputs.log-level }}" ]; then
-          echo "SFCC_LOG_LEVEL=${{ inputs.log-level }}" >> "$GITHUB_ENV"
         fi
 
     - name: Install plugins


### PR DESCRIPTION
## What

The `setup` GitHub Action's **Set environment variables** step wrote every credential to `$GITHUB_ENV` with an inline-interpolated `echo`:

```bash
echo "SFCC_PASSWORD=${{ inputs.password }}" >> "$GITHUB_ENV"
```

GitHub substitutes `${{ inputs.* }}` into the **script text** before bash runs, so bash then performs its *own* `$`-expansion on the resulting double-quoted string. Any `$WORD` / `$$` / `$(...)` in the credential is stripped or mangled — silently corrupting credentials that contain `$` (e.g. auto-generated **WebDAV access keys** like `abc$FOO123`). The failure surfaced downstream as an unexplained **401 Unauthorized** on the WebDAV `PUT` in `actions/code-deploy`, with no indication the credential had been altered. The `[ -n "${{ inputs.* }}" ]` guards had the same flaw plus a shell-injection vector.

Reproduced locally: `pa$$key$FOO123$end` → `pa92899key`.

## How

- **`actions/setup/action.yml`** — all 17 inputs now flow through the step's `env:` block (`IN_*`), which GitHub injects verbatim and the shell never re-parses. A `set_env()` helper writes each non-empty value using GitHub's documented **heredoc env syntax** (`NAME<<DELIM … DELIM`, per-run random delimiter — the same mechanism `@actions/core` uses), emitting the value via `printf` as an *argument*. Values containing `$`, `%`, quotes, backticks, `$(...)`, `=`, and even embedded newlines are preserved byte-for-byte. `selfsigned` keeps its `true`/`1` guard; `NO_COLOR=1` is unchanged.
- **`.github/workflows/test-actions.yml`** — new `setup-special-char-credentials` regression job that round-trips `$`-bearing credentials (including a *renamed* input, `short-code` → `SFCC_SHORTCODE`, and `tenant-id`) and asserts byte-for-byte preservation. Expected values are injected via `env:`, so the test itself is immune to the bug it guards.
- **Changeset** targets `@salesforce/b2c-dx-docs` (established precedent for actions-only changes; the `actions/` tree releases via git tag, not npm).

## Verification

- Full `set_env` loop simulated end-to-end from the action body: every credential round-trips; empty/unprovided inputs are skipped.
- `printf`-trap stress test (`%s%d%n`, `-n`, `--password`, `a=b=c`, newlines) — all literal.
- `pnpm run typecheck:agent` passes across all packages (TypeScript untouched).
- Adversarial review (4 independent lenses: shell-semantics, completeness, test-validity, behavior-parity) — all `fix_correct`, 0 blockers/majors.

## Test plan

- The new `setup-special-char-credentials` CI job exercises the `$`-credential path automatically; it fails against the old code and passes against the fix.

Closes #531

@W-23178876
