### PR TITLE
@W-23333714 clarified usage of SFCC_SHORTCODE vs SFCC_SHORT_CODE

### DIFF
--- a/.changeset/busy-cities-notice.md
+++ b/.changeset/busy-cities-notice.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+'@salesforce/b2c-cli': patch
+---
+
+Clarified SFCC_SHORTCODE vs SFCC_SHORT_CODE env var usage

--- a/docs/cli/ecdn.md
+++ b/docs/cli/ecdn.md
@@ -13,7 +13,7 @@ All eCDN commands support these flags:
 | Flag | Description | Environment Variable |
 |------|-------------|---------------------|
 | `--tenant-id` | B2C Commerce tenant ID | `SFCC_TENANT_ID` |
-| `--short-code` | API short code | `SFCC_SHORT_CODE` |
+| `--short-code` | API short code | `SFCC_SHORTCODE` |
 | `--json` | Output as JSON | - |
 
 ### Zone Selection

--- a/packages/b2c-cli/src/commands/slas/client/open.ts
+++ b/packages/b2c-cli/src/commands/slas/client/open.ts
@@ -44,6 +44,7 @@ export default class SlasClientOpen extends BaseCommand<typeof SlasClientOpen> {
     'short-code': Flags.string({
       description: 'SCAPI short code',
       env: 'SFCC_SHORTCODE',
+      default: async () => process.env.SFCC_SHORT_CODE || undefined,
     }),
   };
 

--- a/packages/b2c-tooling-sdk/src/cli/oauth-command.ts
+++ b/packages/b2c-tooling-sdk/src/cli/oauth-command.ts
@@ -71,6 +71,7 @@ export abstract class OAuthCommand<T extends typeof Command> extends BaseCommand
     'short-code': Flags.string({
       description: 'SCAPI short code',
       env: 'SFCC_SHORTCODE',
+      default: async () => process.env.SFCC_SHORT_CODE || undefined,
       helpGroup: 'AUTH',
     }),
     'tenant-id': Flags.string({

--- a/packages/b2c-tooling-sdk/src/config/sources/env-source.ts
+++ b/packages/b2c-tooling-sdk/src/config/sources/env-source.ts
@@ -35,6 +35,7 @@ const ENV_VAR_MAP: Record<string, keyof NormalizedConfig> = {
   SFCC_CLIENT_ID: 'clientId',
   SFCC_CLIENT_SECRET: 'clientSecret',
   SFCC_OAUTH_SCOPES: 'scopes',
+  SFCC_SHORT_CODE: 'shortCode',
   SFCC_SHORTCODE: 'shortCode',
   SFCC_TENANT_ID: 'tenantId',
   SFCC_CARTRIDGES: 'cartridges',

--- a/packages/b2c-tooling-sdk/test/config/env-source.test.ts
+++ b/packages/b2c-tooling-sdk/test/config/env-source.test.ts
@@ -72,6 +72,18 @@ describe('config/EnvSource', () => {
       expect(result!.config.shortCode).to.equal('abc123');
     });
 
+    it('maps SFCC_SHORT_CODE to shortCode (legacy alias)', () => {
+      const source = new EnvSource({SFCC_SHORT_CODE: 'abc123'});
+      const result = source.load({});
+      expect(result!.config.shortCode).to.equal('abc123');
+    });
+
+    it('SFCC_SHORTCODE takes precedence over SFCC_SHORT_CODE when both set', () => {
+      const source = new EnvSource({SFCC_SHORT_CODE: 'legacy-code', SFCC_SHORTCODE: 'canonical-code'});
+      const result = source.load({});
+      expect(result!.config.shortCode).to.equal('canonical-code');
+    });
+
     it('maps SFCC_TENANT_ID to tenantId', () => {
       const source = new EnvSource({SFCC_TENANT_ID: 'abcd_prd'});
       const result = source.load({});


### PR DESCRIPTION
## Summary

Document `SFCC_SHORTCODE` as the official supported env var, but also silently accept `SFCC_SHORT_CODE` when provided

## Testing

Here's how to manually verify both paths:

1. SFCC_SHORTCODE still works (canonical — no regression):

SFCC_SHORTCODE=kv7kzm78 ./cli ecdn zones list --tenant-id zzxy_prd

2. SFCC_SHORT_CODE works as fallback (new behavior):

SFCC_SHORT_CODE=kv7kzm78 ./cli ecdn zones list --tenant-id zzxy_prd
Should behave identically to the above.

3. SFCC_SHORTCODE wins when both are set:

SFCC_SHORT_CODE=wrong-code SFCC_SHORTCODE=kv7kzm78 ./cli ecdn zones list --tenant-id zzxy_prd
Should use kv7kzm78, not wrong-code.

4. Explicit flag still wins over both env vars:

SFCC_SHORT_CODE=wrong-code SFCC_SHORTCODE=also-wrong ./cli ecdn zones list --tenant-id zzxy_prd --short-code kv7kzm78
Should use kv7kzm78.

You can use b2c setup inspect to see which value was resolved without needing a real network call, if that command shows shortCode in its output.

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
