### PR TITLE
fix(actions): forward full auth/config inputs to high-level actions; clear Node 20 warning

### DIFF
--- a/.changeset/actions-forward-auth-inputs.md
+++ b/.changeset/actions-forward-auth-inputs.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-dx-docs': patch
+---
+
+GitHub Actions: the high-level actions (`code-deploy`, `data-import`, `job-run`, `webdav-upload`) and the root action now forward the full set of auth/config inputs to `setup` — `account-manager-host`, `short-code`, `tenant-id`, `certificate`, `certificate-passphrase`, `selfsigned`, and `webdav-server` (where applicable). Previously these were silently dropped with an "Unexpected input(s)" warning, so a non-default Account Manager host or staging mTLS credentials had to be set via env vars or a separate `setup` step. Also bumped the bundled `setup-node`/`checkout` references to Node 24-capable majors to clear the Node 20 deprecation warning.

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,18 @@ inputs:
   account-manager-host:
     description: 'Account Manager hostname → SFCC_ACCOUNT_MANAGER_HOST'
     required: false
+  webdav-server:
+    description: 'Separate WebDAV hostname (used for staging cert. hostnames) → SFCC_WEBDAV_SERVER'
+    required: false
+  certificate:
+    description: 'Path to PKCS12 client certificate for two-factor (mTLS) auth → SFCC_CERTIFICATE'
+    required: false
+  certificate-passphrase:
+    description: 'Passphrase for the PKCS12 client certificate → SFCC_CERTIFICATE_PASSPHRASE'
+    required: false
+  selfsigned:
+    description: 'Allow self-signed server certificates → SFCC_SELFSIGNED. Set to "true" to enable; omit otherwise.'
+    required: false
 
 outputs:
   cli-version:
@@ -93,6 +105,10 @@ runs:
         mrt-project: ${{ inputs.mrt-project }}
         mrt-environment: ${{ inputs.mrt-environment }}
         account-manager-host: ${{ inputs.account-manager-host }}
+        webdav-server: ${{ inputs.webdav-server }}
+        certificate: ${{ inputs.certificate }}
+        certificate-passphrase: ${{ inputs.certificate-passphrase }}
+        selfsigned: ${{ inputs.selfsigned }}
 
     - name: Run command
       id: command

