### PR TITLE
fix(mcp): stop debug tools from routinely suggesting the session cookie

### DIFF
--- a/.changeset/debug-cookie-deemphasize.md
+++ b/.changeset/debug-cookie-deemphasize.md
@@ -1,0 +1,7 @@
+---
+'@salesforce/b2c-dx-mcp': patch
+'@salesforce/b2c-dx-docs': patch
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Stop MCP debug tools from routinely suggesting the session cookie (`dwsid`). The cookie is only needed in the rare multi-app-server production instance group case where a breakpoint is never hit — it is now surfaced as a troubleshooting hint on breakpoint timeout instead of in the `debug_start_session`/`debug_list_sessions` descriptions. Also clarifies that the debugger needs standard Basic auth (account password or a `WebDAV File Access and UX Studio` access key) with no separate Business Manager enablement step.

--- a/docs/guide/script-debugger.md
+++ b/docs/guide/script-debugger.md
@@ -8,10 +8,7 @@ The B2C Commerce **Script Debugger** lets you set breakpoints, step through code
 
 ## Requirements
 
-The debugger needs two things:
-
-1. **The Script Debugger enabled on the instance.** In Business Manager: **Administration → Development Configuration → Script Debugger → Enable**.
-2. **Basic auth credentials** — a Business Manager username and a WebDAV access key (used as the password). OAuth/client credentials are **not** sufficient.
+The debugger needs **Basic auth credentials** — a Business Manager username and either the account password or a `WebDAV File Access and UX Studio` access key (used as the password). OAuth/client credentials are **not** sufficient.
 
 The debugger uses the same resolved credentials as the rest of the CLI (flags, `SFCC_*` environment variables, or `dw.json`). See the [Authentication Guide](/guide/authentication#webdav-access) for access key setup and [CLI Configuration](/guide/configuration) for how credentials are resolved.
 

--- a/docs/mcp/tools/diagnostics.md
+++ b/docs/mcp/tools/diagnostics.md
@@ -12,13 +12,11 @@ Requires **Basic Auth** credentials only. OAuth is not supported by the SDAPI.
 
 **Required:**
 
-- **Basic Auth** - `hostname`, `username`, and `password` (WebDAV access key) for a Business Manager user with the `WebDAV_Manage_Customization` permission.
+- **Basic Auth** - `hostname`, `username`, and `password` — either the account password or a `WebDAV File Access and UX Studio` access key — for a user with the `WebDAV_Manage_Customization` permission.
 
 **Configuration priority:** Flags → Environment variables → `dw.json` config file
 
-The script debugger must also be enabled on the instance: Business Manager > Administration > Development Configuration > Script Debugger > Enable.
-
-See [Configuration](../configuration) for complete credential setup details including flags and environment variables. See [Authentication Setup](../../guide/authentication#webdav-access) for WebDAV access key configuration instructions.
+See [Configuration](../configuration) for complete credential setup details including flags and environment variables. See [Authentication Setup](../../guide/authentication#webdav-access) for access key configuration instructions.
 
 ## Recovery from broken or orphaned sessions
 
@@ -66,9 +64,11 @@ No parameters.
 
 ## Server affinity (hitting breakpoints)
 
-B2C Commerce instances may run multiple application servers behind a load balancer. The debugger attaches to **one** app server, and a breakpoint only fires when your code executes on that same server.
+> **Most sessions don't need this.** Set your breakpoint and trigger the request as usual. Only reach for the session cookie when a breakpoint is _never_ hit even though you're sure the request exercises that code — and only in the specific **production instance group** configurations that run multiple app servers. This never applies to sandboxes.
 
-To pin the triggering request to the correct app server, both `debug_start_session` and `debug_list_sessions` return a `session_cookie`:
+Some production instance group configurations run multiple application servers behind a load balancer. The debugger attaches to **one** app server, and a breakpoint only fires when your code executes on that same server. Sandboxes run a single app server, so this never comes up there.
+
+If a breakpoint won't hit for this reason, pin the triggering request to the correct app server using the `session_cookie` returned by `debug_start_session` and `debug_list_sessions`:
 
 ```json
 {"name": "dwsid", "value": "abc123..."}

--- a/packages/b2c-dx-mcp/src/tools/diagnostics/debug-capture-at-breakpoint.ts
+++ b/packages/b2c-dx-mcp/src/tools/diagnostics/debug-capture-at-breakpoint.ts
@@ -47,7 +47,13 @@ interface CaptureOutput {
   evaluations?: Array<{expression: string; result: string}>;
   auto_continued: boolean;
   trigger_status?: number;
+  hint?: string;
 }
+
+const TIMEOUT_HINT =
+  'Breakpoint not hit. First confirm the triggered request actually exercised this code path and the breakpoint line is reachable. ' +
+  'In some production instance group configurations (which can run multiple app servers — this never applies to sandboxes), a breakpoint may be missed because the request landed on a different app server than the one holding the debug session. ' +
+  'Only in that specific case, retrieve session_cookie from debug_list_sessions and resend the triggering request with that cookie (Cookie: <name>=<value>) to pin it to the app server holding the session.';
 
 export function createDebugCaptureAtBreakpointTool(
   loadServices: () => Promise<Services> | Services,
@@ -128,6 +134,7 @@ export function createDebugCaptureAtBreakpointTool(
             halted: false,
             timed_out: true,
             auto_continued: false,
+            hint: TIMEOUT_HINT,
           };
         }
 

--- a/packages/b2c-dx-mcp/src/tools/diagnostics/debug-list-sessions.ts
+++ b/packages/b2c-dx-mcp/src/tools/diagnostics/debug-list-sessions.ts
@@ -32,8 +32,8 @@ export function createDebugListSessionsTool(
     {
       name: 'debug_list_sessions',
       description:
-        'List active script debugger sessions with their breakpoints, any halted threads, and the session_cookie (e.g. dwsid). ' +
-        'Use this to discover orphaned sessions, check whether breakpoints are armed, poll for halted threads in the non-blocking debug workflow, and retrieve the session cookie to pin a triggering request (Cookie: <name>=<value>) to the app server holding the session.',
+        'List active script debugger sessions with their breakpoints and any halted threads. ' +
+        'Use this to discover orphaned sessions, check whether breakpoints are armed, and poll for halted threads in the non-blocking debug workflow.',
       toolsets: ['CARTRIDGES', 'DIAGNOSTICS', 'SCAPI'],
       inputSchema: {},
       async execute(_args, context) {

--- a/packages/b2c-dx-mcp/src/tools/diagnostics/debug-start-session.ts
+++ b/packages/b2c-dx-mcp/src/tools/diagnostics/debug-start-session.ts
@@ -42,9 +42,7 @@ export function createDebugStartSessionTool(
       description:
         'Start a script debugger session on a B2C Commerce instance to debug SFRA controllers, custom API scripts, hooks, jobs, or any server-side script. ' +
         'Returns a session_id for use with other debug tools, plus discovered cartridge mappings. ' +
-        'Also returns session_cookie (e.g. dwsid): to reliably hit a breakpoint on a multi-app-server instance, send the request that triggers your code (storefront page load, SCAPI/OCAPI call) with this cookie (Cookie: <name>=<value>) so it lands on the same app server holding the debug session. ' +
-        'WARNING: Debug sessions halt remote request threads on the instance. Always call debug_end_session when finished. ' +
-        'Requires Basic auth credentials (username/password) and the script debugger enabled in Business Manager.',
+        'WARNING: Debug sessions halt remote request threads on the instance. Always call debug_end_session when finished.',
       toolsets: ['CARTRIDGES', 'DIAGNOSTICS', 'SCAPI'],
       inputSchema: {
         cartridge_directory: z
@@ -64,8 +62,8 @@ export function createDebugStartSessionTool(
         const credentials = context.services.getBasicAuthCredentials();
         if (!credentials) {
           throw new Error(
-            'Basic auth credentials (hostname, username, password) are required for the script debugger. ' +
-              'Set via SFCC_SERVER/SFCC_USERNAME/SFCC_PASSWORD env vars, or configure in dw.json.',
+            'Basic auth credentials (username/password) are required for the script debugger. ' +
+              'Set via SFCC_SERVER/SFCC_USERNAME/SFCC_PASSWORD env vars, or dw.json.',
           );
         }
 

--- a/packages/b2c-dx-mcp/src/tools/diagnostics/debug-wait-for-stop.ts
+++ b/packages/b2c-dx-mcp/src/tools/diagnostics/debug-wait-for-stop.ts
@@ -25,7 +25,13 @@ interface WaitForStopOutput {
   timed_out?: boolean;
   thread_id?: number;
   location?: MappedLocation;
+  hint?: string;
 }
+
+const TIMEOUT_HINT =
+  'Breakpoint not hit. First confirm the request actually exercised this code path and the breakpoint line is reachable. ' +
+  'In some production instance group configurations (which can run multiple app servers — this never applies to sandboxes), a breakpoint may be missed because the request landed on a different app server than the one holding the debug session. ' +
+  'Only in that specific case, retrieve session_cookie from debug_list_sessions and resend the triggering request with that cookie (Cookie: <name>=<value>) to pin it to the app server holding the session.';
 
 export function createDebugWaitForStopTool(
   loadServices: () => Promise<Services> | Services,
@@ -54,7 +60,7 @@ export function createDebugWaitForStopTool(
         const timeout = Math.min(args.timeout_ms ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 
         const thread = await getRegistry(context).waitForHalt(entry, timeout);
-        if (!thread) return {halted: false, timed_out: true};
+        if (!thread) return {halted: false, timed_out: true, hint: TIMEOUT_HINT};
 
         const location = projectThreadLocation(thread, entry.sourceMapper);
         return {

--- a/skills/b2c-cli/skills/b2c-debug/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-debug/SKILL.md
@@ -21,8 +21,7 @@ Run `b2c setup inspect` to see the resolved configuration and which source provi
 
 ## Prerequisites
 
-- Basic Auth credentials (username/password) for a BM user with `WebDAV_Manage_Customization`
-- Script Debugger enabled: BM > Administration > Development Configuration > Enable Script Debugger
+- Basic Auth credentials for a BM user with `WebDAV_Manage_Customization`: a username and either the account password or a `WebDAV File Access and UX Studio` access key
 
 ## Interactive Debugging
 


### PR DESCRIPTION
## What

The debugger `dwsid` session cookie is only useful in a narrow scenario — certain **production instance group** configurations that run multiple app servers, where a triggering request can land on a different app server than the one holding the debug session and the breakpoint never fires. It never applies to sandboxes.

Because `debug_start_session` and `debug_list_sessions` advertised the cookie in their tool descriptions ("send the request that triggers your code with this cookie…"), coding agents were suggesting users set the cookie as a routine step.

This PR moves the cookie guidance to where it's actually the remedy and cleans up related credential wording.

## Changes

- **`debug_start_session` / `debug_list_sessions`**: removed the cookie instructions from the tool descriptions. The `session_cookie` output field is unchanged — it's still returned for the cases that need it, just no longer advertised as routine.
- **`debug_wait_for_stop` / `debug_capture_at_breakpoint`**: on breakpoint timeout, return a `hint` that first tells the agent to verify the code path is actually exercised, then explains the cookie remedy scoped to multi-app-server production instance groups only (never sandboxes).
- **Credential guidance**: removed the incorrect "enable the Script Debugger in Business Manager" prerequisite (it's always available) and clarified the password can be the account password **or** a `WebDAV File Access and UX Studio` access key. Applied to the MCP tool error, docs, and the `b2c-debug` skill.

## Testing

No manual testing required — behavior is unchanged; only tool/output descriptions and a timeout hint field were adjusted. Automated typecheck, lint, and the MCP test suite pass.