### PR TITLE
Add refresh:docs-data maintainer script; update bundled data to DWAPP 26.7

### DIFF
--- a/.changeset/refresh-docs-data-26-7.md
+++ b/.changeset/refresh-docs-data-26-7.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+Refresh bundled Script API docs, XSD schemas, Page Designer content schemas, and standard job-step data to platform version DWAPP 26.7. The `content validate` command now matches the current platform rules for Page Designer component types — `component_id` accepts the full platform character set and is only valid on embedded components (`embedded: true`).

--- a/.claude/skills/sdk-module-development/SKILL.md
+++ b/.claude/skills/sdk-module-development/SKILL.md
@@ -399,6 +399,55 @@ import { WebDavClient } from '@salesforce/b2c-tooling-sdk/clients';
 import { WebDavClient } from '../../src/clients/webdav.js';
 ```
 
+## Refreshing Bundled Platform Data (Docs, Schemas, Job Steps)
+
+The SDK ships several corpora derived from the B2C Commerce platform under
+`packages/b2c-tooling-sdk/data/`:
+
+| Directory | Contents | Consumed by |
+| --- | --- | --- |
+| `data/script-api/` | Script API reference markdown + `index.json` | `docs search` / `docs read`, MCP `docs_*` |
+| `data/content-schemas/` | Page Designer / content metadefinition JSON schemas | `content validate` |
+| `data/xsd/` | Import/export XSD schemas + `index.json` | `docs schema *`, XML validation |
+| `data/job-steps/` | Standard job-step markdown + dataset + `index.json` | `docs search` / `docs read` |
+
+All of these originate from the **same documentation archive** (`demandware-mock.zip`)
+that `b2c docs download` fetches from an instance — the inner `DWAPP-<version>-API-doc.zip`
+contains `sfdocs/script-api/`, `content/`, `xsd/`, and `jobstepapi/`. Note that the
+user-facing `docs download` command only extracts the Script API markdown; it does **not**
+update the bundled data files.
+
+### Refresh all data at once
+
+Run the maintainer script against a current instance (uses your default instance/auth
+via the CLI, so no extra setup):
+
+```bash
+pnpm --filter @salesforce/b2c-tooling-sdk run refresh:docs-data
+
+# Target a non-default instance, or keep the temp workdir for inspection:
+B2C_INSTANCE=my-sandbox KEEP_WORKDIR=1 pnpm --filter @salesforce/b2c-tooling-sdk run refresh:docs-data
+```
+
+`scripts/refresh-docs-data.ts` downloads the archive via `b2c docs download`, repopulates
+every `data/` directory above from the inner API-doc zip, then regenerates the derived
+datasets and search indexes (`build:job-steps-dataset`, `generate:job-steps-docs`,
+`generate:docs-index`). It prints the detected platform version (e.g. `DWAPP 26.7`).
+
+### After refreshing
+
+- **Review the diff** under `packages/b2c-tooling-sdk/data/`. Index files change their
+  `generatedAt` timestamp every run; look for substantive schema/doc changes.
+- The refresh **overwrites files wholesale** — there are no hand-maintained local patches
+  to preserve today. If a platform schema change alters validation behavior (e.g. a
+  `content-schemas/*.json` rule), update the affected tests to match the new platform rule.
+- Run `pnpm --filter @salesforce/b2c-tooling-sdk run test:agent` and add a changeset when
+  the refresh changes user-facing behavior (bump the platform version, note the change).
+
+The individual generation scripts can still be run standalone (see each script's header
+comment), but `refresh:docs-data` is the one-step path that keeps every corpus in sync
+with a single platform release.
+
 ## New Module Checklist
 
 1. Create module directory under `src/`

--- a/README.md
+++ b/README.md
@@ -204,6 +204,29 @@ See the [documentation site](https://salesforcecommercecloud.github.io/b2c-devel
 
 When adding new public APIs, ensure they have comprehensive JSDoc comments as these will appear in the generated documentation.
 
+### Bundled Platform Data (Script API docs, schemas, job steps)
+
+The SDK ships several corpora derived from the B2C Commerce platform under `packages/b2c-tooling-sdk/data/`:
+
+| Directory | Contents | Consumed by |
+|-----------|----------|-------------|
+| `script-api/` | Script API reference markdown + search index | `b2c docs search` / `docs read`, MCP `docs_*` |
+| `content-schemas/` | Page Designer / content metadefinition JSON schemas | `b2c content validate` |
+| `xsd/` | Import/export XSD schemas + search index | `b2c docs schema *`, XML validation |
+| `job-steps/` | Standard job-step markdown + dataset + search index | `b2c docs search` / `docs read` |
+
+All of these originate from the same documentation archive that `b2c docs download` fetches from an instance (the inner `DWAPP-<version>-API-doc.zip`). To refresh **all** of them to a new platform release at once, run the maintainer script against a current instance (it uses your default instance/auth via the CLI):
+
+```bash
+# Refresh every data set and regenerate the derived indexes
+pnpm --filter @salesforce/b2c-tooling-sdk run refresh:docs-data
+
+# Target a non-default instance, or keep the temp workdir for inspection
+B2C_INSTANCE=my-sandbox KEEP_WORKDIR=1 pnpm --filter @salesforce/b2c-tooling-sdk run refresh:docs-data
+```
+
+The script prints the detected platform version (e.g. `DWAPP 26.7`). Afterward, review the diff under `packages/b2c-tooling-sdk/data/` (index files always change their `generatedAt` timestamp; look for substantive schema/doc changes), run `pnpm --filter @salesforce/b2c-tooling-sdk run test:agent`, and add a changeset if the refresh changes user-facing behavior. See the `sdk-module-development` skill for details.
+
 ## Releases and Publishing
 
 This project uses [Changesets](https://github.com/changesets/changesets) for version management and publishes to npm using [OIDC trusted publishers](https://docs.npmjs.com/trusted-publishers).

--- a/packages/b2c-tooling-sdk/data/content-schemas/componenttype.json
+++ b/packages/b2c-tooling-sdk/data/content-schemas/componenttype.json
@@ -1,44 +1,67 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  
-  "type":"object",
-  
+  "type": "object",
   "properties": {
-    "name": {"$ref":"common.json#/definitions/name"},
-    "description": {"$ref":"common.json#/definitions/description"},
+    "name": {
+      "$ref": "common.json#/definitions/name"
+    },
+    "description": {
+      "$ref": "common.json#/definitions/description"
+    },
     "arch_type": {
       "$ref": "common.json#/definitions/arch_type"
     },
-    "group": {"$ref":"common.json#/definitions/id"},
     "embedded": {
       "type": "boolean"
     },
     "component_id": {
       "type": "string",
       "maxLength": 256,
-      "pattern": "^[\\w][\\w-]*$"
+      "pattern": "^[\\w-~:\\[\\]@!'*,;=]+$",
+      "description": "Developer-defined content ID for embedded components. Used as the Content.ID when the component is created."
+    },
+    "group": {
+      "$ref": "common.json#/definitions/id"
     },
     "region_definitions": {
       "type": "array",
-      "items": {"$ref": "regiondefinition.json"}
+      "items": {
+        "$ref": "regiondefinition.json"
+      }
     },
     "attribute_definition_groups": {
       "type": "array",
-      "items": {"$ref": "attributedefinitiongroup.json"}
+      "items": {
+        "$ref": "attributedefinitiongroup.json"
+      }
     }
   },
-  "required": ["region_definitions","attribute_definition_groups", "group"],
+  "required": [
+    "region_definitions",
+    "attribute_definition_groups",
+    "group"
+  ],
   "allOf": [
     {
       "anyOf": [
         {
           "not": {
-            "properties": {"embedded": {"enum": [true]}},
-            "required": ["embedded"]
+            "properties": {
+              "embedded": {
+                "enum": [
+                  true
+                ]
+              }
+            },
+            "required": [
+              "embedded"
+            ]
           }
         },
         {
-          "required": ["component_id"]
+          "required": [
+            "component_id"
+          ]
         }
       ]
     },
@@ -46,13 +69,52 @@
       "anyOf": [
         {
           "not": {
-            "properties": {"embedded": {"enum": [true]}},
-            "required": ["embedded"]
+            "properties": {
+              "embedded": {
+                "enum": [
+                  true
+                ]
+              }
+            },
+            "required": [
+              "embedded"
+            ]
           }
         },
         {
-          "properties": {"arch_type": {"enum": ["headless"]}},
-          "required": ["arch_type"]
+          "properties": {
+            "arch_type": {
+              "enum": [
+                "headless"
+              ]
+            }
+          },
+          "required": [
+            "arch_type"
+          ]
+        }
+      ]
+    },
+    {
+      "anyOf": [
+        {
+          "not": {
+            "required": [
+              "component_id"
+            ]
+          }
+        },
+        {
+          "properties": {
+            "embedded": {
+              "enum": [
+                true
+              ]
+            }
+          },
+          "required": [
+            "embedded"
+          ]
         }
       ]
     }

--- a/packages/b2c-tooling-sdk/data/job-steps/index.json
+++ b/packages/b2c-tooling-sdk/data/job-steps/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-06-23T21:52:07.659Z",
+  "generatedAt": "2026-07-01T00:01:00.492Z",
   "entries": [
     {
       "id": "CatalogDeltaExport",

--- a/packages/b2c-tooling-sdk/data/job-steps/job-steps.json
+++ b/packages/b2c-tooling-sdk/data/job-steps/job-steps.json
@@ -4,7 +4,7 @@
     "description": "Catalog of standard (system) B2C Commerce job step type IDs available in Business Manager job flows and jobs.xml site-import flows.",
     "derivation": "Generated from the public B2C Commerce Job Step API documentation (the jobstepapi section of the Script API documentation archive obtained via `b2c docs download`). Each step lists its purpose, execution scope, and input parameters (required, description, allowed values, default) as published in that documentation.",
     "platformDocVersion": "DWAPP 26.7",
-    "regenerate": "pnpm --filter @salesforce/b2c-tooling-sdk run build:job-steps-dataset -- <jobstep-html-dir>; then run generate:job-steps-docs"
+    "regenerate": "pnpm --filter @salesforce/b2c-tooling-sdk run refresh:docs-data (or, standalone: build:job-steps-dataset -- <jobstep-html-dir> [version]; then generate:job-steps-docs)"
   },
   "steps": [
     {

--- a/packages/b2c-tooling-sdk/data/script-api/index.json
+++ b/packages/b2c-tooling-sdk/data/script-api/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-06-23T22:27:06.446Z",
+  "generatedAt": "2026-07-01T00:01:00.856Z",
   "entries": [
     {
       "id": "dw.alert",

--- a/packages/b2c-tooling-sdk/data/xsd/index.json
+++ b/packages/b2c-tooling-sdk/data/xsd/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-06-23T22:27:06.448Z",
+  "generatedAt": "2026-07-01T00:01:00.858Z",
   "entries": [
     {
       "id": "abtest",

--- a/packages/b2c-tooling-sdk/package.json
+++ b/packages/b2c-tooling-sdk/package.json
@@ -229,6 +229,7 @@
     "generate:docs-index": "tsx scripts/generate-docs-index.ts",
     "build:job-steps-dataset": "tsx scripts/build-job-steps-dataset.ts",
     "generate:job-steps-docs": "tsx scripts/generate-job-steps-docs.ts",
+    "refresh:docs-data": "tsx scripts/refresh-docs-data.ts",
     "prepack": "node scripts/strip-dev-exports.cjs",
     "postpack": "git checkout package.json"
   },

--- a/packages/b2c-tooling-sdk/scripts/build-job-steps-dataset.ts
+++ b/packages/b2c-tooling-sdk/scripts/build-job-steps-dataset.ts
@@ -211,8 +211,11 @@ function parseStep(typeId: string, text: string): JobStep {
 
 function main(): void {
   const inputDir = process.argv[2];
+  // Optional platform version (e.g. "26.7"), forwarded by refresh-docs-data.ts.
+  // Falls back to the previously bundled version when run standalone.
+  const platformVersion = process.argv[3] ?? '26.7';
   if (!inputDir) {
-    console.error('Usage: build-job-steps-dataset.ts <dir-with-jobstep-html>');
+    console.error('Usage: build-job-steps-dataset.ts <dir-with-jobstep-html> [platform-version]');
     console.error('  The directory must contain jobstep.<TypeID>.html files from the');
     console.error('  jobstepapi section of a downloaded B2C Commerce documentation archive.');
     process.exit(1);
@@ -241,9 +244,9 @@ function main(): void {
         'Catalog of standard (system) B2C Commerce job step type IDs available in Business Manager job flows and jobs.xml site-import flows.',
       derivation:
         'Generated from the public B2C Commerce Job Step API documentation (the jobstepapi section of the Script API documentation archive obtained via `b2c docs download`). Each step lists its purpose, execution scope, and input parameters (required, description, allowed values, default) as published in that documentation.',
-      platformDocVersion: 'DWAPP 26.7',
+      platformDocVersion: `DWAPP ${platformVersion}`,
       regenerate:
-        'pnpm --filter @salesforce/b2c-tooling-sdk run build:job-steps-dataset -- <jobstep-html-dir>; then run generate:job-steps-docs',
+        'pnpm --filter @salesforce/b2c-tooling-sdk run refresh:docs-data (or, standalone: build:job-steps-dataset -- <jobstep-html-dir> [version]; then generate:job-steps-docs)',
     },
     steps,
   };

--- a/packages/b2c-tooling-sdk/scripts/refresh-docs-data.ts
+++ b/packages/b2c-tooling-sdk/scripts/refresh-docs-data.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+/**
+ * Refreshes ALL bundled documentation data sets at once from a single B2C
+ * Commerce documentation archive, then regenerates every derived index.
+ *
+ * The bundled corpora all originate from the same `demandware-mock.zip` archive
+ * that `b2c docs download` fetches from an instance, but historically each was
+ * synced by hand and drifted independently. This script makes the whole refresh
+ * one reproducible step:
+ *
+ *   1. Download the archive from the user's default instance via the CLI
+ *      (`b2c docs download` — reuses the user's instance/auth config).
+ *   2. From the inner `DWAPP-<version>-API-doc.zip`, repopulate:
+ *        - data/script-api/*.md          (Script API reference)
+ *        - data/content-schemas/*.json   (Page Designer / content metadefinitions)
+ *        - data/xsd/*.xsd                (import/export XSD schemas)
+ *      and extract `jobstepapi/html/api/jobstep.*.html` for the job-step dataset.
+ *   3. Regenerate the job-step dataset + markdown (build:job-steps-dataset,
+ *      generate:job-steps-docs) and the search indexes (generate:docs-index).
+ *
+ * Usage (from repo root or the SDK package):
+ *   pnpm --filter @salesforce/b2c-tooling-sdk run refresh:docs-data
+ *
+ * Options (env vars):
+ *   B2C_INSTANCE   forwarded to `b2c docs download --instance <name>` to pick a
+ *                  non-default instance.
+ *   KEEP_WORKDIR=1 keep the temp download/extract directory for inspection.
+ */
+
+import {execFileSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import JSZip from 'jszip';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SDK_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(SDK_ROOT, '../..');
+const DATA_DIR = path.join(SDK_ROOT, 'data');
+
+const SCRIPT_API_DIR = path.join(DATA_DIR, 'script-api');
+const CONTENT_SCHEMAS_DIR = path.join(DATA_DIR, 'content-schemas');
+const XSD_DIR = path.join(DATA_DIR, 'xsd');
+
+/** Run a command, inheriting stdio so progress/auth prompts are visible. */
+function run(cmd: string, args: string[], cwd: string): void {
+  execFileSync(cmd, args, {cwd, stdio: 'inherit'});
+}
+
+/** Replace every file matching `keep`-excluded predicate in a dir, then copy fresh files in. */
+function syncDir(targetDir: string, files: {name: string; content: Buffer}[], removeExt: string): void {
+  fs.mkdirSync(targetDir, {recursive: true});
+  for (const existing of fs.readdirSync(targetDir)) {
+    if (existing.endsWith(removeExt)) {
+      fs.rmSync(path.join(targetDir, existing));
+    }
+  }
+  for (const {name, content} of files) {
+    fs.writeFileSync(path.join(targetDir, name), content);
+  }
+}
+
+/** Pull all entries under `prefix` (non-directory) out of a loaded zip. */
+async function entriesUnder(zip: JSZip, prefix: string): Promise<{name: string; content: Buffer}[]> {
+  const out: {name: string; content: Buffer}[] = [];
+  for (const [relPath, entry] of Object.entries(zip.files)) {
+    if (!relPath.startsWith(prefix) || entry.dir) continue;
+    const name = relPath.slice(prefix.length);
+    if (!name || name.includes('/')) continue; // flat only
+    out.push({name, content: await entry.async('nodebuffer')});
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const keepWorkdir = process.env.KEEP_WORKDIR === '1';
+  const instance = process.env.B2C_INSTANCE;
+
+  const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-docs-refresh-'));
+  const downloadDir = path.join(workdir, 'download');
+  fs.mkdirSync(downloadDir, {recursive: true});
+
+  try {
+    // 1. Download the archive via the CLI (uses the user's default instance/auth).
+    console.log('→ Downloading documentation archive via `b2c docs download`...');
+    const cliArgs = ['docs', 'download', downloadDir, '--keep-archive'];
+    if (instance) cliArgs.push('--instance', instance);
+    run(path.join(REPO_ROOT, 'cli'), cliArgs, REPO_ROOT);
+
+    // 2. Open the outer archive and locate the inner API-doc zip.
+    const outerZipPath = path.join(downloadDir, 'demandware-mock.zip');
+    const outerZip = await JSZip.loadAsync(fs.readFileSync(outerZipPath));
+    const apiDocName = Object.keys(outerZip.files).find((n) => /DWAPP-.*API-doc\.zip$/i.test(n));
+    if (!apiDocName) throw new Error('API documentation archive not found in downloaded package');
+
+    const versionMatch = apiDocName.match(/DWAPP-([\d.]+)-API-doc\.zip$/i);
+    const version = versionMatch?.[1] ?? 'unknown';
+    console.log(`→ Archive version: DWAPP ${version}`);
+
+    const innerZip = await JSZip.loadAsync(await outerZip.files[apiDocName].async('nodebuffer'));
+
+    // 3. Script API markdown.
+    const scriptApi = await entriesUnder(innerZip, 'sfdocs/script-api/');
+    const scriptApiMd = scriptApi.filter((f) => f.name.endsWith('.md'));
+    syncDir(SCRIPT_API_DIR, scriptApiMd, '.md');
+    console.log(`→ Script API: ${scriptApiMd.length} markdown files`);
+
+    // 4. Content / Page Designer JSON schemas.
+    const contentSchemas = (await entriesUnder(innerZip, 'content/')).filter((f) => f.name.endsWith('.json'));
+    syncDir(CONTENT_SCHEMAS_DIR, contentSchemas, '.json');
+    console.log(`→ Content schemas: ${contentSchemas.length} JSON files`);
+
+    // 5. XSD schemas (index.json is regenerated below, so only .xsd is swapped).
+    const xsds = (await entriesUnder(innerZip, 'xsd/')).filter((f) => f.name.endsWith('.xsd'));
+    syncDir(XSD_DIR, xsds, '.xsd');
+    console.log(`→ XSD schemas: ${xsds.length} files`);
+
+    // 6. Job-step HTML → temp dir for the dataset builder.
+    const jobStepHtmlDir = path.join(workdir, 'jobstep-html');
+    fs.mkdirSync(jobStepHtmlDir, {recursive: true});
+    const jobStepHtml = (await entriesUnder(innerZip, 'jobstepapi/html/api/')).filter((f) =>
+      /^jobstep\.[A-Za-z0-9_]+\.html$/.test(f.name),
+    );
+    for (const {name, content} of jobStepHtml) {
+      fs.writeFileSync(path.join(jobStepHtmlDir, name), content);
+    }
+    console.log(`→ Job-step HTML: ${jobStepHtml.length} files`);
+
+    // 7. Regenerate derived artifacts via the existing scripts.
+    console.log('→ Building job-step dataset...');
+    run('pnpm', ['exec', 'tsx', 'scripts/build-job-steps-dataset.ts', jobStepHtmlDir, version], SDK_ROOT);
+
+    console.log('→ Generating job-step docs...');
+    run('pnpm', ['exec', 'tsx', 'scripts/generate-job-steps-docs.ts'], SDK_ROOT);
+
+    console.log('→ Generating search indexes...');
+    run('pnpm', ['exec', 'tsx', 'scripts/generate-docs-index.ts'], SDK_ROOT);
+
+    console.log(`\n✓ Bundled documentation data refreshed to DWAPP ${version}.`);
+    console.log('  Review the diff under packages/b2c-tooling-sdk/data/ before committing.');
+  } finally {
+    if (keepWorkdir) {
+      console.log(`(workdir kept at ${workdir})`);
+    } else {
+      fs.rmSync(workdir, {recursive: true, force: true});
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error('Failed to refresh documentation data:', err);
+  process.exit(1);
+});

--- a/packages/b2c-tooling-sdk/test/operations/content/validate.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/content/validate.test.ts
@@ -334,12 +334,15 @@ describe('content metadefinition validation', () => {
       expect(result.valid).to.equal(true);
     });
 
-    it('passes when component_id is set without embedded', () => {
+    it('fails when component_id is set without embedded', () => {
+      // Per the platform schema, component_id is only valid on embedded
+      // components (embedded:true) — setting it otherwise is rejected.
       const result = validateMetaDefinition(
         {group: 'content', component_id: 'my-comp', region_definitions: [], attribute_definition_groups: []},
         {type: 'componenttype'},
       );
-      expect(result.valid).to.equal(true);
+      expect(result.valid).to.equal(false);
+      expect(result.errors.some((e) => e.message.includes('embedded'))).to.equal(true);
     });
   });
 


### PR DESCRIPTION
## What

Adds a single maintainer script that refreshes **all** the platform-derived data the SDK bundles, and uses it to close a real update gap against the current platform release (**DWAPP 26.7**).

The SDK ships several corpora under `packages/b2c-tooling-sdk/data/`:

| Directory | Contents | Consumed by |
|-----------|----------|-------------|
| `script-api/` | Script API reference markdown + index | `docs search`/`read`, MCP `docs_*` |
| `content-schemas/` | Page Designer / content metadefinition JSON schemas | `content validate` |
| `xsd/` | Import/export XSD schemas + index | `docs schema *`, XML validation |
| `job-steps/` | Standard job-step markdown + dataset + index | `docs search`/`read` |

These all originate from the same `demandware-mock.zip` archive that `b2c docs download` fetches, but each was synced by hand and had drifted independently. The user-facing `docs download` command only extracts Script API markdown — it never updated the bundled data files.

## Changes

- **`scripts/refresh-docs-data.ts`** (`pnpm --filter @salesforce/b2c-tooling-sdk run refresh:docs-data`) — downloads the archive by shelling out to `b2c docs download` (reuses the user's default instance/auth), repopulates every `data/` directory from the inner API-doc zip, and regenerates the derived datasets + search indexes. Prints the detected platform version.
- **Bundled data refreshed to DWAPP 26.7.** The only substantive change was `content-schemas/componenttype.json`, which was stale: 26.7 broadens the `component_id` character set, adds a description, and enforces that `component_id` is only valid on embedded components (`embedded: true`). Other corpora were already current (index diffs are timestamp-only).
- **`build-job-steps-dataset.ts`** now takes the platform version as an argument instead of hardcoding it, so provenance stays accurate on future refreshes.
- **Test update:** the `content validate` test asserting the old `component_id` behavior now reflects the authoritative 26.7 rule.
- **Docs:** the refresh process is documented in the root `README.md` (Documentation section) and the `sdk-module-development` skill.

## Behavior change

`b2c content validate` for `componenttype` metadefinitions now matches the current platform: `component_id` accepts the full platform character set and is rejected unless the component is embedded.

## Manual testing

- Run `pnpm --filter @salesforce/b2c-tooling-sdk run refresh:docs-data` against a sandbox and confirm it reports the platform version and produces a clean diff under `packages/b2c-tooling-sdk/data/` (only `generatedAt` timestamps plus any genuine platform changes).