### PR TITLE
feat(schema): add description field to regiondefinition.json @W-22617900

### DIFF
--- a/.changeset/regiondefinition-description-field.md
+++ b/.changeset/regiondefinition-description-field.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+Add optional `description` field to `regiondefinition.json` schema, matching the field added to the ECOM platform schema in W-22617900.

--- a/.changeset/regiondefinition-description-field.md
+++ b/.changeset/regiondefinition-description-field.md
@@ -1,5 +1,5 @@
 ---
-'@salesforce/b2c-tooling-sdk': patch
+'@salesforce/b2c-tooling-sdk': minor
 ---
 
 Add optional `description` field to `regiondefinition.json` schema, matching the field added to the ECOM platform schema in W-22617900.

--- a/packages/b2c-tooling-sdk/data/content-schemas/regiondefinition.json
+++ b/packages/b2c-tooling-sdk/data/content-schemas/regiondefinition.json
@@ -6,6 +6,7 @@
   "properties": {
     "id": {"$ref":"common.json#/definitions/id"},
     "name": {"$ref":"common.json#/definitions/name"},
+    "description": {"$ref":"common.json#/definitions/description"},
     "max_components": {
       "type": "integer",
       "minimum": 1

--- a/packages/b2c-tooling-sdk/test/operations/content/validate.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/content/validate.test.ts
@@ -341,6 +341,28 @@ describe('content metadefinition validation', () => {
       );
       expect(result.valid).to.equal(true);
     });
+
+    it('passes when region definition includes a description', () => {
+      const result = validateMetaDefinition(
+        {
+          group: 'content',
+          region_definitions: [{id: 'main', name: 'Main', description: 'The main content region'}],
+          attribute_definition_groups: [],
+        },
+        {type: 'componenttype'},
+      );
+      expect(result.valid).to.equal(true);
+    });
+
+    it('passes when pagetype region definition includes a description', () => {
+      const result = validateMetaDefinition(
+        {
+          region_definitions: [{id: 'hero', name: 'Hero', description: 'Top hero region'}],
+        },
+        {type: 'pagetype'},
+      );
+      expect(result.valid).to.equal(true);
+    });
   });
 
   describe('error message formatting', () => {


### PR DESCRIPTION
## Summary
Mirrors the description field added to the ECOM platform schema in W-22617900, allowing Page Designer region definitions to include a description without failing b2c-tooling-sdk validation.

## Testing

How was this tested?

## Dependencies

- [ ] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [ ] Tests pass (`pnpm test`)
- [ ] Code is formatted (`pnpm run format`)
