### PR TITLE
@W-23195592 surface custom step types in cartridge view

### DIFF
--- a/.changeset/cartridge-custom-step-types.md
+++ b/.changeset/cartridge-custom-step-types.md
@@ -1,0 +1,10 @@
+---
+'b2c-vs-extension': minor
+---
+
+Surface **Custom Step Types** as a third category under each cartridge in the **Cartridges** explorer, alongside Hooks and Job Steps.
+
+- Custom step types are parsed from any `steptypes.json` under the cartridge (both `script-module-step` and `chunk-script-module-step` categories are supported, and the legacy flat-array shape is tolerated).
+- **Clicking a step type opens its module implementation** (the `.js` file referenced by the `module` field) — resolving across sibling cartridges when the module lives in a different cartridge from where it's registered.
+- **Right-click → Show Step Type Definition** jumps to the `@type-id` line inside `steptypes.json` for the alternate navigation target.
+- Nodes for step types whose module cannot be resolved on disk fall back to opening the JSON definition, so the click always does something useful.

--- a/packages/b2c-vs-extension/.vscode-test.step-types.mjs
+++ b/packages/b2c-vs-extension/.vscode-test.step-types.mjs
@@ -1,0 +1,14 @@
+import {defineConfig} from '@vscode/test-cli';
+
+export default defineConfig([
+  {
+    label: 'jobs-menu-and-step-types',
+    files: ['out/test/jobs-menu.test.js', 'out/test/cartridge-step-types.test.js'],
+    version: 'stable',
+    workspaceFolder: 'src/test/fixtures/empty-workspace',
+    mocha: {
+      ui: 'tdd',
+      timeout: 20000,
+    },
+  },
+]);

--- a/packages/b2c-vs-extension/.vscode-test.step-types.mjs
+++ b/packages/b2c-vs-extension/.vscode-test.step-types.mjs
@@ -3,7 +3,7 @@ import {defineConfig} from '@vscode/test-cli';
 export default defineConfig([
   {
     label: 'jobs-menu-and-step-types',
-    files: ['out/test/jobs-menu.test.js', 'out/test/cartridge-step-types.test.js'],
+    files: ['out/test/jobs-menu.test.js', 'out/test/cartridge-step-types.test.js', 'out/test/jobs-xml-parser.test.js'],
     version: 'stable',
     workspaceFolder: 'src/test/fixtures/empty-workspace',
     mocha: {

--- a/packages/b2c-vs-extension/package.json
+++ b/packages/b2c-vs-extension/package.json
@@ -843,7 +843,7 @@
         },
         {
           "id": "b2cJobsExplorer",
-          "name": "Job History",
+          "name": "Jobs",
           "icon": "media/b2c-icon.svg",
           "contextualTitle": "B2C-DX",
           "visibility": "collapsed"
@@ -905,7 +905,7 @@
       {
         "view": "b2cJobsExplorer",
         "when": "!b2c-dx.jobs.needsOAuth",
-        "contents": "Job History is not loaded by default to avoid unwanted OCAPI traffic.\n\n[Refresh Now](command:b2c-dx.jobs.refresh)\n[Enable Auto-Refresh](command:b2c-dx.jobs.toggleAutoRefresh)\n[Run Job](command:b2c-dx.jobs.run)\n[Open in Business Manager](command:b2c-dx.jobs.openBmDefinitions)"
+        "contents": "Jobs view is not loaded by default to avoid unwanted OCAPI traffic.\n\n[Refresh Now](command:b2c-dx.jobs.refresh)\n[Enable Auto-Refresh](command:b2c-dx.jobs.toggleAutoRefresh)\n[Run Job](command:b2c-dx.jobs.run)\n[Open in Business Manager](command:b2c-dx.jobs.openBmDefinitions)"
       },
       {
         "view": "b2cCartridgeExplorer",
@@ -1228,6 +1228,12 @@
         "command": "b2c-dx.jobs.run",
         "title": "Run Job",
         "icon": "$(play)",
+        "category": "B2C DX - Job History"
+      },
+      {
+        "command": "b2c-dx.jobs.openDefinitionFile",
+        "title": "Open jobs.xml",
+        "icon": "$(go-to-file)",
         "category": "B2C DX - Job History"
       },
       {
@@ -2109,6 +2115,16 @@
           "group": "1_lifecycle@1"
         },
         {
+          "command": "b2c-dx.jobs.run",
+          "when": "view == b2cJobsExplorer && viewItem == workspaceJob",
+          "group": "1_lifecycle@1"
+        },
+        {
+          "command": "b2c-dx.jobs.openDefinitionFile",
+          "when": "view == b2cJobsExplorer && viewItem == workspaceJob",
+          "group": "2_navigation@1"
+        },
+        {
           "command": "b2c-dx.jobs.viewExecutionDetails",
           "when": "view == b2cJobsExplorer && viewItem =~ /^jobExecution-/",
           "group": "1_info@1"
@@ -2236,6 +2252,10 @@
         },
         {
           "command": "b2c-dx.jobs.clearAllFilters",
+          "when": "false"
+        },
+        {
+          "command": "b2c-dx.jobs.openDefinitionFile",
           "when": "false"
         },
         {

--- a/packages/b2c-vs-extension/package.json
+++ b/packages/b2c-vs-extension/package.json
@@ -1153,6 +1153,18 @@
         "category": "B2C DX - Job History"
       },
       {
+        "command": "b2c-dx.jobs.openFiltersActive",
+        "title": "Filter Job History (filters active)",
+        "icon": "$(filter-filled)",
+        "category": "B2C DX - Job History"
+      },
+      {
+        "command": "b2c-dx.jobs.clearAllFilters",
+        "title": "Clear All Job History Filters",
+        "icon": "$(clear-all)",
+        "category": "B2C DX - Job History"
+      },
+      {
         "command": "b2c-dx.jobs.refresh",
         "title": "Refresh",
         "icon": "$(refresh)",
@@ -1836,7 +1848,12 @@
         },
         {
           "command": "b2c-dx.jobs.openFilters",
-          "when": "view == b2cJobsExplorer",
+          "when": "view == b2cJobsExplorer && !b2c-dx.jobs.hasActiveFilters",
+          "group": "navigation@4"
+        },
+        {
+          "command": "b2c-dx.jobs.openFiltersActive",
+          "when": "view == b2cJobsExplorer && b2c-dx.jobs.hasActiveFilters",
           "group": "navigation@4"
         },
         {
@@ -2211,6 +2228,14 @@
       "commandPalette": [
         {
           "command": "b2c-dx.isml.createTemplate",
+          "when": "false"
+        },
+        {
+          "command": "b2c-dx.jobs.openFiltersActive",
+          "when": "false"
+        },
+        {
+          "command": "b2c-dx.jobs.clearAllFilters",
           "when": "false"
         },
         {

--- a/packages/b2c-vs-extension/package.json
+++ b/packages/b2c-vs-extension/package.json
@@ -1213,6 +1213,12 @@
         "category": "B2C DX - Job History"
       },
       {
+        "command": "b2c-dx.jobs.toggleGroupingChronological",
+        "title": "Show as Chronological Timeline",
+        "icon": "$(list-tree)",
+        "category": "B2C DX - Job History"
+      },
+      {
         "command": "b2c-dx.jobs.importSiteArchive",
         "title": "Import Site Archive",
         "icon": "$(cloud-upload)",
@@ -1844,7 +1850,12 @@
         },
         {
           "command": "b2c-dx.jobs.toggleGrouping",
-          "when": "view == b2cJobsExplorer",
+          "when": "view == b2cJobsExplorer && b2c-dx.jobs.groupingMode != groupByJobId",
+          "group": "navigation@2"
+        },
+        {
+          "command": "b2c-dx.jobs.toggleGroupingChronological",
+          "when": "view == b2cJobsExplorer && b2c-dx.jobs.groupingMode == groupByJobId",
           "group": "navigation@2"
         },
         {
@@ -2186,7 +2197,7 @@
         },
         {
           "command": "b2c-dx.cartridge.openStepTypeDefinition",
-          "when": "view == b2cCartridgeExplorer && viewItem == cartridge-step-type",
+          "when": "view == b2cCartridgeExplorer && viewItem =~ /^cartridge-step-type/",
           "group": "navigation@1"
         }
       ],
@@ -2400,6 +2411,10 @@
         },
         {
           "command": "b2c-dx.cartridge.openStepTypeDefinition",
+          "when": "false"
+        },
+        {
+          "command": "b2c-dx.jobs.toggleGroupingChronological",
           "when": "false"
         },
         {

--- a/packages/b2c-vs-extension/package.json
+++ b/packages/b2c-vs-extension/package.json
@@ -1225,6 +1225,12 @@
         "category": "B2C DX - Job Definitions"
       },
       {
+        "command": "b2c-dx.cartridge.openStepTypeDefinition",
+        "title": "Show Step Type Definition",
+        "icon": "$(go-to-file)",
+        "category": "B2C DX - Cartridges"
+      },
+      {
         "command": "b2c-dx.jobs.rerun",
         "title": "Re-Run Job",
         "icon": "$(debug-restart)",
@@ -2144,6 +2150,11 @@
           "command": "b2c-dx.jobs.createScaffold",
           "when": "view == b2cCartridgeExplorer && viewItem == cartridge",
           "group": "4_scaffold@1"
+        },
+        {
+          "command": "b2c-dx.cartridge.openStepTypeDefinition",
+          "when": "view == b2cCartridgeExplorer && viewItem == cartridge-step-type",
+          "group": "navigation@1"
         }
       ],
       "file/newFile": [
@@ -2340,6 +2351,10 @@
         },
         {
           "command": "b2c-dx.jobs.disableAutoRefresh",
+          "when": "false"
+        },
+        {
+          "command": "b2c-dx.cartridge.openStepTypeDefinition",
           "when": "false"
         },
         {

--- a/packages/b2c-vs-extension/src/code-sync/cartridge-tree-provider.ts
+++ b/packages/b2c-vs-extension/src/code-sync/cartridge-tree-provider.ts
@@ -12,16 +12,19 @@ import type {CartridgeService} from '../cartridges/cartridge-service.js';
 /**
  * The Cartridges tree was originally a flat list of cartridge mappings. Per the
  * post-W-22653699 review feedback, it now expands into the cartridge contents
- * developers actually act on — starting with hooks and job steps. Each cartridge
- * shows two "category" children: Hooks and Job Steps, populated from a hand-rolled
- * scan of the cartridge folder (we don't want to depend on the full server-side
+ * developers actually act on — hooks, job steps, and custom step types. Each
+ * cartridge shows three "category" children, populated from a hand-rolled scan
+ * of the cartridge folder (we don't want to depend on the full server-side
  * deploy pipeline just to render the tree).
- *
- * Surfacing custom step *types* with jump-to-module-implementation (mapping
- * steptypes.json `module` → file) is tracked separately and is intentionally not
- * implemented here.
  */
-export type CartridgeNode = CartridgeItem | CartridgeCategoryItem | CartridgeFileItem | CartridgeCategoryEmptyItem;
+export type CartridgeCategory = 'hooks' | 'jobSteps' | 'stepTypes';
+
+export type CartridgeNode =
+  | CartridgeItem
+  | CartridgeCategoryItem
+  | CartridgeFileItem
+  | CartridgeStepTypeItem
+  | CartridgeCategoryEmptyItem;
 
 export class CartridgeItem extends vscode.TreeItem {
   readonly kind = 'cartridge' as const;
@@ -42,18 +45,35 @@ export class CartridgeItem extends vscode.TreeItem {
   }
 }
 
-/** Grouping node beneath a cartridge ("Hooks", "Job Steps", ...). */
+const CATEGORY_LABELS: Record<CartridgeCategory, string> = {
+  hooks: 'Hooks',
+  jobSteps: 'Job Steps',
+  stepTypes: 'Custom Step Types',
+};
+
+const CATEGORY_ICONS: Record<CartridgeCategory, string> = {
+  hooks: 'plug',
+  jobSteps: 'list-ordered',
+  stepTypes: 'symbol-method',
+};
+
+const CATEGORY_EMPTY_HINTS: Record<CartridgeCategory, {label: string; description: string}> = {
+  hooks: {label: 'No hooks registered', description: 'Add a hooks.json to register one'},
+  jobSteps: {label: 'No job step modules found', description: 'Drop a script into cartridge/scripts/jobsteps/'},
+  stepTypes: {label: 'No custom step types registered', description: 'Add a steptypes.json in the cartridge root'},
+};
+
+/** Grouping node beneath a cartridge ("Hooks", "Job Steps", "Custom Step Types"). */
 export class CartridgeCategoryItem extends vscode.TreeItem {
   readonly kind = 'category' as const;
 
   constructor(
     readonly cartridge: CartridgeMapping,
-    readonly category: 'hooks' | 'jobSteps',
+    readonly category: CartridgeCategory,
   ) {
-    const label = category === 'hooks' ? 'Hooks' : 'Job Steps';
-    super(label, vscode.TreeItemCollapsibleState.Collapsed);
+    super(CATEGORY_LABELS[category], vscode.TreeItemCollapsibleState.Collapsed);
     this.id = `cart-cat:${cartridge.src}:${category}`;
-    this.iconPath = new vscode.ThemeIcon(category === 'hooks' ? 'plug' : 'list-ordered');
+    this.iconPath = new vscode.ThemeIcon(CATEGORY_ICONS[category]);
     this.contextValue = `cartridge-${category}`;
   }
 }
@@ -67,14 +87,13 @@ export class CartridgeCategoryEmptyItem extends vscode.TreeItem {
 
   constructor(
     readonly cartridge: CartridgeMapping,
-    readonly category: 'hooks' | 'jobSteps',
+    readonly category: CartridgeCategory,
   ) {
-    const label = category === 'hooks' ? 'No hooks registered' : 'No job step modules found';
-    super(label, vscode.TreeItemCollapsibleState.None);
+    const hint = CATEGORY_EMPTY_HINTS[category];
+    super(hint.label, vscode.TreeItemCollapsibleState.None);
     this.id = `cart-cat-empty:${cartridge.src}:${category}`;
     this.iconPath = new vscode.ThemeIcon('info');
-    this.description =
-      category === 'hooks' ? 'Add a hooks.json to register one' : 'Drop a script into cartridge/scripts/jobsteps/';
+    this.description = hint.description;
     this.contextValue = `cartridge-${category}-empty`;
   }
 }
@@ -99,6 +118,68 @@ export class CartridgeFileItem extends vscode.TreeItem {
       title: 'Open',
       arguments: [vscode.Uri.file(filePath)],
     };
+  }
+}
+
+/**
+ * Parsed shape of one custom step type entry (`script-module-step` or
+ * `chunk-script-module-step`) registered in a cartridge's `steptypes.json`.
+ */
+export interface StepTypeEntry {
+  /** `@type-id` value, e.g. "custom.MyImportStep". */
+  readonly typeId: string;
+  /** Which category the entry was declared under — displayed as a badge. */
+  readonly kind: 'task' | 'chunk';
+  /**
+   * The `module` field verbatim, e.g. "app_custom_core/cartridge/scripts/jobsteps/myStep".
+   * May or may not include a `.js` suffix. May reference a different cartridge.
+   */
+  readonly moduleRef: string;
+  /** Absolute path to the `steptypes.json` that declared this entry. */
+  readonly stepTypesPath: string;
+}
+
+/**
+ * Leaf node for a single custom step type. Default click opens the resolved
+ * module implementation (the `.js` file). Right-click offers "Show Step Type
+ * Definition" which jumps to the `@type-id` line inside `steptypes.json`.
+ */
+export class CartridgeStepTypeItem extends vscode.TreeItem {
+  readonly kind = 'stepType' as const;
+
+  constructor(
+    readonly entry: StepTypeEntry,
+    readonly cartridgeRoot: string,
+    /** Resolved absolute path to the module `.js` — undefined if unresolvable. */
+    readonly moduleFile: string | undefined,
+  ) {
+    super(entry.typeId, vscode.TreeItemCollapsibleState.None);
+    this.id = `cart-step-type:${entry.stepTypesPath}:${entry.typeId}`;
+    this.description = entry.kind === 'chunk' ? 'chunk' : 'task';
+    this.iconPath = new vscode.ThemeIcon('symbol-method');
+    this.tooltip = moduleFile
+      ? `${entry.typeId}\n${entry.moduleRef}\n→ ${moduleFile}`
+      : `${entry.typeId}\n${entry.moduleRef}\n(module could not be resolved on disk)`;
+    this.contextValue = moduleFile ? 'cartridge-step-type' : 'cartridge-step-type-unresolved';
+
+    // Default click → jump to the module implementation. This is what a
+    // developer usually wants (edit the code). Jumping to the JSON entry is
+    // offered as a right-click action ("Show Step Type Definition").
+    if (moduleFile) {
+      this.command = {
+        command: 'vscode.open',
+        title: 'Open Module Implementation',
+        arguments: [vscode.Uri.file(moduleFile)],
+      };
+    } else {
+      // Fall back to opening the steptypes.json entry so the click still does
+      // something useful when we can't find the module file.
+      this.command = {
+        command: 'b2c-dx.cartridge.openStepTypeDefinition',
+        title: 'Show Step Type Definition',
+        arguments: [entry.typeId, entry.stepTypesPath],
+      };
+    }
   }
 }
 
@@ -131,6 +212,7 @@ export class CartridgeTreeProvider implements vscode.TreeDataProvider<CartridgeN
       return [
         new CartridgeCategoryItem(element.cartridge, 'hooks'),
         new CartridgeCategoryItem(element.cartridge, 'jobSteps'),
+        new CartridgeCategoryItem(element.cartridge, 'stepTypes'),
       ];
     }
 
@@ -142,10 +224,9 @@ export class CartridgeTreeProvider implements vscode.TreeDataProvider<CartridgeN
   }
 
   /**
-   * Enumerates the files for a category. Hooks are detected by `hooks.json`
-   * registrations under the cartridge; job steps come from
-   * `cartridge/scripts/jobsteps/`. Both fall back to globbing if conventional
-   * locations are missing.
+   * Enumerates the children for a category. Hooks come from `hooks.json`
+   * registrations; job-step files from `cartridge/scripts/jobsteps/`; custom
+   * step types from any `steptypes.json` in the cartridge root or under it.
    */
   private async getCategoryChildren(node: CartridgeCategoryItem): Promise<CartridgeNode[]> {
     const cartridgeRoot = node.cartridge.src;
@@ -156,9 +237,25 @@ export class CartridgeTreeProvider implements vscode.TreeDataProvider<CartridgeN
       return files.map((file) => new CartridgeFileItem(file, cartridgeRoot));
     }
 
