### PR TITLE
feat(schema): add page-type preview field in pagetype.json @W-23250875

### DIFF
--- a/.changeset/preview-pagetype-schema.md
+++ b/.changeset/preview-pagetype-schema.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-tooling-sdk': minor
+---
+
+Add optional `preview` property to the page-type JSON Schema to mirror ECOM W-23233931.

--- a/packages/b2c-tooling-sdk/data/content-schemas/pagetype.json
+++ b/packages/b2c-tooling-sdk/data/content-schemas/pagetype.json
@@ -16,6 +16,10 @@
     "route": {
       "$ref": "common.json#/definitions/route"
     },
+    "preview": {
+      "type": "string",
+      "enum": ["default"]
+    },
     "region_definitions": {
       "type": "array",
       "items": {"$ref": "regiondefinition.json"}

--- a/packages/b2c-tooling-sdk/test/operations/content/validate.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/content/validate.test.ts
@@ -218,6 +218,65 @@ describe('content metadefinition validation', () => {
     it('throws MetaDefinitionDetectionError for undetectable data', () => {
       expect(() => validateMetaDefinition({foo: 'bar'})).to.throw(MetaDefinitionDetectionError);
     });
+
+    it('accepts preview: "default" on a page type', () => {
+      const result = validateMetaDefinition(
+        {region_definitions: [{id: 'main', name: 'Main'}], preview: 'default'},
+        {type: 'pagetype'},
+      );
+      expect(result.valid).to.equal(true);
+      expect(result.errors).to.have.lengthOf(0);
+    });
+
+    it('accepts page type without preview', () => {
+      const result = validateMetaDefinition({region_definitions: [{id: 'main', name: 'Main'}]}, {type: 'pagetype'});
+      expect(result.valid).to.equal(true);
+    });
+
+    it('rejects preview value not in enum', () => {
+      const result = validateMetaDefinition(
+        {region_definitions: [{id: 'main', name: 'Main'}], preview: 'fancy'},
+        {type: 'pagetype'},
+      );
+      expect(result.valid).to.equal(false);
+      expect(result.errors.some((e) => e.message.toLowerCase().includes('enum'))).to.equal(true);
+    });
+
+    it('rejects non-string preview', () => {
+      const result = validateMetaDefinition(
+        {region_definitions: [{id: 'main', name: 'Main'}], preview: 123},
+        {type: 'pagetype'},
+      );
+      expect(result.valid).to.equal(false);
+      expect(
+        result.errors.some(
+          (e) => e.message.toLowerCase().includes('string') || e.message.toLowerCase().includes('type'),
+        ),
+      ).to.equal(true);
+    });
+
+    it('rejects preview on a component type', () => {
+      const result = validateMetaDefinition(
+        {
+          group: 'content',
+          region_definitions: [],
+          attribute_definition_groups: [],
+          preview: 'default',
+        },
+        {type: 'componenttype'},
+      );
+      expect(result.valid).to.equal(false);
+      expect(result.errors.some((e) => e.message.includes('additional property'))).to.equal(true);
+    });
+
+    it('auto-detects page type with preview', () => {
+      const result = validateMetaDefinition({
+        region_definitions: [{id: 'main', name: 'Main'}],
+        preview: 'default',
+      });
+      expect(result.valid).to.equal(true);
+      expect(result.schemaType).to.equal('pagetype');
+    });
   });
 
   describe('validateMetaDefinitionFile', () => {
@@ -253,6 +312,16 @@ describe('content metadefinition validation', () => {
     it('throws MetaDefinitionDetectionError for undetectable file', () => {
       const filePath = writeTempJson({foo: 'bar'});
       expect(() => validateMetaDefinitionFile(filePath)).to.throw(MetaDefinitionDetectionError);
+    });
+
+    it('validates a page type file with preview', () => {
+      const filePath = writeTempJson({
+        region_definitions: [{id: 'main', name: 'Main'}],
+        preview: 'default',
+      });
+      const result = validateMetaDefinitionFile(filePath, {type: 'pagetype'});
+      expect(result.valid).to.equal(true);
+      expect(result.filePath).to.equal(path.resolve(filePath));
     });
   });
 


### PR DESCRIPTION
## Summary

Added an optional `preview` property to the b2c-tooling-sdk's mirror of the page-type JSON Schema (`pagetype.json`). The field is a string with `enum: ["default"]` and is positioned between `route` and `region_definitions`.

## Testing

- Added 7 new unit tests in `packages/b2c-tooling-sdk/test/operations/content/validate.test.ts` covering accept/reject paths for the new `preview` field on both page-type and component-type schemas, including auto-detection and file-based validation.
- Ran `pnpm --filter @salesforce/b2c-tooling-sdk run test` — **1889 passing**, 0 failing, 83.05% statement coverage.
- Ran `pnpm --filter @salesforce/b2c-tooling-sdk run lint:agent` and `typecheck:agent` — both clean.
- Verified formatting with `prettier` on the two changed files — no changes needed.

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
