### PR TITLE
fix(mrt-welcome-app): escape reflected user input in echo response (@W-23137861)

### DIFF
--- a/packages/mrt-welcome-app/src/utils/welcome-routes.test.ts
+++ b/packages/mrt-welcome-app/src/utils/welcome-routes.test.ts
@@ -14,12 +14,21 @@ import {echo} from './welcome-routes.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const decodeHtmlEntities = (s: string): string =>
+  s
+    .replace(/&#34;/g, '"')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+
 const parseJsonFromHtml = (html: string): any => {
   const match = html.match(/<pre class="code">([\s\S]*?)<\/pre>/);
   if (!match || !match[1]) {
     throw new Error('Could not find JSON in HTML response');
   }
-  return JSON.parse(match[1].trim());
+  return JSON.parse(decodeHtmlEntities(match[1].trim()));
 };
 
 describe('welcome-routes', () => {
@@ -88,6 +97,21 @@ describe('welcome-routes', () => {
 
       const json = parseJsonFromHtml(response.text);
       expect(json.ip).to.not.be.undefined;
+    });
+
+    it('should HTML-escape user-controllable input reflected in the response', async () => {
+      app.get('/*splat', echo);
+
+      const response = await request(app).get(
+        '/test?value=%3Ch1%3Esample%20%3Ca%20href=https://example.com%3Elink%3C/a%3E%3C/h1%3E',
+      );
+
+      expect(response.text).to.not.match(/<h1>sample/);
+      expect(response.text).to.not.match(/<a href=https:\/\/example\.com>link<\/a>/);
+      expect(response.text).to.include('&lt;h1&gt;sample');
+
+      const json = parseJsonFromHtml(response.text);
+      expect(json.query.value).to.equal('<h1>sample <a href=https://example.com>link</a></h1>');
     });
   });
 });

--- a/packages/mrt-welcome-app/src/views/layout.html
+++ b/packages/mrt-welcome-app/src/views/layout.html
@@ -115,7 +115,7 @@
         >
       </section>
       <h4>HTTP request info</h4>
-      <pre class="code"><%- JSON.stringify(json_content, null, 2) %></pre>
+      <pre class="code"><%= JSON.stringify(json_content, null, 2) %></pre>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes a **reflected HTML injection (XSS) sink** in `packages/mrt-welcome-app/src/views/layout.html`. The diagnostic "HTTP request info" block previously emitted JSON-stringified request data via EJS's unescaped interpolation (`<%- JSON.stringify(json_content, null, 2) %>`). Because `JSON.stringify` does not escape HTML metacharacters, attacker-controlled URL data (query params, path, headers) reflected from the request rendered as live HTML — e.g. `?value=<h1>sample <a href=https://example.com>link</a></h1>` produced an actual heading and link in the victim's browser.

The fix switches that single interpolation to EJS's HTML-escaped form (`<%= … %>`), so user-controllable strings render as visible text rather than markup. The server still records inputs verbatim; only the rendering is sanitized.

GUS work item: [W-23137861](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/a07EE00002csmXNYAY/view)

## Testing

- `pnpm --filter @salesforce/mrt-welcome-app test` — all 25 tests pass, including the new regression.
- Added one regression test (`should HTML-escape user-controllable input reflected in the response`) that wires `echo` on a catch-all route, issues the PVR repro URL, and asserts (a) no live `<h1>`/anchor markup leaks into the response, (b) the entity-escaped form (`&lt;h1&gt;sample`) is present, and (c) the raw input still round-trips through the JSON payload — confirming the sanitization is render-only.
- Verified the new test **fails on `develop`** (before the template fix) and **passes with the fix applied**.
- Updated the existing `parseJsonFromHtml` test helper to HTML-decode the extracted JSON block, since the now-escaped diagnostic block contains entities like `&lt;`, `&gt;`, `&amp;`, `&#34;`, `&#39;`. The decoder is a six-entity local helper (with `&amp;` replaced last to avoid double-decoding) — no new dependencies.
- Manual verification: rendered the template with the malicious payload and confirmed the output is escaped.

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)