-    const files = await collectJobStepFiles(cartridgeRoot);
-    if (files.length === 0) return [new CartridgeCategoryEmptyItem(node.cartridge, 'jobSteps')];
-    return files.map((file) => new CartridgeFileItem(file, cartridgeRoot));
+    if (node.category === 'jobSteps') {
+      const files = await collectJobStepFiles(cartridgeRoot);
+      if (files.length === 0) return [new CartridgeCategoryEmptyItem(node.cartridge, 'jobSteps')];
+      return files.map((file) => new CartridgeFileItem(file, cartridgeRoot));
+    }
+
+    const entries = await collectStepTypeEntries(cartridgeRoot);
+    if (entries.length === 0) return [new CartridgeCategoryEmptyItem(node.cartridge, 'stepTypes')];
+
+    const otherRoots = this.cartridgeService
+      .getCartridges()
+      .map((c) => c.src)
+      .filter((src) => src !== cartridgeRoot);
+    return Promise.all(
+      entries.map(async (entry) => {
+        const moduleFile = await resolveStepTypeModule(entry.moduleRef, cartridgeRoot, otherRoots);
+        return new CartridgeStepTypeItem(entry, cartridgeRoot, moduleFile);
+      }),
+    );
   }
 
   dispose(): void {
@@ -249,6 +346,147 @@ async function collectJobStepFiles(cartridgeRoot: string): Promise<string[]> {
   if (!(await pathExists(scriptsDir))) return [];
   const all = await findFiles(scriptsDir, (name) => name.endsWith('.js') || name.endsWith('.ts'));
   return all.filter((file) => file.toLowerCase().includes('jobstep'));
+}
+
+/**
+ * Reads every `steptypes.json` under the cartridge and flattens the registered
+ * step type entries. B2C requires `step-types` to be an object keyed by
+ * category (`script-module-step` for task steps, `chunk-script-module-step` for
+ * chunk steps), but tooling has historically also written a flat array — we
+ * tolerate both. Malformed files are skipped silently since they are common
+ * during edits.
+ */
+export async function collectStepTypeEntries(cartridgeRoot: string): Promise<StepTypeEntry[]> {
+  const results: StepTypeEntry[] = [];
+  const stepTypesFiles = await findFiles(cartridgeRoot, (name) => name === 'steptypes.json');
+
+  for (const stepTypesPath of stepTypesFiles) {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(await fs.readFile(stepTypesPath, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const stepTypes = parsed['step-types'];
+    for (const {entries, kind} of expandStepTypeCategories(stepTypes)) {
+      for (const entry of entries) {
+        const typeId = typeof entry['@type-id'] === 'string' ? (entry['@type-id'] as string) : undefined;
+        const moduleRef = typeof entry.module === 'string' ? (entry.module as string) : undefined;
+        if (!typeId || !moduleRef) continue;
+        results.push({typeId, kind, moduleRef, stepTypesPath});
+      }
+    }
+  }
+
+  return results.sort((a, b) => a.typeId.localeCompare(b.typeId));
+}
+
+/**
+ * Normalizes the shape variants of the `step-types` node into a flat list of
+ * `{entries, kind}` pairs. Handles the two documented forms plus the untagged
+ * flat-array form some legacy scaffolders emit.
+ */
+function expandStepTypeCategories(
+  stepTypes: unknown,
+): Array<{entries: Array<Record<string, unknown>>; kind: 'task' | 'chunk'}> {
+  if (!stepTypes) return [];
+
+  if (Array.isArray(stepTypes)) {
+    // Flat form: assume task steps (the more common category). Consumers who
+    // author chunk steps in this shape are rare; we'd rather show them than
+    // hide them behind a strict shape check.
+    return [{entries: stepTypes as Array<Record<string, unknown>>, kind: 'task'}];
+  }
+
+  if (typeof stepTypes !== 'object') return [];
+
+  const record = stepTypes as Record<string, unknown>;
+  const groups: Array<{entries: Array<Record<string, unknown>>; kind: 'task' | 'chunk'}> = [];
+  const taskEntries = record['script-module-step'];
+  if (Array.isArray(taskEntries)) {
+    groups.push({entries: taskEntries as Array<Record<string, unknown>>, kind: 'task'});
+  }
+  const chunkEntries = record['chunk-script-module-step'];
+  if (Array.isArray(chunkEntries)) {
+    groups.push({entries: chunkEntries as Array<Record<string, unknown>>, kind: 'chunk'});
+  }
+  return groups;
+}
+
+/**
+ * Resolves a step type `module` reference to an absolute file path on disk.
+ *
+ * `module` is expected to be cartridge-scoped, e.g.
+ * `app_custom_core/cartridge/scripts/jobsteps/myStep` (extension optional).
+ * The first path segment is the owning cartridge — which may or may not be the
+ * cartridge that *declares* the step type, so we try the containing cartridge
+ * first and then fall back to any other workspace cartridge with a matching
+ * name. Returns undefined when nothing resolves (typo, cartridge outside the
+ * workspace, etc.).
+ */
+export async function resolveStepTypeModule(
+  moduleRef: string,
+  cartridgeRoot: string,
+  otherCartridgeRoots: readonly string[],
+): Promise<string | undefined> {
+  const trimmed = moduleRef.trim();
+  if (!trimmed) return undefined;
+
+  const segments = trimmed.split('/').filter(Boolean);
+  if (segments.length === 0) return undefined;
+
+  const [firstSegment, ...rest] = segments;
+  const relWithoutCartridge = rest.length > 0 ? rest.join('/') : firstSegment;
+  const declaringCartridgeName = path.basename(cartridgeRoot);
+
+  const withJsExt = (candidate: string): string[] =>
+    candidate.endsWith('.js') ? [candidate] : [candidate, `${candidate}.js`];
+
+  const candidateBases: string[] = [];
+
+  // 1. Try treating the first segment as the cartridge prefix and looking
+  //    inside the declaring cartridge. Covers "<self>/cartridge/scripts/...".
+  if (firstSegment === declaringCartridgeName) {
+    candidateBases.push(path.join(cartridgeRoot, relWithoutCartridge));
+  }
+  // 2. Try the module path as-is under the declaring cartridge (legacy form
+  //    without the cartridge prefix, e.g. "cartridge/scripts/...").
+  candidateBases.push(path.join(cartridgeRoot, trimmed));
+
+  // 3. Look across other workspace cartridges when the module names a
+  //    different cartridge (some teams register step types in one cartridge
+  //    but implement them in a shared "core" cartridge).
+  for (const otherRoot of otherCartridgeRoots) {
+    if (path.basename(otherRoot) === firstSegment) {
+      candidateBases.push(path.join(otherRoot, relWithoutCartridge));
+    }
+  }
+
+  for (const base of candidateBases) {
+    for (const candidate of withJsExt(base)) {
+      if (await pathExists(candidate)) return candidate;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Opens `steptypes.json` and jumps the cursor to the line where the given
+ * `@type-id` is declared. Falls back to opening the file at the top if the id
+ * can't be located (e.g. the file was edited between refresh and click).
+ */
+export async function openStepTypeDefinition(typeId: string, stepTypesPath: string): Promise<void> {
+  const uri = vscode.Uri.file(stepTypesPath);
+  const doc = await vscode.workspace.openTextDocument(uri);
+  const text = doc.getText();
+  const escaped = typeId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = text.match(new RegExp(`"@type-id"\\s*:\\s*"${escaped}"`));
+  const options: vscode.TextDocumentShowOptions = {preview: true};
+  if (match && typeof match.index === 'number') {
+    const position = doc.positionAt(match.index);
+    options.selection = new vscode.Range(position, position);
+  }
+  await vscode.window.showTextDocument(doc, options);
 }
 
 /**

--- a/packages/b2c-vs-extension/src/code-sync/index.ts
+++ b/packages/b2c-vs-extension/src/code-sync/index.ts
@@ -8,7 +8,7 @@ import type {CartridgeService} from '../cartridges/cartridge-service.js';
 import type {B2CExtensionConfig} from '../config-provider.js';
 import {registerSafeCommand} from '../safety.js';
 import {CodeSyncManager} from './code-sync-manager.js';
-import {CartridgeTreeProvider, CartridgeItem} from './cartridge-tree-provider.js';
+import {CartridgeTreeProvider, CartridgeItem, openStepTypeDefinition} from './cartridge-tree-provider.js';
 import {createDeployCommand, createDeployOneCommand} from './deploy-command.js';
 import {registerCartridgeCommands, updateCodeVersionDisplay} from './cartridge-commands.js';
 
@@ -88,6 +88,17 @@ export function registerCodeSync(
       // best-effort
     }
   });
+
+  // Jumps to the @type-id line inside the cartridge's steptypes.json. The
+  // default click on a step type node opens the module (.js) implementation;
+  // this command is the alternative offered via the right-click menu.
+  const openStepTypeDefinitionCmd = registerSafeCommand(
+    'b2c-dx.cartridge.openStepTypeDefinition',
+    async (typeId?: string, stepTypesPath?: string) => {
+      if (!typeId || !stepTypesPath) return;
+      await openStepTypeDefinition(typeId, stepTypesPath);
+    },
+  );
 
   const uploadToInstanceCmd = registerSafeCommand('b2c-dx.codeSync.uploadToInstance', async (uri?: vscode.Uri) => {
     if (!uri) return;
@@ -175,6 +186,7 @@ export function registerCodeSync(
     deployOneCmd,
     refreshCmd,
     uploadCartridgeCmd,
+    openStepTypeDefinitionCmd,
     uploadToInstanceCmd,
     cartridgesSub,
     ...cartridgeCmdDisposables,

--- a/packages/b2c-vs-extension/src/code-sync/index.ts
+++ b/packages/b2c-vs-extension/src/code-sync/index.ts
@@ -8,7 +8,12 @@ import type {CartridgeService} from '../cartridges/cartridge-service.js';
 import type {B2CExtensionConfig} from '../config-provider.js';
 import {registerSafeCommand} from '../safety.js';
 import {CodeSyncManager} from './code-sync-manager.js';
-import {CartridgeTreeProvider, CartridgeItem, openStepTypeDefinition} from './cartridge-tree-provider.js';
+import {
+  CartridgeTreeProvider,
+  CartridgeItem,
+  CartridgeStepTypeItem,
+  openStepTypeDefinition,
+} from './cartridge-tree-provider.js';
 import {createDeployCommand, createDeployOneCommand} from './deploy-command.js';
 import {registerCartridgeCommands, updateCodeVersionDisplay} from './cartridge-commands.js';
 
@@ -92,11 +97,25 @@ export function registerCodeSync(
   // Jumps to the @type-id line inside the cartridge's steptypes.json. The
   // default click on a step type node opens the module (.js) implementation;
   // this command is the alternative offered via the right-click menu.
+  //
+  // Two invocation shapes: (a) the default-click path from
+  // `TreeItem.command.arguments` passes `(typeId, stepTypesPath)`; (b) the
+  // right-click menu path from `view/item/context` passes the TreeItem itself
+  // as the first arg. Handle both so neither is silently dropped.
   const openStepTypeDefinitionCmd = registerSafeCommand(
     'b2c-dx.cartridge.openStepTypeDefinition',
-    async (typeId?: string, stepTypesPath?: string) => {
-      if (!typeId || !stepTypesPath) return;
-      await openStepTypeDefinition(typeId, stepTypesPath);
+    async (typeIdOrItem?: string | CartridgeStepTypeItem, stepTypesPath?: string) => {
+      let typeId: string | undefined;
+      let resolvedPath: string | undefined;
+      if (typeIdOrItem instanceof CartridgeStepTypeItem) {
+        typeId = typeIdOrItem.entry.typeId;
+        resolvedPath = typeIdOrItem.entry.stepTypesPath;
+      } else {
+        typeId = typeIdOrItem;
+        resolvedPath = stepTypesPath;
+      }
+      if (!typeId || !resolvedPath) return;
+      await openStepTypeDefinition(typeId, resolvedPath);
     },
   );
 

--- a/packages/b2c-vs-extension/src/jobs/index.ts
+++ b/packages/b2c-vs-extension/src/jobs/index.ts
@@ -94,7 +94,7 @@ export function registerJobs(context: vscode.ExtensionContext, configProvider: B
   const onDidChangeTreeSub = treeProvider.onDidChangeTreeData(() => updateJobHistoryMessage());
 
   const builtInScaffoldsDir = path.join(context.extensionPath, 'dist', 'data', 'scaffolds');
-  const commandDisposables = registerJobsCommands(configProvider, treeProvider, {
+  const commandDisposables = registerJobsCommands(configProvider, treeProvider, treeView, {
     builtInScaffoldsDir,
     extensionUri: context.extensionUri,
     onAutoRefreshChanged: (enabled) => {
@@ -102,6 +102,16 @@ export function registerJobs(context: vscode.ExtensionContext, configProvider: B
       updateJobHistoryMessage();
     },
   });
+
+  // Keep the Workspace Jobs section in sync with the filesystem — edits and
+  // scaffolds appear the moment the underlying jobs.xml is saved instead of
+  // waiting for the next Refresh. Scoped to jobs.xml, so unrelated file churn
+  // never triggers a re-render of the tree.
+  const jobsXmlWatcher = vscode.workspace.createFileSystemWatcher('**/jobs.xml');
+  const onJobsXmlChanged = (): void => treeProvider.invalidateWorkspaceJobs();
+  jobsXmlWatcher.onDidCreate(onJobsXmlChanged);
+  jobsXmlWatcher.onDidChange(onJobsXmlChanged);
+  jobsXmlWatcher.onDidDelete(onJobsXmlChanged);
 
   configProvider.onDidReset(() => {
     treeProvider.stopPolling();

--- a/packages/b2c-vs-extension/src/jobs/index.ts
+++ b/packages/b2c-vs-extension/src/jobs/index.ts
@@ -41,7 +41,12 @@ export function registerJobs(context: vscode.ExtensionContext, configProvider: B
     }
     const refreshLabel = lastRefresh ? lastRefresh.toLocaleTimeString() : '—';
     const autoLabel = treeProvider.isPollingEnabled() ? ' · Auto-Refresh on' : '';
-    treeView.message = `Updated ${refreshLabel}${autoLabel}`;
+    // Prepend an explicit filter summary whenever any filter is narrowing the
+    // tree. This is the primary "hey, results are being hidden" signal — the
+    // title-bar icon swap alone was too easy to miss.
+    const filterSummary = treeProvider.describeActiveFilters();
+    const filterLabel = filterSummary ? `Filters: ${filterSummary} · ` : '';
+    treeView.message = `${filterLabel}Updated ${refreshLabel}${autoLabel}`;
   };
   updateJobHistoryMessage();
 
@@ -82,6 +87,12 @@ export function registerJobs(context: vscode.ExtensionContext, configProvider: B
   // above — visible as a noticeable lag after pressing Refresh.
   const onDidLoadSub = treeProvider.onDidLoad(() => updateJobHistoryMessage());
 
+  // Filter changes fire onDidChangeTreeData (not onDidLoad), so subscribe there
+  // too — otherwise the "Filters: …" prefix in the message would lag until the
+  // next 5s timer tick (or the next fetch). Fast-path only; the fire itself is
+  // already gated to real state changes inside the provider.
+  const onDidChangeTreeSub = treeProvider.onDidChangeTreeData(() => updateJobHistoryMessage());
+
   const builtInScaffoldsDir = path.join(context.extensionPath, 'dist', 'data', 'scaffolds');
   const commandDisposables = registerJobsCommands(configProvider, treeProvider, {
     builtInScaffoldsDir,
@@ -100,7 +111,7 @@ export function registerJobs(context: vscode.ExtensionContext, configProvider: B
     updateJobHistoryMessage();
   });
 
-  context.subscriptions.push(treeView, onDidLoadSub, ...commandDisposables, {
+  context.subscriptions.push(treeView, onDidLoadSub, onDidChangeTreeSub, ...commandDisposables, {
     dispose: () => {
       clearInterval(messageRefreshTimer);
       treeProvider.stopPolling();

--- a/packages/b2c-vs-extension/src/jobs/index.ts
+++ b/packages/b2c-vs-extension/src/jobs/index.ts
@@ -107,8 +107,17 @@ export function registerJobs(context: vscode.ExtensionContext, configProvider: B
   // scaffolds appear the moment the underlying jobs.xml is saved instead of
   // waiting for the next Refresh. Scoped to jobs.xml, so unrelated file churn
   // never triggers a re-render of the tree.
+  //
+  // Filter out matches inside dependency / build output directories:
+  // `createFileSystemWatcher` doesn't honor `files.exclude`, and a jobs.xml
+  // shipped inside a dependency or a build artifact is not workspace code we
+  // want to surface — those events would cause pointless tree re-renders.
   const jobsXmlWatcher = vscode.workspace.createFileSystemWatcher('**/jobs.xml');
-  const onJobsXmlChanged = (): void => treeProvider.invalidateWorkspaceJobs();
+  const IGNORED_WATCHER_SEGMENTS = /[/\\](?:node_modules|dist|out|build|\.git)[/\\]/;
+  const onJobsXmlChanged = (uri: vscode.Uri): void => {
+    if (IGNORED_WATCHER_SEGMENTS.test(uri.fsPath)) return;
+    treeProvider.invalidateWorkspaceJobs();
+  };
   jobsXmlWatcher.onDidCreate(onJobsXmlChanged);
   jobsXmlWatcher.onDidChange(onJobsXmlChanged);
   jobsXmlWatcher.onDidDelete(onJobsXmlChanged);

--- a/packages/b2c-vs-extension/src/jobs/jobs-commands.ts
+++ b/packages/b2c-vs-extension/src/jobs/jobs-commands.ts
@@ -33,6 +33,7 @@ import type {
   JobTreeItem,
   JobsTreeDataProvider,
 } from './jobs-tree-provider.js';
+import {extractJobBlockXml, extractJobIdsFromXml, findJobBlockOffset, stripXmlComments} from './jobs-xml-parser.js';
 
 const JOB_DETAILS_SCHEME = 'b2c-job-details';
 /** Built-in SDK scaffold that generates a custom job step + steptypes.json registration. */
@@ -639,12 +640,20 @@ async function mergeJobIntoJobsXml(jobsXmlPath: string, spec: JobScaffoldSpec): 
 
   const jobBlock = buildJobBlockXml(spec);
   const jobIdPattern = escapeRegExp(spec.jobId);
-  // Match an existing <job job-id="<this id>"> … </job> block (any attribute order).
-  const existingJobRegex = new RegExp(`[ \\t]*<job\\b[^>]*\\bjob-id="${jobIdPattern}"[\\s\\S]*?</job>\\n?`, 'i');
+  // Attribute order isn't guaranteed by the XSD; either quote style is legal.
+  const existingJobRegex = new RegExp(
+    `[ \\t]*<job\\b[^>]*\\bjob-id\\s*=\\s*(["'])${jobIdPattern}\\1[\\s\\S]*?</job>\\n?`,
+    'i',
+  );
+
+  // Detect "already declared" against a comment-stripped copy so a commented-out
+  // block doesn't trigger a replace (which would rewrite the comment away). But
+  // apply the actual write to the raw content so comments and formatting outside
+  // the block are preserved.
+  const alreadyDeclared = existingJobRegex.test(stripXmlComments(existing));
 
   let updated: string;
-  if (existingJobRegex.test(existing)) {
-    // Re-scaffold of the same job-id → replace that block in place.
+  if (alreadyDeclared) {
     updated = existing.replace(existingJobRegex, `${jobBlock}\n`);
   } else {
     // New job-id → insert before the closing </jobs>.
@@ -807,12 +816,8 @@ async function getWorkspaceJobIds(): Promise<string[]> {
       } catch {
         continue;
       }
-      // Match <job job-id="..."> — attribute order is not guaranteed by the XSD.
-      const jobRegex = /<job\b[^>]*\bjob-id="([^"]+)"/gi;
-      let match: RegExpExecArray | null;
-      while ((match = jobRegex.exec(content)) !== null) {
-        const id = match[1]?.trim();
-        if (id) ids.add(id);
+      for (const id of extractJobIdsFromXml(content)) {
+        ids.add(id);
       }
     }
     return [...ids].sort((a, b) => a.localeCompare(b));
@@ -836,8 +841,6 @@ async function findWorkspaceJobDefinition(jobId: string): Promise<{sourcePath: s
     '**/jobs.xml',
     '**/{node_modules,dist,out,.vscode-test,coverage,.git}/**',
   );
-  const jobIdPattern = jobId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const jobRegex = new RegExp(`<job\\b[^>]*\\bjob-id="${jobIdPattern}"[\\s\\S]*?</job>`, 'i');
   for (const uri of uris) {
     let content: string;
     try {
@@ -845,9 +848,9 @@ async function findWorkspaceJobDefinition(jobId: string): Promise<{sourcePath: s
     } catch {
       continue;
     }
-    const match = jobRegex.exec(content);
-    if (match) {
-      return {sourcePath: uri.fsPath, jobBlock: match[0]};
+    const jobBlock = extractJobBlockXml(content, jobId);
+    if (jobBlock) {
+      return {sourcePath: uri.fsPath, jobBlock};
     }
   }
   return undefined;
@@ -1114,18 +1117,36 @@ export function registerJobsCommands(
         );
         if (confirm !== 'Deploy & Run') return;
 
-        await vscode.window.withProgress(
-          {location: vscode.ProgressLocation.Notification, title: `Deploying job definition ${jobId}...`},
-          () => deployJobDefinitionToBm(instance, definition.jobBlock),
-        );
+        // Isolate the deploy step so its failures don't get mislabelled as run
+        // failures downstream. A site-archive-import fault has a completely
+        // different remediation (fix the jobs.xml, check WebDAV scopes) than a
+        // job-execution fault, and hiding it inside the generic "Failed to run"
+        // toast makes it look like the run failed instead of the deploy.
+        try {
+          await vscode.window.withProgress(
+            {location: vscode.ProgressLocation.Notification, title: `Deploying job definition ${jobId}...`},
+            () => deployJobDefinitionToBm(instance, definition.jobBlock),
+          );
+        } catch (deployError) {
+          const detail = deployError instanceof Error ? deployError.message : String(deployError);
+          showScopeAwareError(`Failed to deploy job definition ${jobId} from ${relSource}`, deployError);
+          // Log to the developer console for the full stack; the toast stays terse.
+          console.error(`[b2c-dx] Deploy of ${jobId} failed:`, detail);
+          return;
+        }
         finished = await triggerAndWait();
       }
 
       try {
         const log = await getJobLog(instance, finished);
         await openJobLog(finished.id ?? jobId, log);
-      } catch {
-        // Log may not be available yet; the success notification still applies.
+      } catch (logError) {
+        // The log may not be flushed yet on a just-finished job (BM writes it
+        // asynchronously) — that's expected and doesn't warrant a toast. Log
+        // to the developer console so real failures (permissions on the log
+        // dir, network flap) are still diagnosable when a user reports "job
+        // ran but no log opened."
+        console.warn(`[b2c-dx] Could not open log for ${jobId}:`, logError);
       }
       void vscode.window.showInformationMessage(`Job ${jobId} finished successfully.`);
     } catch (error) {
@@ -1134,8 +1155,9 @@ export function registerJobsCommands(
           const log = await getJobLog(instance, error.execution);
           await openJobLog(error.execution.id ?? jobId, log);
           revealExecutionErrorInActiveEditor(error.execution);
-        } catch {
-          // Fall through to the generic error toast when the log is unavailable.
+        } catch (logError) {
+          // Log may still be flushing; fall through to the generic error toast.
+          console.warn(`[b2c-dx] Could not open failure log for ${jobId}:`, logError);
         }
         const detail = getJobErrorMessage(error.execution) ?? error.execution.exit_status?.message;
         void vscode.window.showErrorMessage(`Job ${jobId} failed${detail ? `: ${detail}` : '.'}`);
@@ -1391,12 +1413,12 @@ export function registerJobsCommands(
     if (!target) return;
 
     const doc = await vscode.workspace.openTextDocument(target.sourcePath);
-    const text = doc.getText();
-    const pattern = new RegExp(`<job\\b[^>]*\\bjob-id="${target.jobId.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}"`);
-    const match = pattern.exec(text);
+    // findJobBlockOffset ignores commented-out blocks and returns an offset in
+    // the ORIGINAL text so we can `positionAt` directly.
+    const offset = findJobBlockOffset(doc.getText(), target.jobId);
     const options: vscode.TextDocumentShowOptions = {preview: false};
-    if (match) {
-      const position = doc.positionAt(match.index);
+    if (offset !== undefined) {
+      const position = doc.positionAt(offset);
       options.selection = new vscode.Range(position, position);
     }
     await vscode.window.showTextDocument(doc, options);
@@ -1439,9 +1461,12 @@ export function registerJobsCommands(
         // steptypes.json reference kept for clarity in tooltips/logs.
         void stepTypesPath;
       } catch (error) {
-        void vscode.window.showErrorMessage(
-          `Failed to create job scaffold: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        const detail = error instanceof Error ? error.message : String(error);
+        // Toast stays terse; the developer console gets the full stack so a
+        // partial scaffold left on disk is diagnosable (mirrors the deploy
+        // error path).
+        console.error('[b2c-dx] Scaffold failed:', error);
+        void vscode.window.showErrorMessage(`Failed to create job scaffold: ${detail}`);
       }
     },
   );
@@ -1508,11 +1533,12 @@ export function registerJobsCommands(
       return;
     }
 
+    // VS Code auto-adds a Cancel button to modal dialogs — passing an explicit
+    // one produces two Cancel-like actions. Keep only the affirmative.
     const choice = await vscode.window.showWarningMessage(
       `Stop execution ${executionId} for job ${node.jobId}?`,
       {modal: true},
       'Stop',
-      'Cancel',
     );
     if (choice !== 'Stop') return;
 
@@ -1641,13 +1667,24 @@ export function registerJobsCommands(
   /**
    * Cycles the root grouping between BM-style chronological and group-by-job-id.
    * No refetch — the provider just re-renders the same cached executions.
+   *
+   * VS Code can't swap a title-bar icon on a single command based on context, so
+   * the current-state icon is expressed by binding two commands to the same
+   * handler and gating each on `b2c-dx.jobs.groupingMode` (see package.json).
+   * The alias's icon is `list-tree`, shown when we're grouped and clicking will
+   * flatten to chronological.
    */
-  const toggleGrouping = registerSafeCommand('b2c-dx.jobs.toggleGrouping', () => {
+  const handleGroupingToggle = (): void => {
     const next = treeProvider.toggleGroupingMode();
     void vscode.window.showInformationMessage(
       next === 'groupByJobId' ? 'Job history grouped by Job ID.' : 'Job history shown as chronological timeline.',
     );
-  });
+  };
+  const toggleGrouping = registerSafeCommand('b2c-dx.jobs.toggleGrouping', handleGroupingToggle);
+  const toggleGroupingChronological = registerSafeCommand(
+    'b2c-dx.jobs.toggleGroupingChronological',
+    handleGroupingToggle,
+  );
 
   /**
    * Inline name filter, modeled after Business Manager's job-name search box.
@@ -1680,6 +1717,7 @@ export function registerJobsCommands(
     enableAutoRefresh,
     disableAutoRefresh,
     toggleGrouping,
+    toggleGroupingChronological,
     runJob,
     openDefinitionFile,
     importSiteArchive,

--- a/packages/b2c-vs-extension/src/jobs/jobs-commands.ts
+++ b/packages/b2c-vs-extension/src/jobs/jobs-commands.ts
@@ -18,6 +18,8 @@ import {
 import {getApiErrorMessage} from '@salesforce/b2c-tooling-sdk';
 import {createScaffoldRegistry, generateFromScaffold} from '@salesforce/b2c-tooling-sdk/scaffold';
 import {findCartridges} from '@salesforce/b2c-tooling-sdk/operations/code';
+import type {B2CInstance} from '@salesforce/b2c-tooling-sdk';
+import JSZip from 'jszip';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
@@ -566,6 +568,17 @@ async function writeJobScaffold(
   // load ("invalid step in script module"). The "custom." prefix is restored on
   // the @type-id during normalization below.
   const cartridgeNamePath = path.relative(root.fsPath, plan.cartridgeDir);
+  const stepTypesPath = path.join(plan.cartridgeDir, 'steptypes.json');
+
+  // Snapshot the previously-registered categories BEFORE the SDK scaffold runs.
+  // The scaffold's steptypes-entry.json.ejs template emits a bare array like
+  // `[{new entry}]`, and the SDK's json-merge deep-merges that into the
+  // `step-types` path where the existing value is a keyed object. Array-vs-object
+  // in `deepMerge` falls back to "return source", which silently replaces every
+  // previously-registered category with the new entry's array — wiping earlier
+  // custom step types. Re-injecting the snapshot in normalization keeps history.
+  const preservedCategories = await readExistingStepCategories(stepTypesPath);
+
   const result = await generateFromScaffold(scaffold, {
     outputDir: root.fsPath,
     variables: {
@@ -578,11 +591,11 @@ async function writeJobScaffold(
   });
 
   const scriptPaths = result.files.filter((file) => file.absolutePath.endsWith('.js')).map((file) => file.absolutePath);
-  const stepTypesPath = path.join(plan.cartridgeDir, 'steptypes.json');
 
   // Normalize the generated steptypes.json into the exact shape B2C requires:
   // keyed `step-types` object, context flags matching the job scope, a
   // cartridge-prefixed module path, and the `custom.` type-id prefix restored.
+  // Also restores any categories the SDK merge dropped (see comment above).
   await normalizeStepTypesJson(
     stepTypesPath,
     plan.spec.stepKind,
@@ -590,6 +603,7 @@ async function writeJobScaffold(
     plan.spec.cartridgeName,
     plan.stepIdBare,
     plan.spec.stepTypeId,
+    preservedCategories,
   );
 
   // Merge the matching job into jobs.xml at the cartridge root. A cartridge can
@@ -655,6 +669,27 @@ function escapeRegExp(value: string): string {
  * (`<cartridge>/cartridge/scripts/...`) so it resolves at runtime. Existing step
  * categories in the file are preserved.
  */
+/**
+ * Reads the current `step-types` object from a cartridge's steptypes.json.
+ * Returns `{}` if the file doesn't exist, isn't JSON, or has no `step-types`.
+ *
+ * Callers snapshot this BEFORE the SDK scaffold runs so previously-registered
+ * categories can be re-injected after the SDK's array-vs-object json-merge
+ * clobbers them (see writeJobScaffold for the underlying bug).
+ */
+async function readExistingStepCategories(stepTypesPath: string): Promise<Record<string, unknown>> {
+  try {
+    const raw = JSON.parse(await fs.readFile(stepTypesPath, 'utf-8')) as Record<string, unknown>;
+    const stepTypes = raw['step-types'];
+    if (stepTypes && typeof stepTypes === 'object' && !Array.isArray(stepTypes)) {
+      return stepTypes as Record<string, unknown>;
+    }
+  } catch {
+    // Missing file or invalid JSON — treat as empty snapshot.
+  }
+  return {};
+}
+
 async function normalizeStepTypesJson(
   stepTypesPath: string,
   stepKind: 'task' | 'chunk',
@@ -662,20 +697,37 @@ async function normalizeStepTypesJson(
   cartridgeName: string,
   stepIdBare: string,
   stepTypeId: string,
+  preservedCategories: Record<string, unknown> = {},
 ): Promise<void> {
   const raw = JSON.parse(await fs.readFile(stepTypesPath, 'utf-8')) as Record<string, unknown>;
   const categoryKey = stepKind === 'chunk' ? 'chunk-script-module-step' : 'script-module-step';
   const stepTypes = raw['step-types'];
 
-  // Collect step entries from whichever shape the scaffold produced.
+  // Collect step entries from whichever shape the scaffold produced. Restore any
+  // categories the SDK's array-vs-object merge dropped (see writeJobScaffold).
   let entries: Array<Record<string, unknown>> = [];
-  let existingCategories: Record<string, unknown> = {};
+  let existingCategories: Record<string, unknown> = {...preservedCategories};
   if (Array.isArray(stepTypes)) {
     entries = stepTypes as Array<Record<string, unknown>>;
   } else if (stepTypes && typeof stepTypes === 'object') {
-    existingCategories = stepTypes as Record<string, unknown>;
+    existingCategories = {...preservedCategories, ...(stepTypes as Record<string, unknown>)};
     const current = existingCategories[categoryKey];
     entries = Array.isArray(current) ? (current as Array<Record<string, unknown>>) : [];
+  }
+
+  // The current-run entries also need to survive the categoryKey rebuild below —
+  // append them to whatever the preserved snapshot had for this category so
+  // re-scaffolding a second chunk step doesn't drop the first one.
+  const preservedForCategory = preservedCategories[categoryKey];
+  if (Array.isArray(preservedForCategory)) {
+    const known = new Set(entries.map((entry) => String(entry['@type-id'] ?? '')));
+    for (const preserved of preservedForCategory as Array<Record<string, unknown>>) {
+      const typeId = String(preserved['@type-id'] ?? '');
+      if (typeId && !known.has(typeId)) {
+        entries.push(preserved);
+        known.add(typeId);
+      }
+    }
   }
 
   // Align context flags with the job scope: blank site context = org-scoped.
@@ -727,19 +779,131 @@ function getConfiguredKnownJobIds(): string[] {
   return [...new Set(sanitized)].sort((a, b) => a.localeCompare(b));
 }
 
+/**
+ * Scans every `jobs.xml` in the workspace for `<job job-id="…">` values.
+ *
+ * Execution-history lookup only surfaces jobs that have already run at least
+ * once, so newly-deployed jobs are invisible to the picker until their first
+ * execution — a chicken-and-egg problem for testing. Reading the workspace
+ * cartridges gives us the authoritative list of jobs the user *intends* to run
+ * (they're the same file BM ingests), independent of whether the sandbox has
+ * ever executed them.
+ *
+ * Uses `vscode.workspace.findFiles` so it honors `files.exclude` /
+ * `search.exclude` and works in multi-root workspaces. Excludes node_modules,
+ * `dist`, `out`, `.vscode-test` etc. by default.
+ */
+async function getWorkspaceJobIds(): Promise<string[]> {
+  try {
+    const uris = await vscode.workspace.findFiles(
+      '**/jobs.xml',
+      '**/{node_modules,dist,out,.vscode-test,coverage,.git}/**',
+    );
+    const ids = new Set<string>();
+    for (const uri of uris) {
+      let content: string;
+      try {
+        content = await fs.readFile(uri.fsPath, 'utf-8');
+      } catch {
+        continue;
+      }
+      // Match <job job-id="..."> — attribute order is not guaranteed by the XSD.
+      const jobRegex = /<job\b[^>]*\bjob-id="([^"]+)"/gi;
+      let match: RegExpExecArray | null;
+      while ((match = jobRegex.exec(content)) !== null) {
+        const id = match[1]?.trim();
+        if (id) ids.add(id);
+      }
+    }
+    return [...ids].sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Locate the workspace `jobs.xml` that declares `jobId` and extract just that
+ * `<job>` block. Returns `undefined` when the job isn't defined in any workspace
+ * jobs.xml — the caller then knows there's nothing to deploy.
+ *
+ * The single-job archive we build from this is what BM ingests to register the
+ * job definition (OCAPI only lets you *run* jobs that BM already knows about,
+ * not create them). We slice just the one block so the deploy is minimal and
+ * doesn't touch unrelated jobs on the instance.
+ */
+async function findWorkspaceJobDefinition(jobId: string): Promise<{sourcePath: string; jobBlock: string} | undefined> {
+  const uris = await vscode.workspace.findFiles(
+    '**/jobs.xml',
+    '**/{node_modules,dist,out,.vscode-test,coverage,.git}/**',
+  );
+  const jobIdPattern = jobId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const jobRegex = new RegExp(`<job\\b[^>]*\\bjob-id="${jobIdPattern}"[\\s\\S]*?</job>`, 'i');
+  for (const uri of uris) {
+    let content: string;
+    try {
+      content = await fs.readFile(uri.fsPath, 'utf-8');
+    } catch {
+      continue;
+    }
+    const match = jobRegex.exec(content);
+    if (match) {
+      return {sourcePath: uri.fsPath, jobBlock: match[0]};
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Deploys a single job definition to BM by wrapping the extracted `<job>` block
+ * in a minimal `jobs.xml`, zipping it as a site archive, and importing it.
+ *
+ * BM's site-archive-import merges by job-id, so this is safe to call repeatedly
+ * for the same job — existing entries are updated in place, other jobs on the
+ * server are untouched.
+ */
+async function deployJobDefinitionToBm(instance: B2CInstance, jobBlock: string): Promise<void> {
+  const jobsXml = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<jobs xmlns="http://www.demandware.com/xml/impex/jobs/2015-07-01">',
+    jobBlock,
+    '</jobs>',
+    '',
+  ].join('\n');
+
+  const zip = new JSZip();
+  zip.file('jobs.xml', jobsXml);
+  const buffer = await zip.generateAsync({type: 'nodebuffer', compression: 'DEFLATE'});
+
+  await siteArchiveImport(instance, buffer);
+}
+
 async function promptForJobId(treeProvider: JobsTreeDataProvider, hintedJobId?: string): Promise<string | undefined> {
-  const discovered = await treeProvider.getDiscoveredJobIds();
+  const [discovered, workspaceJobs] = await Promise.all([treeProvider.getDiscoveredJobIds(), getWorkspaceJobIds()]);
   const known = getConfiguredKnownJobIds();
   const hint = hintedJobId?.trim();
-  const options = [...new Set([...(hint ? [hint] : []), ...discovered, ...known])].sort((a, b) => a.localeCompare(b));
+  const options = [...new Set([...(hint ? [hint] : []), ...discovered, ...workspaceJobs, ...known])].sort((a, b) =>
+    a.localeCompare(b),
+  );
 
   if (options.length > 0) {
+    const discoveredSet = new Set(discovered);
+    const workspaceSet = new Set(workspaceJobs);
+    const knownSet = new Set(known);
+    const describeSource = (jobId: string): string | undefined => {
+      if (jobId === hint) return 'Selected job';
+      const sources: string[] = [];
+      if (workspaceSet.has(jobId)) sources.push('workspace jobs.xml');
+      if (discoveredSet.has(jobId)) sources.push('run history');
+      if (knownSet.has(jobId)) sources.push('configured');
+      return sources.length > 0 ? sources.join(' · ') : undefined;
+    };
+
     const customLabel = '$(edit) Enter job ID manually...';
     const picked = await vscode.window.showQuickPick(
       [
         ...options.map((jobId) => ({
           label: jobId,
-          description: jobId === hint ? 'Selected job' : undefined,
+          description: describeSource(jobId),
           picked: jobId === hint,
         })),
         {label: customLabel, description: undefined, picked: false},
@@ -748,7 +912,7 @@ async function promptForJobId(treeProvider: JobsTreeDataProvider, hintedJobId?: 
         title: 'Run Job',
         placeHolder: hint
           ? `Confirm the job to run (default: ${hint}), or enter another`
-          : 'Select a discovered/configured job ID, or enter manually',
+          : 'Select a job (workspace jobs.xml, run history, or configured), or enter manually',
         matchOnDescription: true,
       },
     );
@@ -819,6 +983,7 @@ function isJobNotRunnableError(error: unknown): boolean {
 export function registerJobsCommands(
   configProvider: B2CExtensionConfig,
   treeProvider: JobsTreeDataProvider,
+  treeView: vscode.TreeView<unknown>,
   options: {
     builtInScaffoldsDir: string;
     extensionUri?: vscode.Uri;
@@ -907,8 +1072,8 @@ export function registerJobsCommands(
       return;
     }
 
-    try {
-      const finished = await vscode.window.withProgress(
+    const triggerAndWait = async (): Promise<JobExecution> => {
+      return vscode.window.withProgress(
         {location: vscode.ProgressLocation.Notification, title: `Running job ${jobId}...`, cancellable: false},
         async (progress) => {
           const execution = await executeJob(instance, jobId, {parameters});
@@ -916,14 +1081,45 @@ export function registerJobsCommands(
           if (!executionId) return execution;
 
           progress.report({message: `Execution ${executionId} started`});
-          // Surface the running execution in the views immediately (jobs can
-          // finish in <1s, so without this the "running" state is never seen).
           treeProvider.refresh();
           return waitForJob(instance, jobId, executionId, {
             onPoll: (info) => progress.report({message: `${info.status} · ${info.elapsedSeconds}s elapsed`}),
           });
         },
       );
+    };
+
+    try {
+      let finished: JobExecution;
+      try {
+        finished = await triggerAndWait();
+      } catch (firstError) {
+        // OCAPI can only run jobs that BM already knows about. When the job is
+        // defined in the workspace but hasn't been imported yet, transparently
+        // deploy its jobs.xml block via site-archive-import (which BM merges by
+        // job-id) and retry. sfcc-* system jobs and jobs missing from the
+        // workspace stay as hard errors — nothing to deploy.
+        if (!isJobNotRunnableError(firstError) || isSystemJobId(jobId)) {
+          throw firstError;
+        }
+        const definition = await findWorkspaceJobDefinition(jobId);
+        if (!definition) {
+          throw firstError;
+        }
+        const relSource = vscode.workspace.asRelativePath(definition.sourcePath);
+        const confirm = await vscode.window.showInformationMessage(
+          `Job "${jobId}" isn't registered on Business Manager yet. Deploy the definition from ${relSource} and run it?`,
+          {modal: true},
+          'Deploy & Run',
+        );
+        if (confirm !== 'Deploy & Run') return;
+
+        await vscode.window.withProgress(
+          {location: vscode.ProgressLocation.Notification, title: `Deploying job definition ${jobId}...`},
+          () => deployJobDefinitionToBm(instance, definition.jobBlock),
+        );
+        finished = await triggerAndWait();
+      }
 
       try {
         const log = await getJobLog(instance, finished);
@@ -947,7 +1143,7 @@ export function registerJobsCommands(
         // System (sfcc-*) jobs appear in execution history but aren't exposed as
         // runnable definitions via OCAPI. Explain rather than surface the raw fault.
         void vscode.window.showWarningMessage(
-          `"${jobId}" can't be run from here. ${isSystemJobId(jobId) ? 'It is a platform system job that runs on the instance scheduler' : 'No runnable job with this ID is defined in Business Manager'} — only custom/BM-defined jobs can be triggered via the API.`,
+          `"${jobId}" can't be run from here. ${isSystemJobId(jobId) ? 'It is a platform system job that runs on the instance scheduler' : 'No runnable job with this ID is defined in Business Manager, and no workspace jobs.xml declares it'} — only custom/BM-defined jobs can be triggered via the API.`,
         );
       } else {
         showScopeAwareError(`Failed to run job ${jobId}`, error);
@@ -1143,13 +1339,26 @@ export function registerJobsCommands(
       return;
     }
 
-    // Accept a job id from an execution tree node, a string arg, or nothing
-    // (toolbar). When invoked from a specific execution we already know which
-    // job to run, so skip the picker (showing 60 sfcc-* alternatives is noise)
-    // and go straight to params + confirm. The picker is only for the toolbar
-    // entry point where no job is known.
-    const hintedJobId =
+    // Resolve the target job in this priority order:
+    //   1. explicit arg from a right-click / execution-node invocation
+    //   2. current tree selection (user clicked a row, then the toolbar Run
+    //      icon) — reading `treeView.selection` here rather than trusting the
+    //      arg VS Code passes to the title-bar command, because that arg is
+    //      the *focused* node (VS Code renders the last-focused row with a
+    //      gray outline even after the user clicked away), which users read
+    //      as "nothing selected". `treeView.selection` matches what the user
+    //      sees highlighted.
+    //   3. picker fallback when nothing is selected.
+    const argHint =
       typeof node === 'string' ? node : node && typeof node === 'object' && 'jobId' in node ? node.jobId : undefined;
+    let selectionHint: string | undefined;
+    if (!argHint) {
+      const [selected] = treeView.selection as ReadonlyArray<unknown>;
+      if (selected && typeof selected === 'object' && 'jobId' in selected) {
+        selectionHint = (selected as {jobId?: string}).jobId;
+      }
+    }
+    const hintedJobId = argHint ?? selectionHint;
     const chosenJobId = hintedJobId?.trim() || (await promptForJobId(treeProvider));
     if (!chosenJobId) return;
 
@@ -1167,6 +1376,30 @@ export function registerJobsCommands(
     if (confirm !== 'Run') return;
 
     await runJobAndTail(chosenJobId, parameters);
+  });
+
+  // Right-click on a Workspace Job row → open its declaring jobs.xml at the
+  // matching `<job job-id="...">` line so the user can inspect or edit the
+  // definition. Falls back to opening the file at the top when the regex can't
+  // find the id (shouldn't happen for a row that was parsed out of that file,
+  // but degrades gracefully if the file was edited between scan and click).
+  const openDefinitionFile = registerSafeCommand('b2c-dx.jobs.openDefinitionFile', async (node?: unknown) => {
+    const target =
+      node && typeof node === 'object' && 'sourcePath' in node && 'jobId' in node
+        ? (node as {sourcePath: string; jobId: string})
+        : undefined;
+    if (!target) return;
+
+    const doc = await vscode.workspace.openTextDocument(target.sourcePath);
+    const text = doc.getText();
+    const pattern = new RegExp(`<job\\b[^>]*\\bjob-id="${target.jobId.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}"`);
+    const match = pattern.exec(text);
+    const options: vscode.TextDocumentShowOptions = {preview: false};
+    if (match) {
+      const position = doc.positionAt(match.index);
+      options.selection = new vscode.Range(position, position);
+    }
+    await vscode.window.showTextDocument(doc, options);
   });
 
   const createScaffold = registerSafeCommand(
@@ -1448,6 +1681,7 @@ export function registerJobsCommands(
     disableAutoRefresh,
     toggleGrouping,
     runJob,
+    openDefinitionFile,
     importSiteArchive,
     exportSiteArchive,
     createScaffold,

--- a/packages/b2c-vs-extension/src/jobs/jobs-commands.ts
+++ b/packages/b2c-vs-extension/src/jobs/jobs-commands.ts
@@ -115,8 +115,12 @@ async function chooseUnifiedFilterAction(
         action: {kind: 'advanced'} as const,
       },
       {
-        label: 'Clear History Filters',
-        detail: 'Clear Job ID/user/date filters',
+        label: 'Clear All Filters',
+        // "Clear History Filters" was misleading: it only wiped the advanced
+        // fields, leaving the status filter set. Users expected one "clear"
+        // action to reset everything, so the option now resets status + all
+        // advanced fields together (see JobsTreeDataProvider.clearAllFilters).
+        detail: 'Reset status to All and clear Job ID / user / date filters',
         action: {kind: 'clear'} as const,
       },
     ],
@@ -151,12 +155,16 @@ async function promptForHistoryFilters(current: JobHistoryFilters): Promise<JobH
   const action = await vscode.window.showQuickPick(
     [
       {
-        label: 'Set / Update Filters',
+        label: 'Set / Update Advanced Filters',
         description: 'Filter by Job ID, user, start time, and end time',
       },
       {
-        label: 'Clear All Filters',
-        description: 'Remove job history filters and show all matching status entries',
+        // Scoped to advanced fields only — status is intentionally left alone
+        // here because the caller entered this dialog specifically to edit
+        // advanced filters. Users who want a full reset should pick "Clear All
+        // Filters" from the outer Job History Filters picker.
+        label: 'Clear Advanced Filters',
+        description: 'Remove Job ID / user / date filters (leaves the status filter as-is)',
       },
     ],
     {
@@ -166,7 +174,7 @@ async function promptForHistoryFilters(current: JobHistoryFilters): Promise<JobH
   );
 
   if (!action) return undefined;
-  if (action.label === 'Clear All Filters') {
+  if (action.label === 'Clear Advanced Filters') {
     return {
       jobIdContains: '',
       executedBy: '',
@@ -977,8 +985,12 @@ export function registerJobsCommands(
     }
 
     if (action.kind === 'clear') {
-      treeProvider.clearHistoryFilters();
-      void vscode.window.showInformationMessage('Job history filters cleared.');
+      // "Clear All Filters" resets status AND advanced fields — matches user
+      // mental model (one "clear" wipes everything). The previous behavior
+      // only cleared advanced fields, so the toast lied when a status filter
+      // was still narrowing the tree.
+      treeProvider.clearAllFilters();
+      void vscode.window.showInformationMessage('All job history filters cleared.');
       return;
     }
 
@@ -986,8 +998,28 @@ export function registerJobsCommands(
     if (!nextFilters) return;
     treeProvider.setHistoryFilters(nextFilters);
     void vscode.window.showInformationMessage(
-      treeProvider.hasHistoryFilters() ? 'Job history filters updated.' : 'Job history filters cleared.',
+      treeProvider.hasHistoryFilters() ? 'Job history filters updated.' : 'Advanced job history filters cleared.',
     );
+  });
+
+  // Alias command bound to the filled-filter title-bar icon. VS Code doesn't
+  // support conditional icons on a single command, so the "filters are active"
+  // state is expressed by swapping to a second command entry with the same
+  // handler but a different icon (see `contributes.commands` + `menus.view/title`
+  // in package.json). Hidden from the command palette.
+  const openFiltersActive = registerSafeCommand('b2c-dx.jobs.openFiltersActive', async () => {
+    await vscode.commands.executeCommand('b2c-dx.jobs.openFilters');
+  });
+
+  // One-shot "reset everything" — wired to the empty-state row's click when
+  // filters are hiding results, and exposed as a first-class command for
+  // keyboard/palette use. Silent no-op when nothing is set.
+  const clearAllFilters = registerSafeCommand('b2c-dx.jobs.clearAllFilters', () => {
+    const hadAny = treeProvider.hasAnyActiveFilter();
+    treeProvider.clearAllFilters();
+    if (hadAny) {
+      void vscode.window.showInformationMessage('All job history filters cleared.');
+    }
   });
 
   const setHistoryFilters = registerSafeCommand('b2c-dx.jobs.setHistoryFilters', async () => {
@@ -1406,6 +1438,8 @@ export function registerJobsCommands(
     detailsProvider,
     refresh,
     openFilters,
+    openFiltersActive,
+    clearAllFilters,
     setStatusFilter,
     setHistoryFilters,
     setNameFilter,

--- a/packages/b2c-vs-extension/src/jobs/jobs-tree-provider.ts
+++ b/packages/b2c-vs-extension/src/jobs/jobs-tree-provider.ts
@@ -31,7 +31,13 @@ export interface JobHistoryExecutionRow {
   execution: JobExecution;
 }
 
-export type JobsTreeNode = JobTreeItem | JobExecutionTreeItem | JobsEmptyStateTreeItem | JobsLoadHintTreeItem;
+export type JobsTreeNode =
+  | JobTreeItem
+  | JobExecutionTreeItem
+  | JobsEmptyStateTreeItem
+  | JobsLoadHintTreeItem
+  | JobsSectionHeaderTreeItem
+  | WorkspaceJobTreeItem;
 
 const JOBS_FETCH_LIMIT = 200;
 const DEFAULT_DISCOVERY_SCAN_LIMIT = 2000;
@@ -75,6 +81,26 @@ function parseTimestamp(value: string | undefined): number | undefined {
   if (!value) return undefined;
   const parsed = Date.parse(value);
   return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Best-effort cartridge name for a jobs.xml path. Walks up looking for a folder
+ * with a `.project` sibling (the canonical B2C cartridge marker). Returns
+ * undefined when the file lives outside any cartridge — surface still works as
+ * a workspace-level row, just without a cartridge label.
+ */
+function detectCartridgeName(jobsXmlPath: string): string | undefined {
+  const parts = jobsXmlPath.split(/[/\\]/);
+  // Look for the segment immediately containing jobs.xml, then walk up. The
+  // last segment is jobs.xml itself, so start from the parent.
+  for (let i = parts.length - 2; i >= 1; i--) {
+    if (parts[i] === 'cartridge' && parts[i - 1]) {
+      return parts[i - 1];
+    }
+  }
+  // Fall back to the immediate parent directory name — good enough for
+  // labeling when the cartridge structure isn't the canonical one.
+  return parts[parts.length - 2];
 }
 
 function getExecutionUsers(execution: JobExecution): string[] {
@@ -361,6 +387,54 @@ export class JobsEmptyStateTreeItem extends vscode.TreeItem {
   }
 }
 
+/**
+ * Non-selectable group heading — used to split the tree into "Workspace Jobs"
+ * and "Job History" without needing two separate views. Section headers are
+ * collapsible so the two lists can be toggled independently.
+ */
+export class JobsSectionHeaderTreeItem extends vscode.TreeItem {
+  readonly nodeType = 'sectionHeader' as const;
+
+  constructor(
+    readonly section: 'workspace' | 'history',
+    label: string,
+    description: string | undefined,
+    initial: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.Expanded,
+  ) {
+    super(label, initial);
+    this.id = `jobs-section:${section}`;
+    this.contextValue = `jobs-section-${section}`;
+    this.iconPath = new vscode.ThemeIcon(section === 'workspace' ? 'file-code' : 'history');
+    this.description = description;
+  }
+}
+
+/**
+ * A job declared in a workspace `jobs.xml` — surfaces custom jobs before they
+ * have any execution history. Right-click "Run Job" targets these directly so
+ * users don't have to type the id or wait for the first run.
+ */
+export class WorkspaceJobTreeItem extends vscode.TreeItem {
+  readonly nodeType = 'workspaceJob' as const;
+
+  constructor(
+    readonly jobId: string,
+    readonly sourcePath: string,
+    readonly cartridgeName: string | undefined,
+  ) {
+    super(jobId, vscode.TreeItemCollapsibleState.None);
+    this.id = `workspaceJob:${jobId}:${sourcePath}`;
+    this.contextValue = 'workspaceJob';
+    this.iconPath = new vscode.ThemeIcon('play-circle');
+    this.description = cartridgeName ?? 'workspace';
+    this.tooltip = new vscode.MarkdownString(
+      `**${jobId}**\n\nDeclared in \`${vscode.workspace.asRelativePath(sourcePath)}\`` +
+        (cartridgeName ? `\n\nCartridge: **${cartridgeName}**` : '') +
+        '\n\nRight-click → Run Job to execute (the extension will auto-deploy the definition if BM does not know it yet).',
+    );
+  }
+}
+
 /** Shown before the user has explicitly loaded job history (or after a config reset). */
 export class JobsLoadHintTreeItem extends vscode.TreeItem {
   readonly nodeType = 'loadHint' as const;
@@ -395,6 +469,7 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
   readonly onDidLoad = this.onDidLoadEmitter.event;
 
   private discoveryExecutionCache: JobExecution[] | undefined;
+  private workspaceJobsCache: WorkspaceJobTreeItem[] | undefined;
   private pollingTimer: ReturnType<typeof setInterval> | undefined;
   private statusFilter: JobStatusFilter;
   private groupingMode: JobGroupingMode;
@@ -546,13 +621,16 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
 
   async getChildren(element?: JobsTreeNode): Promise<JobsTreeNode[]> {
     if (!element) return this.getRootNodes();
+    if (element instanceof JobsSectionHeaderTreeItem) {
+      return element.section === 'workspace' ? this.getWorkspaceSectionRows() : this.getHistorySectionRows();
+    }
     if (element instanceof JobTreeItem) {
       // Grouped view: each child execution renders as a leaf labeled by its
       // start timestamp — the job id is already on the parent row.
       return element.executions.map((execution) => new JobExecutionTreeItem(element.jobId, execution, false));
     }
-    // Executions are leaves; step-level drill-down lives in **View Execution
-    // Details** (and the BM deep-link).
+    // Workspace jobs and executions are leaves; step-level drill-down lives in
+    // **View Execution Details** (and the BM deep-link).
     return [];
   }
 
@@ -563,7 +641,57 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
   refresh(): void {
     this.loadedOnce = true;
     this.discoveryExecutionCache = undefined;
+    this.workspaceJobsCache = undefined;
     this.onDidChangeTreeDataEmitter.fire();
+  }
+
+  /**
+   * Refreshes only the workspace-jobs cache. Used by the file-watcher when a
+   * `jobs.xml` is edited/added/removed so the tree updates without paying for
+   * an OCAPI history round-trip.
+   */
+  invalidateWorkspaceJobs(): void {
+    this.workspaceJobsCache = undefined;
+    this.onDidChangeTreeDataEmitter.fire();
+  }
+
+  /**
+   * Scans workspace `jobs.xml` files and returns one row per declared `<job>`.
+   * Cached until an explicit refresh or file-watcher invalidation — cartridges
+   * usually declare a handful of jobs, but re-parsing on every getChildren call
+   * would be wasteful when the user is just expanding/collapsing sections.
+   */
+  private async loadWorkspaceJobs(): Promise<WorkspaceJobTreeItem[]> {
+    if (this.workspaceJobsCache) return this.workspaceJobsCache;
+
+    const uris = await vscode.workspace.findFiles(
+      '**/jobs.xml',
+      '**/{node_modules,dist,out,.vscode-test,coverage,.git}/**',
+    );
+    const rows: WorkspaceJobTreeItem[] = [];
+    const seen = new Set<string>();
+    for (const uri of uris) {
+      let content: string;
+      try {
+        content = await vscode.workspace.fs.readFile(uri).then((buf) => Buffer.from(buf).toString('utf-8'));
+      } catch {
+        continue;
+      }
+      const cartridgeName = detectCartridgeName(uri.fsPath);
+      const jobRegex = /<job\b[^>]*\bjob-id="([^"]+)"/gi;
+      let match: RegExpExecArray | null;
+      while ((match = jobRegex.exec(content)) !== null) {
+        const jobId = match[1]?.trim();
+        if (!jobId) continue;
+        const key = `${jobId}::${uri.fsPath}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        rows.push(new WorkspaceJobTreeItem(jobId, uri.fsPath, cartridgeName));
+      }
+    }
+    rows.sort((a, b) => a.jobId.localeCompare(b.jobId));
+    this.workspaceJobsCache = rows;
+    return rows;
   }
 
   /** Soft refresh: re-renders the tree without dropping caches (e.g. filter changes). */
@@ -575,6 +703,7 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
   resetLoaded(): void {
     this.loadedOnce = false;
     this.discoveryExecutionCache = undefined;
+    this.workspaceJobsCache = undefined;
     this.onDidChangeTreeDataEmitter.fire();
   }
 
@@ -664,9 +793,28 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
     const instance = this.configProvider.getInstance();
     if (!instance) return [];
 
-    if (!this.loadedOnce) {
-      return [new JobsLoadHintTreeItem()];
-    }
+    // Workspace-jobs section is populated from local files, so it works even
+    // before the user hits Refresh. History still gates behind an explicit
+    // refresh so a passive side-panel open doesn't hit OCAPI.
+    const workspaceRows = await this.loadWorkspaceJobs();
+    const workspaceHeader = new JobsSectionHeaderTreeItem(
+      'workspace',
+      'Workspace Jobs',
+      workspaceRows.length > 0 ? `${workspaceRows.length}` : 'None found',
+    );
+    const historyHeader = new JobsSectionHeaderTreeItem('history', 'Job History', this.describeHistoryHeader());
+
+    return [workspaceHeader, historyHeader];
+  }
+
+  /**
+   * Rows under the "Job History" section — same content the view rendered
+   * pre-section-split. Kept as a private method so the section header can
+   * delegate to it, and any future changes to the history rendering (grouping,
+   * empty-state copy, load hint) live in one place.
+   */
+  private async getHistorySectionRows(): Promise<JobsTreeNode[]> {
+    if (!this.loadedOnce) return [new JobsLoadHintTreeItem()];
 
     await this.loadJobs();
     if (!this.discoveryExecutionCache) return [];
@@ -686,18 +834,10 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
       );
 
     if (rows.length === 0) {
-      // Reflect ANY active filter (status or advanced) — not just the advanced
-      // ones. Previously this only used hasHistoryFilters(), so a status-only
-      // filter (e.g. "Failed") produced the plain "No failed jobs" copy with
-      // no clear-filter affordance, even though a filter was hiding rows.
       return [new JobsEmptyStateTreeItem(this.statusFilter, this.hasAnyActiveFilter(), this.describeActiveFilters())];
     }
 
     if (this.groupingMode === 'groupByJobId') {
-      // Bucket executions per job, preserving the SDK's start_time-desc order
-      // inside each bucket. Jobs are then sorted by their most-recent run so the
-      // currently-active / most-recently-touched jobs float to the top — the
-      // same order BM's Job Definitions sidebar uses.
       const byJob = new Map<string, JobExecution[]>();
       for (const row of rows) {
         const existing = byJob.get(row.jobId);
@@ -705,19 +845,27 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
         else byJob.set(row.jobId, [row.execution]);
       }
 
-      const groupNodes = [...byJob.entries()]
+      return [...byJob.entries()]
         .sort(([, aRuns], [, bRuns]) => {
           const aLatest = parseTimestamp(aRuns[0]?.start_time) ?? 0;
           const bLatest = parseTimestamp(bRuns[0]?.start_time) ?? 0;
           return bLatest - aLatest;
         })
         .map(([jobId, runs]) => new JobTreeItem(jobId, runs));
-
-      return groupNodes;
     }
 
-    // Chronological view: SDK already returns by start_time desc; preserve that order.
     return rows.map((row) => new JobExecutionTreeItem(row.jobId, row.execution));
+  }
+
+  private async getWorkspaceSectionRows(): Promise<JobsTreeNode[]> {
+    const rows = await this.loadWorkspaceJobs();
+    return rows;
+  }
+
+  private describeHistoryHeader(): string | undefined {
+    if (!this.loadedOnce) return 'Click to load';
+    if (this.hasAnyActiveFilter()) return this.describeActiveFilters() ?? undefined;
+    return undefined;
   }
 
   /** Single fetch path used by both root rendering and lookup APIs. */

--- a/packages/b2c-vs-extension/src/jobs/jobs-tree-provider.ts
+++ b/packages/b2c-vs-extension/src/jobs/jobs-tree-provider.ts
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
+import {findCartridges} from '@salesforce/b2c-tooling-sdk/operations/code';
 import {searchJobExecutions, type JobExecution} from '@salesforce/b2c-tooling-sdk/operations/jobs';
 import * as vscode from 'vscode';
 import type {B2CExtensionConfig} from '../config-provider.js';
 import {showThrottledError} from '../notify.js';
+import {detectCartridgeName, extractJobIdsFromXml} from './jobs-xml-parser.js';
 
 export type JobStatusFilter = 'all' | 'active' | 'running' | 'scheduled' | 'failed' | 'completed';
 type ExecutionStatus = 'running' | 'failed' | 'completed' | 'scheduled';
@@ -81,26 +83,6 @@ function parseTimestamp(value: string | undefined): number | undefined {
   if (!value) return undefined;
   const parsed = Date.parse(value);
   return Number.isNaN(parsed) ? undefined : parsed;
-}
-
-/**
- * Best-effort cartridge name for a jobs.xml path. Walks up looking for a folder
- * with a `.project` sibling (the canonical B2C cartridge marker). Returns
- * undefined when the file lives outside any cartridge — surface still works as
- * a workspace-level row, just without a cartridge label.
- */
-function detectCartridgeName(jobsXmlPath: string): string | undefined {
-  const parts = jobsXmlPath.split(/[/\\]/);
-  // Look for the segment immediately containing jobs.xml, then walk up. The
-  // last segment is jobs.xml itself, so start from the parent.
-  for (let i = parts.length - 2; i >= 1; i--) {
-    if (parts[i] === 'cartridge' && parts[i - 1]) {
-      return parts[i - 1];
-    }
-  }
-  // Fall back to the immediate parent directory name — good enough for
-  // labeling when the cartridge structure isn't the canonical one.
-  return parts[parts.length - 2];
 }
 
 function getExecutionUsers(execution: JobExecution): string[] {
@@ -668,6 +650,15 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
       '**/jobs.xml',
       '**/{node_modules,dist,out,.vscode-test,coverage,.git}/**',
     );
+
+    // Prefer the SDK's authoritative cartridge list (walks `.project` markers)
+    // for labeling — it correctly identifies non-standard layouts (cartridge
+    // directly under `src/`, cartridges under a `cartridges/` container, etc.)
+    // that the path-walk heuristic can only approximate. Falls back to the
+    // heuristic when no workspace folder is open or nothing is discovered.
+    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const knownCartridges = workspaceRoot ? findCartridges(workspaceRoot).map((c) => ({name: c.name, src: c.src})) : [];
+
     const rows: WorkspaceJobTreeItem[] = [];
     const seen = new Set<string>();
     for (const uri of uris) {
@@ -677,12 +668,8 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
       } catch {
         continue;
       }
-      const cartridgeName = detectCartridgeName(uri.fsPath);
-      const jobRegex = /<job\b[^>]*\bjob-id="([^"]+)"/gi;
-      let match: RegExpExecArray | null;
-      while ((match = jobRegex.exec(content)) !== null) {
-        const jobId = match[1]?.trim();
-        if (!jobId) continue;
+      const cartridgeName = detectCartridgeName(uri.fsPath, knownCartridges);
+      for (const jobId of extractJobIdsFromXml(content)) {
         const key = `${jobId}::${uri.fsPath}`;
         if (seen.has(key)) continue;
         seen.add(key);

--- a/packages/b2c-vs-extension/src/jobs/jobs-tree-provider.ts
+++ b/packages/b2c-vs-extension/src/jobs/jobs-tree-provider.ts
@@ -131,17 +131,16 @@ function statusFilterLabel(filter: JobStatusFilter): string {
   return 'Completed';
 }
 
-function emptyStateTitle(filter: JobStatusFilter): string {
-  if (filter === 'active') return 'No jobs running';
-  if (filter === 'running') return 'No jobs running';
-  if (filter === 'scheduled') return 'No scheduled jobs';
-  if (filter === 'failed') return 'No failed jobs';
-  if (filter === 'completed') return 'No completed jobs';
+function emptyStateTitle(filter: JobStatusFilter, filtersApplied: boolean): string {
+  // When ANY filter is narrowing results, lead with "No matching jobs" — the
+  // status label alone (e.g. "No running jobs") wrongly implied that no jobs
+  // are running at all, when in reality other filters were also hiding rows.
+  if (filtersApplied || filter !== 'all') return 'No matching jobs';
   return 'No jobs found';
 }
 
 function emptyStateDescription(filter: JobStatusFilter, filtersApplied: boolean): string {
-  if (filtersApplied) return 'Adjust or clear filters to see more.';
+  if (filtersApplied) return 'Click here to clear all filters.';
   if (filter === 'all') return 'Run a job to populate history.';
   return 'Change the status filter to see other entries.';
 }
@@ -339,17 +338,26 @@ export class JobExecutionTreeItem extends vscode.TreeItem {
 export class JobsEmptyStateTreeItem extends vscode.TreeItem {
   readonly nodeType = 'emptyState' as const;
 
-  constructor(filter: JobStatusFilter, filtersApplied: boolean) {
-    super(emptyStateTitle(filter), vscode.TreeItemCollapsibleState.None);
+  constructor(filter: JobStatusFilter, filtersApplied: boolean, filterSummary?: string) {
+    super(emptyStateTitle(filter, filtersApplied), vscode.TreeItemCollapsibleState.None);
     this.id = `jobs-empty-state:${filter}`;
     this.contextValue = 'jobs-empty-state';
     this.iconPath = new vscode.ThemeIcon('info');
-    this.description = filtersApplied
-      ? `${emptyStateDescription(filter, filtersApplied)} (filters active)`
-      : emptyStateDescription(filter, filtersApplied);
+    this.description = emptyStateDescription(filter, filtersApplied);
     this.tooltip = new vscode.MarkdownString(
-      `No job history entries match **${statusFilterLabel(filter)}** right now.\n\nUse the title-bar actions to change the status filter or clear name/advanced filters.`,
+      filtersApplied
+        ? `No entries match the active filters${filterSummary ? `:\n\n\`${filterSummary}\`` : '.'}\n\nClick this row to clear all filters and show every entry, or use the title-bar filter icon to adjust.`
+        : `No job history entries to show. Run a job in Business Manager or via the extension to populate the timeline.`,
     );
+    // When filters are the reason nothing shows, wire the empty row itself to
+    // clear them — one click undoes the accidental narrowing, no digging
+    // through Quick Pick menus.
+    if (filtersApplied) {
+      this.command = {
+        command: 'b2c-dx.jobs.clearAllFilters',
+        title: 'Clear All Filters',
+      };
+    }
   }
 }
 
@@ -400,6 +408,7 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
     this.groupingMode = getDefaultGroupingMode();
     this.updateStatusFilterContext();
     this.updateGroupingModeContext();
+    this.updateHasActiveFiltersContext();
   }
 
   getStatusFilter(): JobStatusFilter {
@@ -420,6 +429,7 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
     if (unchanged) return;
 
     this.historyFilters = normalized;
+    this.updateHasActiveFiltersContext();
     this.onDidChangeTreeDataEmitter.fire();
   }
 
@@ -429,6 +439,65 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
 
   hasHistoryFilters(): boolean {
     return hasHistoryFilters(this.historyFilters);
+  }
+
+  /**
+   * Whether any filter (status other than `all`, or an advanced field) is
+   * currently narrowing the tree. Used to swap the title-bar filter icon to
+   * a filled variant and to gate the message summary — so users can't miss
+   * that results are being hidden.
+   */
+  hasAnyActiveFilter(): boolean {
+    return this.statusFilter !== 'all' || this.hasHistoryFilters();
+  }
+
+  /**
+   * Compact one-line summary of the currently-active filters, or `undefined`
+   * when none are set. Rendered into the tree view's title-bar message so the
+   * user always sees at a glance which filters are hiding results.
+   *
+   * Each part is explicitly labeled (`Status=`, `Job~=`, etc.) so a bare word
+   * like "Active" can't be mistaken for a state flag (the earlier version
+   * emitted "Filters: Active" for the Active status, which read as if it meant
+   * "filters are active" rather than "showing Active jobs").
+   */
+  describeActiveFilters(): string | undefined {
+    const parts: string[] = [];
+    if (this.statusFilter !== 'all') {
+      parts.push(`Status=${statusFilterLabel(this.statusFilter)}`);
+    }
+    if (this.historyFilters.jobIdContains) {
+      parts.push(`Job~="${this.historyFilters.jobIdContains}"`);
+    }
+    if (this.historyFilters.executedBy) {
+      parts.push(`User~="${this.historyFilters.executedBy}"`);
+    }
+    if (this.historyFilters.startFrom) {
+      parts.push(`From=${this.historyFilters.startFrom}`);
+    }
+    if (this.historyFilters.endTo) {
+      parts.push(`To=${this.historyFilters.endTo}`);
+    }
+    return parts.length > 0 ? parts.join(' | ') : undefined;
+  }
+
+  /**
+   * Clears BOTH the status filter (back to "all") and every advanced filter in
+   * one shot. Exists because users think of "filters" as one concept — the old
+   * "Clear History Filters" only wiped the advanced fields, leaving the status
+   * filter set, which produced the confusing "filters cleared" toast while the
+   * status filter kept hiding results.
+   */
+  clearAllFilters(): void {
+    const statusChanged = this.statusFilter !== 'all';
+    const historyChanged = hasHistoryFilters(this.historyFilters);
+    if (!statusChanged && !historyChanged) return;
+
+    this.statusFilter = 'all';
+    this.historyFilters = EMPTY_HISTORY_FILTERS;
+    this.updateStatusFilterContext();
+    this.updateHasActiveFiltersContext();
+    this.onDidChangeTreeDataEmitter.fire();
   }
 
   getLastSuccessfulRefreshAt(): Date | undefined {
@@ -451,6 +520,7 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
     if (this.statusFilter === filter) return;
     this.statusFilter = filter;
     this.updateStatusFilterContext();
+    this.updateHasActiveFiltersContext();
     this.onDidChangeTreeDataEmitter.fire();
   }
 
@@ -573,6 +643,16 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
   }
 
   /**
+   * Publishes a boolean context key that the title-bar menus watch to swap the
+   * filter icon between the outline (`$(filter)`) and filled (`$(filter-filled)`)
+   * variants. Kept in sync everywhere filters change — including construction —
+   * so the UI never lies about whether results are being narrowed.
+   */
+  private updateHasActiveFiltersContext(): void {
+    void vscode.commands.executeCommand('setContext', 'b2c-dx.jobs.hasActiveFilters', this.hasAnyActiveFilter());
+  }
+
+  /**
    * Mirrors the grouping mode into VS Code context so package.json can swap the
    * title-bar icon between `list-flat` (timeline) and `list-tree` (grouped).
    */
@@ -606,7 +686,11 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
       );
 
     if (rows.length === 0) {
-      return [new JobsEmptyStateTreeItem(this.statusFilter, this.hasHistoryFilters())];
+      // Reflect ANY active filter (status or advanced) — not just the advanced
+      // ones. Previously this only used hasHistoryFilters(), so a status-only
+      // filter (e.g. "Failed") produced the plain "No failed jobs" copy with
+      // no clear-filter affordance, even though a filter was hiding rows.
+      return [new JobsEmptyStateTreeItem(this.statusFilter, this.hasAnyActiveFilter(), this.describeActiveFilters())];
     }
 
     if (this.groupingMode === 'groupByJobId') {

--- a/packages/b2c-vs-extension/src/jobs/jobs-xml-parser.ts
+++ b/packages/b2c-vs-extension/src/jobs/jobs-xml-parser.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import * as path from 'node:path';
+
+/**
+ * Shared helpers for reading job definitions out of a `jobs.xml`.
+ *
+ * jobs.xml is user-edited and can take a variety of shapes — commented-out job
+ * blocks, arbitrary attribute order, unusual whitespace. We deliberately don't
+ * pull in a full XML parser (heavy dep, big bundle hit) for a couple of tree
+ * lookups, but we DO need to survive the shapes users actually write. These
+ * helpers centralize the parsing so every caller gets the same behavior and
+ * one place is tested for the tricky cases.
+ */
+
+/**
+ * Removes `<!-- … -->` comment blocks from an XML document. Commented-out job
+ * definitions must not surface as tree rows or auto-deploy candidates — they're
+ * intentionally disabled by the developer.
+ *
+ * The comment regex is non-greedy and multi-line so nested blocks and blocks
+ * spanning many lines are both handled. XML doesn't allow nested comments, so a
+ * single pass is sufficient.
+ */
+export function stripXmlComments(content: string): string {
+  return content.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+const JOB_ID_REGEX = /<job\b[^>]*\bjob-id\s*=\s*(["'])((?:(?!\1).)+)\1/gi;
+
+/**
+ * Extracts every `<job job-id="…">` value from a jobs.xml string in file order,
+ * ignoring commented-out blocks. Returns unique ids only — the same id declared
+ * twice in one file (which would be a user error anyway) collapses to one.
+ *
+ * Handles the shapes we've seen in the wild:
+ * - attributes in any order: `<job name="x" job-id="y">`
+ * - single OR double quotes around the value
+ * - whitespace around the `=`: `<job job-id = "y">`
+ * - commented-out blocks: `<!-- <job job-id="y"/> -->` (skipped)
+ */
+export function extractJobIdsFromXml(content: string): string[] {
+  const cleaned = stripXmlComments(content);
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  let match: RegExpExecArray | null;
+  const regex = new RegExp(JOB_ID_REGEX.source, JOB_ID_REGEX.flags);
+  while ((match = regex.exec(cleaned)) !== null) {
+    const id = match[2]?.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}
+
+/**
+ * Extracts the entire `<job job-id="X"> … </job>` block for a specific job-id,
+ * or `undefined` when the id isn't declared (or is only inside a comment).
+ *
+ * The returned string is the exact block text — callers use it as the payload
+ * of the minimal jobs.xml they upload to BM when auto-deploying a workspace
+ * job definition.
+ */
+export function extractJobBlockXml(content: string, jobId: string): string | undefined {
+  const cleaned = stripXmlComments(content);
+  const escaped = jobId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const blockRegex = new RegExp(`<job\\b[^>]*\\bjob-id\\s*=\\s*(["'])${escaped}\\1[\\s\\S]*?</job>`, 'i');
+  const match = blockRegex.exec(cleaned);
+  return match ? match[0] : undefined;
+}
+
+/**
+ * Locates the character offset of the `<job job-id="X">` opening tag inside a
+ * jobs.xml string, or `undefined` when not found. Callers use this to position
+ * the editor cursor when opening the file from a tree row.
+ *
+ * Returns the offset into the ORIGINAL content (not the comment-stripped copy)
+ * so cursor placement is accurate. When the only match is inside a comment we
+ * return undefined — the editor should open the file at the top rather than
+ * jump into a disabled block.
+ */
+export function findJobBlockOffset(content: string, jobId: string): number | undefined {
+  const cleaned = stripXmlComments(content);
+  const escaped = jobId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`<job\\b[^>]*\\bjob-id\\s*=\\s*(["'])${escaped}\\1`, 'i');
+  const cleanedMatch = regex.exec(cleaned);
+  if (!cleanedMatch) return undefined;
+
+  // Map the offset from the cleaned string back to the original. Comment
+  // removal only deletes bytes, so we can walk the original and count real
+  // (non-comment) characters until we've passed cleanedMatch.index.
+  const target = cleanedMatch.index;
+  let originalOffset = 0;
+  let cleanedConsumed = 0;
+  const commentRegex = /<!--[\s\S]*?-->/g;
+  let commentMatch: RegExpExecArray | null;
+  while ((commentMatch = commentRegex.exec(content)) !== null) {
+    const segmentBeforeComment = commentMatch.index - originalOffset;
+    if (cleanedConsumed + segmentBeforeComment > target) {
+      return originalOffset + (target - cleanedConsumed);
+    }
+    cleanedConsumed += segmentBeforeComment;
+    originalOffset = commentMatch.index + commentMatch[0].length;
+  }
+  return originalOffset + (target - cleanedConsumed);
+}
+
+/**
+ * Best-effort cartridge name for a jobs.xml file.
+ *
+ * When `knownCartridgeRoots` is supplied (e.g. from `findCartridges()`), we
+ * match by path prefix — this is the authoritative source and correctly labels
+ * non-standard layouts (a cartridge directly under `src/`, cartridges under a
+ * `cartridges/` container, etc.).
+ *
+ * When no roots are supplied (tests, or before the tree is initialised), we
+ * fall back to walking up looking for a `cartridge` segment — the canonical
+ * SFCC layout is `<name>/cartridge/**\/jobs.xml`. Uses exact-segment match so
+ * `my-cartridge-utils/` and `cartridges/` don't false-match. Returns the
+ * immediate parent directory as a last resort so a row is never unlabeled.
+ */
+export function detectCartridgeName(
+  jobsXmlPath: string,
+  knownCartridgeRoots?: ReadonlyArray<{name: string; src: string}>,
+): string | undefined {
+  if (knownCartridgeRoots && knownCartridgeRoots.length > 0) {
+    // Longest-match wins — a cartridge nested under another cartridge should be
+    // labelled by the inner one. In practice this is rare, but the sort keeps
+    // the behavior deterministic.
+    const normalized = path.normalize(jobsXmlPath);
+    const bestMatch = [...knownCartridgeRoots]
+      .filter((c) => {
+        const root = path.normalize(c.src);
+        const withSep = root.endsWith(path.sep) ? root : root + path.sep;
+        return normalized === root || normalized.startsWith(withSep);
+      })
+      .sort((a, b) => b.src.length - a.src.length)[0];
+    if (bestMatch) return bestMatch.name;
+  }
+
+  const parts = jobsXmlPath.split(/[/\\]/);
+  for (let i = parts.length - 2; i >= 1; i--) {
+    if (parts[i] === 'cartridge' && parts[i - 1]) {
+      return parts[i - 1];
+    }
+  }
+  return parts[parts.length - 2];
+}

--- a/packages/b2c-vs-extension/src/test/cartridge-step-types.test.ts
+++ b/packages/b2c-vs-extension/src/test/cartridge-step-types.test.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {collectStepTypeEntries, resolveStepTypeModule} from '../code-sync/cartridge-tree-provider.js';
+
+async function mkTmpDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'b2c-step-types-'));
+}
+
+async function writeJson(target: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(target), {recursive: true});
+  await fs.writeFile(target, JSON.stringify(value, null, 2), 'utf-8');
+}
+
+async function writeFile(target: string, contents = ''): Promise<void> {
+  await fs.mkdir(path.dirname(target), {recursive: true});
+  await fs.writeFile(target, contents, 'utf-8');
+}
+
+suite('cartridge-tree-provider — custom step types', () => {
+  suite('collectStepTypeEntries', () => {
+    test('parses task + chunk categories in the canonical shape', async () => {
+      const root = await mkTmpDir();
+      const cartridgeRoot = path.join(root, 'app_custom_core');
+      await writeJson(path.join(cartridgeRoot, 'steptypes.json'), {
+        'step-types': {
+          'script-module-step': [
+            {'@type-id': 'custom.MyTaskStep', module: 'app_custom_core/cartridge/scripts/jobsteps/taskStep'},
+          ],
+          'chunk-script-module-step': [
+            {'@type-id': 'custom.MyChunkStep', module: 'app_custom_core/cartridge/scripts/jobsteps/chunkStep'},
+          ],
+        },
+      });
+
+      const entries = await collectStepTypeEntries(cartridgeRoot);
+      // Sorted alphabetically by typeId.
+      assert.deepStrictEqual(
+        entries.map((e) => ({typeId: e.typeId, kind: e.kind, moduleRef: e.moduleRef})),
+        [
+          {
+            typeId: 'custom.MyChunkStep',
+            kind: 'chunk',
+            moduleRef: 'app_custom_core/cartridge/scripts/jobsteps/chunkStep',
+          },
+          {
+            typeId: 'custom.MyTaskStep',
+            kind: 'task',
+            moduleRef: 'app_custom_core/cartridge/scripts/jobsteps/taskStep',
+          },
+        ],
+      );
+    });
+
+    test('tolerates the legacy flat-array shape as task steps', async () => {
+      const root = await mkTmpDir();
+      const cartridgeRoot = path.join(root, 'legacy_cartridge');
+      await writeJson(path.join(cartridgeRoot, 'steptypes.json'), {
+        'step-types': [{'@type-id': 'custom.Legacy', module: 'legacy_cartridge/cartridge/scripts/foo'}],
+      });
+
+      const entries = await collectStepTypeEntries(cartridgeRoot);
+      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries[0].typeId, 'custom.Legacy');
+      assert.strictEqual(entries[0].kind, 'task');
+    });
+
+    test('silently ignores malformed steptypes.json', async () => {
+      const root = await mkTmpDir();
+      const cartridgeRoot = path.join(root, 'broken');
+      const stepTypesPath = path.join(cartridgeRoot, 'steptypes.json');
+      await fs.mkdir(cartridgeRoot, {recursive: true});
+      await fs.writeFile(stepTypesPath, '{not valid json', 'utf-8');
+
+      const entries = await collectStepTypeEntries(cartridgeRoot);
+      assert.deepStrictEqual(entries, []);
+    });
+
+    test('skips entries missing @type-id or module', async () => {
+      const root = await mkTmpDir();
+      const cartridgeRoot = path.join(root, 'partial');
+      await writeJson(path.join(cartridgeRoot, 'steptypes.json'), {
+        'step-types': {
+          'script-module-step': [
+            {'@type-id': 'custom.Good', module: 'partial/cartridge/scripts/good'},
+            {'@type-id': 'custom.NoModule'},
+            {module: 'partial/cartridge/scripts/noType'},
+          ],
+        },
+      });
+
+      const entries = await collectStepTypeEntries(cartridgeRoot);
+      assert.deepStrictEqual(
+        entries.map((e) => e.typeId),
+        ['custom.Good'],
+      );
+    });
+
+    test('finds steptypes.json nested under the cartridge (not just at the root)', async () => {
+      const root = await mkTmpDir();
+      const cartridgeRoot = path.join(root, 'nested');
+      // Some cartridges keep steptypes.json under a `meta/` or similar subfolder.
+      await writeJson(path.join(cartridgeRoot, 'meta', 'steptypes.json'), {
+        'step-types': {
+          'script-module-step': [{'@type-id': 'custom.Nested', module: 'nested/cartridge/scripts/nestedStep'}],
+        },
+      });
+
+      const entries = await collectStepTypeEntries(cartridgeRoot);
+      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries[0].typeId, 'custom.Nested');
+    });
+  });
+
+  suite('resolveStepTypeModule', () => {
+    test('resolves module inside the declaring cartridge with cartridge prefix (adds .js)', async () => {
+      const root = await mkTmpDir();
+      const cartridgeRoot = path.join(root, 'app_custom_core');
+      const moduleAbs = path.join(cartridgeRoot, 'cartridge', 'scripts', 'jobsteps', 'myStep.js');
+      await writeFile(moduleAbs, '// step');
+
+      const resolved = await resolveStepTypeModule(
+        'app_custom_core/cartridge/scripts/jobsteps/myStep',
+        cartridgeRoot,
+        [],
+      );
+      assert.strictEqual(resolved, moduleAbs);
+    });
+
+    test('resolves module when the reference already includes .js', async () => {
+      const root = await mkTmpDir();
+      const cartridgeRoot = path.join(root, 'app_custom_core');
+      const moduleAbs = path.join(cartridgeRoot, 'cartridge', 'scripts', 'jobsteps', 'myStep.js');
+      await writeFile(moduleAbs);
+
+      const resolved = await resolveStepTypeModule(
+        'app_custom_core/cartridge/scripts/jobsteps/myStep.js',
+        cartridgeRoot,
+        [],
+      );
+      assert.strictEqual(resolved, moduleAbs);
+    });
+
+    test('resolves legacy module reference without the cartridge prefix', async () => {
+      const root = await mkTmpDir();
+      const cartridgeRoot = path.join(root, 'legacy_cartridge');
+      const moduleAbs = path.join(cartridgeRoot, 'cartridge', 'scripts', 'foo.js');
+      await writeFile(moduleAbs);
+
+      const resolved = await resolveStepTypeModule('cartridge/scripts/foo', cartridgeRoot, []);
+      assert.strictEqual(resolved, moduleAbs);
+    });
+
+    test('falls back to a sibling cartridge when the module names a different cartridge', async () => {
+      const root = await mkTmpDir();
+      const registrarRoot = path.join(root, 'app_custom_core');
+      const implementorRoot = path.join(root, 'plugin_shared');
+      const moduleAbs = path.join(implementorRoot, 'cartridge', 'scripts', 'jobsteps', 'shared.js');
+      await fs.mkdir(registrarRoot, {recursive: true});
+      await writeFile(moduleAbs);
+
+      const resolved = await resolveStepTypeModule('plugin_shared/cartridge/scripts/jobsteps/shared', registrarRoot, [
+        implementorRoot,
+      ]);
+      assert.strictEqual(resolved, moduleAbs);
+    });
+
+    test('returns undefined when the module cannot be resolved', async () => {
+      const root = await mkTmpDir();
+      const cartridgeRoot = path.join(root, 'app_custom_core');
+      await fs.mkdir(cartridgeRoot, {recursive: true});
+
+      const resolved = await resolveStepTypeModule(
+        'app_custom_core/cartridge/scripts/jobsteps/missing',
+        cartridgeRoot,
+        [],
+      );
+      assert.strictEqual(resolved, undefined);
+    });
+
+    test('returns undefined for an empty module reference', async () => {
+      const root = await mkTmpDir();
+      const resolved = await resolveStepTypeModule('   ', path.join(root, 'any'), []);
+      assert.strictEqual(resolved, undefined);
+    });
+  });
+});

--- a/packages/b2c-vs-extension/src/test/jobs-menu.test.ts
+++ b/packages/b2c-vs-extension/src/test/jobs-menu.test.ts
@@ -18,7 +18,7 @@ interface MenuEntry {
 
 interface PackageJson {
   contributes: {
-    commands: Array<{command: string; title: string}>;
+    commands: Array<{command: string; title: string; icon?: string}>;
     views: Record<string, Array<{id: string; visibility?: string}>>;
     menus: {
       'view/item/context': MenuEntry[];
@@ -188,6 +188,7 @@ suite('jobs menu contributions (package.json)', () => {
       'b2c-dx.jobs.setNameFilter',
       'b2c-dx.jobs.toggleAutoRefresh',
       'b2c-dx.jobs.toggleGrouping',
+      'b2c-dx.jobs.toggleGroupingChronological',
       'b2c-dx.jobs.importSiteArchive',
       'b2c-dx.jobs.exportSiteArchive',
       'b2c-dx.jobs.run',
@@ -246,9 +247,34 @@ suite('jobs menu contributions (package.json)', () => {
       // Right-click-only action; requires a workspace-job node to know which
       // jobs.xml to open, so a bare palette invocation would be a dead-end.
       'b2c-dx.jobs.openDefinitionFile',
+      // Alias command that only exists to render a different title-bar icon
+      // when grouping is on; the primary `toggleGrouping` handles palette access.
+      'b2c-dx.jobs.toggleGroupingChronological',
     ]) {
       assert.ok(hiddenInPalette.has(command), `${command} should be hidden from command palette`);
     }
+  });
+
+  test('grouping title-bar icon swaps between list-flat and list-tree based on current mode', () => {
+    const titleEntries = pkg.contributes.menus['view/title'].filter((entry) => entry.when?.includes('b2cJobsExplorer'));
+    const flatEntry = titleEntries.find((entry) => entry.command === 'b2c-dx.jobs.toggleGrouping');
+    const treeEntry = titleEntries.find((entry) => entry.command === 'b2c-dx.jobs.toggleGroupingChronological');
+    assert.ok(flatEntry, 'chronological-mode icon entry must exist');
+    assert.ok(treeEntry, 'grouped-mode icon entry must exist');
+    // list-flat is shown while chronological (action = switch to grouped);
+    // list-tree is shown while grouped (action = switch back to chronological).
+    assert.ok(
+      flatEntry.when?.includes('b2c-dx.jobs.groupingMode != groupByJobId'),
+      'chronological variant must be gated when NOT grouped',
+    );
+    assert.ok(
+      treeEntry.when?.includes('b2c-dx.jobs.groupingMode == groupByJobId'),
+      'grouped variant must be gated when grouped',
+    );
+    const flatCmd = pkg.contributes.commands.find((c) => c.command === 'b2c-dx.jobs.toggleGrouping');
+    const treeCmd = pkg.contributes.commands.find((c) => c.command === 'b2c-dx.jobs.toggleGroupingChronological');
+    assert.strictEqual(flatCmd?.icon, '$(list-flat)');
+    assert.strictEqual(treeCmd?.icon, '$(list-tree)');
   });
 
   test('filter title-bar icon swaps between filled and outlined based on active filters', () => {

--- a/packages/b2c-vs-extension/src/test/jobs-menu.test.ts
+++ b/packages/b2c-vs-extension/src/test/jobs-menu.test.ts
@@ -163,6 +163,8 @@ suite('jobs menu contributions (package.json)', () => {
   test('jobs commands are declared and hidden from command palette where appropriate', () => {
     const expectedCommands = [
       'b2c-dx.jobs.openFilters',
+      'b2c-dx.jobs.openFiltersActive',
+      'b2c-dx.jobs.clearAllFilters',
       'b2c-dx.jobs.refresh',
       'b2c-dx.jobs.setStatusFilter',
       'b2c-dx.jobs.setHistoryFilters',
@@ -216,9 +218,31 @@ suite('jobs menu contributions (package.json)', () => {
       'b2c-dx.jobs.viewExecutionDetails',
       'b2c-dx.jobs.openExecutionLog',
       'b2c-dx.jobs.openFailureLog',
+      // Alias command that only exists to render a different title-bar icon
+      // when filters are active; the primary `openFilters` handles palette access.
+      'b2c-dx.jobs.openFiltersActive',
+      // Only invoked from the empty-state tree row; palette entry would be a dead-end.
+      'b2c-dx.jobs.clearAllFilters',
     ]) {
       assert.ok(hiddenInPalette.has(command), `${command} should be hidden from command palette`);
     }
+  });
+
+  test('filter title-bar icon swaps between filled and outlined based on active filters', () => {
+    const titleEntries = pkg.contributes.menus['view/title'].filter((entry) => entry.when?.includes('b2cJobsExplorer'));
+    const outlineEntry = titleEntries.find((entry) => entry.command === 'b2c-dx.jobs.openFilters');
+    const filledEntry = titleEntries.find((entry) => entry.command === 'b2c-dx.jobs.openFiltersActive');
+    assert.ok(outlineEntry, 'outlined filter icon entry must exist');
+    assert.ok(filledEntry, 'filled filter icon entry must exist');
+    assert.ok(
+      outlineEntry.when?.includes('!b2c-dx.jobs.hasActiveFilters'),
+      'outlined variant must be gated on !hasActiveFilters',
+    );
+    assert.ok(
+      filledEntry.when?.includes('b2c-dx.jobs.hasActiveFilters') &&
+        !filledEntry.when.includes('!b2c-dx.jobs.hasActiveFilters'),
+      'filled variant must be gated on hasActiveFilters',
+    );
   });
 
   test('job history title bar exposes the expected actions', () => {

--- a/packages/b2c-vs-extension/src/test/jobs-menu.test.ts
+++ b/packages/b2c-vs-extension/src/test/jobs-menu.test.ts
@@ -58,24 +58,41 @@ function whenClauseMatches(whenClause: string | undefined, viewItem: string): bo
 
 suite('jobs menu contributions (package.json)', () => {
   let pkg: PackageJson;
-  let contextEntries: Record<string, MenuEntry>;
+  /**
+   * Multi-map — a single command can appear more than once in `view/item/context`
+   * with different `when` clauses (e.g. `b2c-dx.jobs.run` is offered on both
+   * execution rows AND workspace-job rows, each with its own context value).
+   * Tests read this list and assert `some(...)` rather than deduping by command,
+   * which would silently drop everything past the first entry.
+   */
+  let contextEntries: Record<string, MenuEntry[]>;
 
   suiteSetup(() => {
     pkg = loadPackageJson();
     contextEntries = {};
     for (const entry of pkg.contributes.menus['view/item/context']) {
       if (entry.command?.startsWith('b2c-dx.jobs.') && entry.when?.includes('b2cJobsExplorer')) {
-        contextEntries[entry.command] = entry;
+        (contextEntries[entry.command] ??= []).push(entry);
       }
     }
   });
 
-  test('job history view lives under the primary b2c-dx container and is collapsed by default', () => {
+  function anyEntryMatches(command: string, viewItem: string): boolean {
+    const entries = contextEntries[command] ?? [];
+    return entries.some((entry) => whenClauseMatches(entry.when, viewItem));
+  }
+
+  test('jobs view lives under the primary b2c-dx container and is collapsed by default', () => {
     const b2cDxViews = pkg.contributes.views['b2c-dx'] ?? [];
-    const historyView = b2cDxViews.find((view) => view.id === 'b2cJobsExplorer');
-    assert.ok(historyView, 'b2cJobsExplorer view should live under the b2c-dx container');
+    const jobsView = b2cDxViews.find((view) => view.id === 'b2cJobsExplorer');
+    assert.ok(jobsView, 'b2cJobsExplorer view should live under the b2c-dx container');
     assert.strictEqual(
-      historyView!.visibility,
+      (jobsView as {name?: string}).name,
+      'Jobs',
+      'b2cJobsExplorer should be labeled "Jobs" — the view surfaces workspace jobs alongside history in one tree',
+    );
+    assert.strictEqual(
+      jobsView!.visibility,
       'collapsed',
       'b2cJobsExplorer should be collapsed by default to stay out of the way until the user opens it',
     );
@@ -182,6 +199,10 @@ suite('jobs menu contributions (package.json)', () => {
       'b2c-dx.jobs.openExecutionLog',
       'b2c-dx.jobs.openFailureLog',
       'b2c-dx.jobs.openBmDefinitions',
+      // Right-click action on Workspace Jobs rows — jumps to the declaring
+      // jobs.xml at the matching <job> block so users can inspect/edit the
+      // definition without hunting for the file.
+      'b2c-dx.jobs.openDefinitionFile',
     ];
     for (const command of expectedCommands) {
       assert.ok(
@@ -198,7 +219,6 @@ suite('jobs menu contributions (package.json)', () => {
       'b2c-dx.jobs.refreshDefinitions',
       'b2c-dx.jobs.deployScaffold',
       'b2c-dx.jobs.deployDefinition',
-      'b2c-dx.jobs.openDefinitionFile',
     ];
     for (const command of removedCommands) {
       assert.ok(
@@ -223,6 +243,9 @@ suite('jobs menu contributions (package.json)', () => {
       'b2c-dx.jobs.openFiltersActive',
       // Only invoked from the empty-state tree row; palette entry would be a dead-end.
       'b2c-dx.jobs.clearAllFilters',
+      // Right-click-only action; requires a workspace-job node to know which
+      // jobs.xml to open, so a bare palette invocation would be a dead-end.
+      'b2c-dx.jobs.openDefinitionFile',
     ]) {
       assert.ok(hiddenInPalette.has(command), `${command} should be hidden from command palette`);
     }
@@ -257,7 +280,7 @@ suite('jobs menu contributions (package.json)', () => {
       'b2c-dx.jobs.openBmDefinitions',
       'b2c-dx.jobs.run',
     ]) {
-      assert.ok(titleCommands.has(command), `${command} should appear in the Job History title bar`);
+      assert.ok(titleCommands.has(command), `${command} should appear in the Jobs title bar`);
     }
 
     // The two state-specific commands must be gated on opposite sides of the
@@ -287,12 +310,28 @@ suite('jobs menu contributions (package.json)', () => {
     );
   });
 
+  test('workspace-job rows expose Run and Open jobs.xml on right-click', () => {
+    // Workspace jobs are declared in a cartridge's jobs.xml but may not yet be
+    // registered in Business Manager. The right-click menu is the primary
+    // affordance for running them — the extension auto-deploys the definition
+    // when BM doesn't know it yet — and for jumping to the source file for
+    // inspection/edit.
+    const workspaceEntries = pkg.contributes.menus['view/item/context'].filter(
+      (entry) => entry.when?.includes('viewItem == workspaceJob') && entry.when?.includes('b2cJobsExplorer'),
+    );
+    const commands = new Set(workspaceEntries.map((entry) => entry.command));
+    assert.ok(commands.has('b2c-dx.jobs.run'), 'Run must be on the workspace-job right-click menu');
+    assert.ok(
+      commands.has('b2c-dx.jobs.openDefinitionFile'),
+      'Open jobs.xml must be on the workspace-job right-click menu',
+    );
+  });
+
   test('jobs context menu visibility aligns with execution states', () => {
-    const runWhen = contextEntries['b2c-dx.jobs.run']?.when;
-    // Run is now offered on execution rows directly (the chronological feed
-    // is the only level in the tree).
-    assert.ok(whenClauseMatches(runWhen, 'jobExecution-running'));
-    assert.ok(whenClauseMatches(runWhen, 'jobExecution-completed'));
+    // Run is offered on both execution rows (chronological feed) AND workspace-job
+    // rows — anyEntryMatches() checks every declared `when` clause for the command.
+    assert.ok(anyEntryMatches('b2c-dx.jobs.run', 'jobExecution-running'));
+    assert.ok(anyEntryMatches('b2c-dx.jobs.run', 'jobExecution-completed'));
 
     // Scaffold and deploy actions are no longer surfaced on the Job History
     // tree — they belong on cartridges / via the palette.
@@ -301,13 +340,11 @@ suite('jobs menu contributions (package.json)', () => {
       'createScaffold should not be in the Job History context menu',
     );
 
-    const stopWhen = contextEntries['b2c-dx.jobs.stop']?.when;
-    assert.ok(whenClauseMatches(stopWhen, 'jobExecution-running'));
-    assert.ok(!whenClauseMatches(stopWhen, 'jobExecution-completed'));
-    assert.ok(!whenClauseMatches(stopWhen, 'jobExecution-failed'));
+    assert.ok(anyEntryMatches('b2c-dx.jobs.stop', 'jobExecution-running'));
+    assert.ok(!anyEntryMatches('b2c-dx.jobs.stop', 'jobExecution-completed'));
+    assert.ok(!anyEntryMatches('b2c-dx.jobs.stop', 'jobExecution-failed'));
 
-    const failureLogWhen = contextEntries['b2c-dx.jobs.openFailureLog']?.when;
-    assert.ok(whenClauseMatches(failureLogWhen, 'jobExecution-failed'));
-    assert.ok(!whenClauseMatches(failureLogWhen, 'jobExecution-running'));
+    assert.ok(anyEntryMatches('b2c-dx.jobs.openFailureLog', 'jobExecution-failed'));
+    assert.ok(!anyEntryMatches('b2c-dx.jobs.openFailureLog', 'jobExecution-running'));
   });
 });

--- a/packages/b2c-vs-extension/src/test/jobs-xml-parser.test.ts
+++ b/packages/b2c-vs-extension/src/test/jobs-xml-parser.test.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as assert from 'assert';
+import * as path from 'path';
+import {
+  detectCartridgeName,
+  extractJobBlockXml,
+  extractJobIdsFromXml,
+  findJobBlockOffset,
+  stripXmlComments,
+} from '../jobs/jobs-xml-parser.js';
+
+suite('jobs-xml-parser', () => {
+  suite('extractJobIdsFromXml', () => {
+    test('parses the canonical double-quoted form', () => {
+      const xml = `<?xml version="1.0"?>
+<jobs xmlns="http://www.demandware.com/xml/impex/jobs/2015-07-01">
+  <job job-id="my-job"><description>x</description><flow/><triggers/></job>
+</jobs>`;
+      assert.deepStrictEqual(extractJobIdsFromXml(xml), ['my-job']);
+    });
+
+    test('tolerates attributes appearing in any order', () => {
+      const xml = `<job name="ignored" job-id="import"><flow/><triggers/></job>`;
+      assert.deepStrictEqual(extractJobIdsFromXml(xml), ['import']);
+    });
+
+    test('tolerates single-quoted attribute values', () => {
+      const xml = `<job job-id='single-quoted'><flow/><triggers/></job>`;
+      assert.deepStrictEqual(extractJobIdsFromXml(xml), ['single-quoted']);
+    });
+
+    test('tolerates whitespace around the attribute equals sign', () => {
+      const xml = `<job job-id = "spaced-equals"><flow/><triggers/></job>`;
+      assert.deepStrictEqual(extractJobIdsFromXml(xml), ['spaced-equals']);
+    });
+
+    test('ignores commented-out job blocks — disabled jobs must not populate the tree', () => {
+      const xml = `<jobs>
+  <!-- <job job-id="disabled"><flow/><triggers/></job> -->
+  <job job-id="live"><flow/><triggers/></job>
+</jobs>`;
+      assert.deepStrictEqual(extractJobIdsFromXml(xml), ['live']);
+    });
+
+    test('ignores multi-line commented-out job blocks', () => {
+      const xml = `<jobs>
+  <!--
+    <job job-id="also-disabled">
+      <flow/><triggers/>
+    </job>
+  -->
+  <job job-id="also-live"><flow/><triggers/></job>
+</jobs>`;
+      assert.deepStrictEqual(extractJobIdsFromXml(xml), ['also-live']);
+    });
+
+    test('returns each id once even if declared multiple times', () => {
+      const xml = `<jobs>
+  <job job-id="dup"><flow/><triggers/></job>
+  <job job-id="dup"><flow/><triggers/></job>
+</jobs>`;
+      assert.deepStrictEqual(extractJobIdsFromXml(xml), ['dup']);
+    });
+
+    test('preserves file order across multiple jobs', () => {
+      const xml = `<jobs>
+  <job job-id="second"><flow/><triggers/></job>
+  <job job-id="first"><flow/><triggers/></job>
+</jobs>`;
+      assert.deepStrictEqual(extractJobIdsFromXml(xml), ['second', 'first']);
+    });
+
+    test('returns empty array when no jobs are declared', () => {
+      assert.deepStrictEqual(extractJobIdsFromXml('<jobs></jobs>'), []);
+      assert.deepStrictEqual(extractJobIdsFromXml(''), []);
+    });
+  });
+
+  suite('extractJobBlockXml', () => {
+    test('returns the full <job>…</job> block for a matching id', () => {
+      const xml = `<jobs>
+  <job job-id="target"><description>x</description><flow/><triggers/></job>
+</jobs>`;
+      const block = extractJobBlockXml(xml, 'target');
+      assert.ok(block?.startsWith('<job job-id="target">'));
+      assert.ok(block?.endsWith('</job>'));
+    });
+
+    test('returns undefined when the id is only inside a comment', () => {
+      const xml = `<jobs>
+  <!-- <job job-id="commented"><flow/><triggers/></job> -->
+</jobs>`;
+      assert.strictEqual(extractJobBlockXml(xml, 'commented'), undefined);
+    });
+
+    test('handles single-quoted attributes', () => {
+      const xml = `<jobs><job job-id='sq'><flow/><triggers/></job></jobs>`;
+      const block = extractJobBlockXml(xml, 'sq');
+      assert.ok(block?.startsWith("<job job-id='sq'>"));
+    });
+
+    test('is exact — different job-id returns undefined', () => {
+      const xml = `<jobs><job job-id="alpha"><flow/><triggers/></job></jobs>`;
+      assert.strictEqual(extractJobBlockXml(xml, 'beta'), undefined);
+    });
+  });
+
+  suite('findJobBlockOffset', () => {
+    test('returns the offset of the opening tag in the original text', () => {
+      const xml = `<jobs>\n  <job job-id="hop">...</job>\n</jobs>`;
+      const offset = findJobBlockOffset(xml, 'hop');
+      assert.notStrictEqual(offset, undefined);
+      assert.strictEqual(xml.slice(offset!, offset! + 5), '<job ');
+    });
+
+    test('returns undefined when the id is only inside a comment', () => {
+      const xml = `<jobs><!-- <job job-id="ghost"/> --></jobs>`;
+      assert.strictEqual(findJobBlockOffset(xml, 'ghost'), undefined);
+    });
+
+    test('skips a comment before the real block and still points at the real tag', () => {
+      // A comment containing a similarly-named block precedes the real one.
+      // The returned offset must land on the real tag, not inside the comment,
+      // so opening the file jumps the user to the live definition.
+      const xml = `<jobs>
+  <!-- old:
+    <job job-id="renamed"><flow/></job>
+  -->
+  <job job-id="renamed"><flow/><triggers/></job>
+</jobs>`;
+      const offset = findJobBlockOffset(xml, 'renamed');
+      assert.notStrictEqual(offset, undefined);
+      // Verify we're at the live tag, not inside the <!-- --> block.
+      assert.ok(!xml.slice(0, offset!).endsWith('<!-- old:\n    '));
+      assert.strictEqual(xml.slice(offset!, offset! + 20), '<job job-id="renamed');
+    });
+  });
+
+  suite('detectCartridgeName', () => {
+    test('prefers a known cartridge root over the path heuristic', () => {
+      // Non-standard layout: cartridge lives directly under src/, no
+      // `.../cartridge/...` segment in the jobs.xml path. Path heuristic would
+      // fall back to the immediate parent dir ("app_storefront_base") but only
+      // by coincidence — supplied roots make the label authoritative.
+      const jobsPath = path.join('/repo', 'src', 'app_storefront_base', 'jobs.xml');
+      const roots = [{name: 'app_storefront_base', src: path.join('/repo', 'src', 'app_storefront_base')}];
+      assert.strictEqual(detectCartridgeName(jobsPath, roots), 'app_storefront_base');
+    });
+
+    test('picks the deepest matching root when cartridges nest', () => {
+      // Contrived but tests the tiebreak — longest src prefix wins so an inner
+      // cartridge label overrides an outer one.
+      const jobsPath = path.join('/repo', 'outer', 'inner', 'cartridge', 'jobs.xml');
+      const roots = [
+        {name: 'outer', src: path.join('/repo', 'outer')},
+        {name: 'inner', src: path.join('/repo', 'outer', 'inner')},
+      ];
+      assert.strictEqual(detectCartridgeName(jobsPath, roots), 'inner');
+    });
+
+    test('falls back to the path heuristic when no known roots are supplied', () => {
+      const jobsPath = path.join('/repo', 'app_custom_core', 'cartridge', 'jobs.xml');
+      assert.strictEqual(detectCartridgeName(jobsPath), 'app_custom_core');
+    });
+
+    test('exact-match segment lookup does not false-match on longer names', () => {
+      // "my-cartridge-utils" contains "cartridge" as a substring, but the
+      // segment lookup checks for an exact "cartridge" folder — no false match.
+      const jobsPath = path.join('/repo', 'my-cartridge-utils', 'jobs.xml');
+      assert.strictEqual(detectCartridgeName(jobsPath), 'my-cartridge-utils');
+    });
+
+    test('exact-match segment lookup does not false-match on the plural container', () => {
+      // A top-level `cartridges/` container is a common layout — the heuristic
+      // must not treat that segment as the canonical `cartridge` marker.
+      const jobsPath = path.join('/repo', 'cartridges', 'app_custom_core', 'jobs.xml');
+      assert.strictEqual(detectCartridgeName(jobsPath), 'app_custom_core');
+    });
+
+    test('returns the parent directory as a last-resort label', () => {
+      // Nothing to anchor on — no known roots, no `cartridge` segment. We still
+      // return a label so tree rows aren't unlabeled.
+      const jobsPath = path.join('/tmp', 'ad-hoc', 'jobs.xml');
+      assert.strictEqual(detectCartridgeName(jobsPath), 'ad-hoc');
+    });
+  });
+
+  suite('stripXmlComments', () => {
+    test('removes a single-line comment', () => {
+      assert.strictEqual(stripXmlComments('a<!-- x -->b'), 'ab');
+    });
+
+    test('removes multi-line comments', () => {
+      assert.strictEqual(stripXmlComments('a<!--\nline1\nline2\n-->b'), 'ab');
+    });
+
+    test('leaves comment-free XML untouched', () => {
+      const xml = '<a><b/></a>';
+      assert.strictEqual(stripXmlComments(xml), xml);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Brief description of what this PR does.

 Surfaces **Custom Step Types** as a third category in the Cartridges explorer and adds **Workspace Jobs** discovery from `jobs.xml`, with filter UX polish for the Jobs view.

  ### What changed

  - **Custom Step Types tree** — each cartridge now shows a "Step Types" group populated from `steptypes.json`. Click a step type to open its module `.js`; right-click → "Show Step Type Definition" jumps to the `@type-id` line in the JSON.
  Cross-cartridge module resolution supported.
  - **Workspace Jobs section** — Jobs tree now shows a "Workspace" section alongside run history, scanning `**/jobs.xml` in the workspace. A file-system watcher keeps it in sync. When the server reports a job as not runnable, the user is
  prompted to auto-deploy the definition from the workspace.
  - **Filter UX** — filter icon swaps between outlined/filled based on active-filter state. "Clear All Filters" now resets both status and advanced fields in one action. Active filter summary shown in the tree view message bar.

  ## Testing

  - Unit tests added for `collectStepTypeEntries` (canonical, legacy flat-array, malformed JSON, missing fields) and `resolveStepTypeModule` (with/without `.js`, cross-cartridge, unresolvable ref).
  - `jobs-menu.test.ts` updated to assert new commands, filter icon swap, and workspace-job context menu entries.
  - Manually verified in Extension Development Host: step types appear under cartridges, click/right-click navigation works, filter icon toggles correctly.


## Dependencies

- [x] No net-new third-party dependencies were added
- [x] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