--- a/actions/README.md
+++ b/actions/README.md
@@ -27,7 +27,7 @@ GitHub Actions for automating Salesforce B2C Commerce operations with the [`@sal
 ### One-step code deploy
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: SalesforceCommerceCloud/b2c-developer-tooling@v1
   with:
     client-id: ${{ secrets.SFCC_CLIENT_ID }}
@@ -40,7 +40,7 @@ GitHub Actions for automating Salesforce B2C Commerce operations with the [`@sal
 ### High-level code deploy
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: SalesforceCommerceCloud/b2c-developer-tooling/actions/code-deploy@v1
   with:
     client-id: ${{ secrets.SFCC_CLIENT_ID }}
@@ -54,7 +54,7 @@ GitHub Actions for automating Salesforce B2C Commerce operations with the [`@sal
 ### Data import
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: SalesforceCommerceCloud/b2c-developer-tooling/actions/data-import@v1
   with:
     client-id: ${{ secrets.SFCC_CLIENT_ID }}

--- a/actions/code-deploy/action.yml
+++ b/actions/code-deploy/action.yml
@@ -46,6 +46,27 @@ inputs:
   password:
     description: 'WebDAV password/access key (falls back to SFCC_PASSWORD env var)'
     required: false
+  short-code:
+    description: 'SCAPI short code (falls back to SFCC_SHORTCODE env var)'
+    required: false
+  tenant-id:
+    description: 'Tenant ID (falls back to SFCC_TENANT_ID env var)'
+    required: false
+  account-manager-host:
+    description: 'Account Manager hostname (falls back to SFCC_ACCOUNT_MANAGER_HOST env var)'
+    required: false
+  webdav-server:
+    description: 'Separate WebDAV hostname for staging (falls back to SFCC_WEBDAV_SERVER env var)'
+    required: false
+  certificate:
+    description: 'Path to PKCS12 client certificate for two-factor (mTLS) auth (falls back to SFCC_CERTIFICATE env var)'
+    required: false
+  certificate-passphrase:
+    description: 'Passphrase for the PKCS12 client certificate (falls back to SFCC_CERTIFICATE_PASSPHRASE env var)'
+    required: false
+  selfsigned:
+    description: 'Allow self-signed server certificates (falls back to SFCC_SELFSIGNED env var)'
+    required: false
   # Setup inputs
   version:
     description: 'CLI version to install if not already set up'
@@ -80,6 +101,13 @@ runs:
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
         code-version: ${{ inputs.code-version }}
+        short-code: ${{ inputs.short-code }}
+        tenant-id: ${{ inputs.tenant-id }}
+        account-manager-host: ${{ inputs.account-manager-host }}
+        webdav-server: ${{ inputs.webdav-server }}
+        certificate: ${{ inputs.certificate }}
+        certificate-passphrase: ${{ inputs.certificate-passphrase }}
+        selfsigned: ${{ inputs.selfsigned }}
 
     - name: Build command
       id: build-cmd

--- a/actions/data-import/action.yml
+++ b/actions/data-import/action.yml
@@ -35,6 +35,27 @@ inputs:
   password:
     description: 'WebDAV password/access key (falls back to SFCC_PASSWORD env var)'
     required: false
+  short-code:
+    description: 'SCAPI short code (falls back to SFCC_SHORTCODE env var)'
+    required: false
+  tenant-id:
+    description: 'Tenant ID (falls back to SFCC_TENANT_ID env var)'
+    required: false
+  account-manager-host:
+    description: 'Account Manager hostname (falls back to SFCC_ACCOUNT_MANAGER_HOST env var)'
+    required: false
+  webdav-server:
+    description: 'Separate WebDAV hostname for staging (falls back to SFCC_WEBDAV_SERVER env var)'
+    required: false
+  certificate:
+    description: 'Path to PKCS12 client certificate for two-factor (mTLS) auth (falls back to SFCC_CERTIFICATE env var)'
+    required: false
+  certificate-passphrase:
+    description: 'Passphrase for the PKCS12 client certificate (falls back to SFCC_CERTIFICATE_PASSPHRASE env var)'
+    required: false
+  selfsigned:
+    description: 'Allow self-signed server certificates (falls back to SFCC_SELFSIGNED env var)'
+    required: false
   # Setup inputs
   version:
     description: 'CLI version to install if not already set up'
@@ -68,6 +89,13 @@ runs:
         server: ${{ inputs.server }}
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
+        short-code: ${{ inputs.short-code }}
+        tenant-id: ${{ inputs.tenant-id }}
+        account-manager-host: ${{ inputs.account-manager-host }}
+        webdav-server: ${{ inputs.webdav-server }}
+        certificate: ${{ inputs.certificate }}
+        certificate-passphrase: ${{ inputs.certificate-passphrase }}
+        selfsigned: ${{ inputs.selfsigned }}
 
     - name: Build command
       id: build-cmd

--- a/actions/job-run/action.yml
+++ b/actions/job-run/action.yml
@@ -33,6 +33,24 @@ inputs:
   server:
     description: 'B2C instance hostname (falls back to SFCC_SERVER env var)'
     required: false
+  short-code:
+    description: 'SCAPI short code (falls back to SFCC_SHORTCODE env var)'
+    required: false
+  tenant-id:
+    description: 'Tenant ID (falls back to SFCC_TENANT_ID env var)'
+    required: false
+  account-manager-host:
+    description: 'Account Manager hostname (falls back to SFCC_ACCOUNT_MANAGER_HOST env var)'
+    required: false
+  certificate:
+    description: 'Path to PKCS12 client certificate for two-factor (mTLS) auth (falls back to SFCC_CERTIFICATE env var)'
+    required: false
+  certificate-passphrase:
+    description: 'Passphrase for the PKCS12 client certificate (falls back to SFCC_CERTIFICATE_PASSPHRASE env var)'
+    required: false
+  selfsigned:
+    description: 'Allow self-signed server certificates (falls back to SFCC_SELFSIGNED env var)'
+    required: false
   # Setup inputs
   version:
     description: 'CLI version to install if not already set up'
@@ -64,6 +82,12 @@ runs:
         client-id: ${{ inputs.client-id }}
         client-secret: ${{ inputs.client-secret }}
         server: ${{ inputs.server }}
+        short-code: ${{ inputs.short-code }}
+        tenant-id: ${{ inputs.tenant-id }}
+        account-manager-host: ${{ inputs.account-manager-host }}
+        certificate: ${{ inputs.certificate }}
+        certificate-passphrase: ${{ inputs.certificate-passphrase }}
+        selfsigned: ${{ inputs.selfsigned }}
 
     - name: Build command
       id: build-cmd

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -81,7 +81,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/actions/webdav-upload/action.yml
+++ b/actions/webdav-upload/action.yml
@@ -31,6 +31,27 @@ inputs:
   password:
     description: 'WebDAV password/access key (falls back to SFCC_PASSWORD env var)'
     required: false
+  short-code:
+    description: 'SCAPI short code (falls back to SFCC_SHORTCODE env var)'
+    required: false
+  tenant-id:
+    description: 'Tenant ID (falls back to SFCC_TENANT_ID env var)'
+    required: false
+  account-manager-host:
+    description: 'Account Manager hostname (falls back to SFCC_ACCOUNT_MANAGER_HOST env var)'
+    required: false
+  webdav-server:
+    description: 'Separate WebDAV hostname for staging (falls back to SFCC_WEBDAV_SERVER env var)'
+    required: false
+  certificate:
+    description: 'Path to PKCS12 client certificate for two-factor (mTLS) auth (falls back to SFCC_CERTIFICATE env var)'
+    required: false
+  certificate-passphrase:
+    description: 'Passphrase for the PKCS12 client certificate (falls back to SFCC_CERTIFICATE_PASSPHRASE env var)'
+    required: false
+  selfsigned:
+    description: 'Allow self-signed server certificates (falls back to SFCC_SELFSIGNED env var)'
+    required: false
   # Setup inputs
   version:
     description: 'CLI version to install if not already set up'
@@ -64,6 +85,13 @@ runs:
         server: ${{ inputs.server }}
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
+        short-code: ${{ inputs.short-code }}
+        tenant-id: ${{ inputs.tenant-id }}
+        account-manager-host: ${{ inputs.account-manager-host }}
+        webdav-server: ${{ inputs.webdav-server }}
+        certificate: ${{ inputs.certificate }}
+        certificate-passphrase: ${{ inputs.certificate-passphrase }}
+        selfsigned: ${{ inputs.selfsigned }}
 
     - name: Upload via WebDAV
       id: upload

--- a/actions/workflow-templates/b2c-code-deploy.yml
+++ b/actions/workflow-templates/b2c-code-deploy.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: SalesforceCommerceCloud/b2c-developer-tooling/actions/code-deploy@v1
         with:

--- a/actions/workflow-templates/b2c-data-import.yml
+++ b/actions/workflow-templates/b2c-data-import.yml
@@ -12,7 +12,7 @@ jobs:
   import:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: SalesforceCommerceCloud/b2c-developer-tooling/actions/data-import@v1
         with:

--- a/actions/workflow-templates/b2c-mrt-deploy.yml
+++ b/actions/workflow-templates/b2c-mrt-deploy.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build storefront
         run: npm run build


### PR DESCRIPTION
## Problem

Callers using the high-level GitHub Actions (e.g. `code-deploy`) hit:

```
Warning: Unexpected input(s) 'account-manager-host', valid inputs are ['cartridge-path', ...]
```

The CLI fully supports `--account-manager-host` / `SFCC_ACCOUNT_MANAGER_HOST`, but only the `setup` action declared it. The high-level wrapper actions (`code-deploy`, `data-import`, `job-run`, `webdav-upload`) and the root action forwarded just a subset of auth inputs to `setup`, so anything undeclared triggered the warning and was **silently dropped** — the AM host (and the entire staging/mTLS + SCAPI input set) never reached the CLI.

This contradicted `docs/guide/ci-cd.md`, which already documents these inputs as working on the standard actions.

## Fix

- Declare and forward the full auth/config input set on each high-level action and the root action:
  - `account-manager-host`, `short-code`, `tenant-id`, `certificate`, `certificate-passphrase`, `selfsigned`, and `webdav-server` (where applicable).
  - `job-run` omits `webdav-server`/`username`/`password` since it is OAuth/OCAPI only.
- Clear the Node 20 deprecation warning by bumping our bundled `actions/setup-node@v4` → `@v6` and the shipped workflow-template / README `actions/checkout@v4` → `@v6` (floating tags are fine for first-party GitHub actions).

## Release

Action-only changes ship by force-moving the `v1` tag, which is gated on a changeset in `publish.yml`. Added a changeset targeting `@salesforce/b2c-dx-docs` (per precedent in #478) so the `v1` tag advances on the next stable release.

## Testing

- All edited action YAML files validated with a YAML parser.
- `test-actions.yml` exercises `--help` smoke tests only; no behavior change there.