### PR TITLE
fix(auth): form-url-encode client credentials in Basic header per RFC 6749 §2.3.1

### DIFF
--- a/.changeset/encode-basic-client-credentials.md
+++ b/.changeset/encode-basic-client-credentials.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+'@salesforce/b2c-cli': patch
+---
+
+Fix OAuth client authentication failing for client secrets containing `+` (or other reserved characters). Per RFC 6749 §2.3.1, the client ID and secret are now form-url-encoded before being Base64-encoded into the HTTP Basic `Authorization` header, matching how they are already encoded when sent in the request body. Previously a raw `+` in a secret was decoded to a space by Account Manager, causing `invalid_client` errors on Basic auth even though the same credential worked via the request body. Affects the client-credentials/password grants (`b2c auth client`, token renewal) and SLAS private-client flows.

--- a/packages/b2c-cli/src/commands/auth/client/index.ts
+++ b/packages/b2c-cli/src/commands/auth/client/index.ts
@@ -5,7 +5,7 @@
  */
 import {Flags} from '@oclif/core';
 import {BaseCommand, loadConfig} from '@salesforce/b2c-tooling-sdk/cli';
-import {setStoredSession, decodeJWT} from '@salesforce/b2c-tooling-sdk/auth';
+import {setStoredSession, decodeJWT, encodeBasicClientCredentials} from '@salesforce/b2c-tooling-sdk/auth';
 import {DEFAULT_ACCOUNT_MANAGER_HOST} from '@salesforce/b2c-tooling-sdk';
 import {t} from '../../../i18n/index.js';
 
@@ -131,7 +131,7 @@ export default class AuthClient extends BaseCommand<typeof AuthClient> {
       grantPayload.scope = scopes.join(' ');
     }
 
-    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+    const credentials = encodeBasicClientCredentials(clientId, clientSecret);
     const url = `https://${accountManagerHost}/dwsso/oauth2/access_token`;
 
     const method = 'POST';

--- a/packages/b2c-tooling-sdk/src/auth/client-credentials.ts
+++ b/packages/b2c-tooling-sdk/src/auth/client-credentials.ts
@@ -10,12 +10,24 @@
  */
 
 /**
- * Form-url-encode a single value per the `application/x-www-form-urlencoded`
- * escaping rules that RFC 6749 Appendix B references (W3C HTML 4.01, UTF-8
- * first). `URLSearchParams` implements exactly these rules -- notably a space
- * becomes `+` (not `%20`), matching Appendix B's own worked example. This is
- * intentionally the same encoder the token-request body uses, so a credential
- * is encoded identically whether it is sent in the Basic header or the body.
+ * Form-url-encode a single value using the `application/x-www-form-urlencoded`
+ * escaping rules that RFC 6749 Appendix B references -- the W3C HTML form rules
+ * (UTF-8 first), NOT RFC 3986 percent-encoding. `URLSearchParams` implements
+ * exactly these rules.
+ *
+ * The two encodings differ only for a space (form rules -> `+`, RFC 3986 ->
+ * `%20`) and a few punctuation chars (`!`, `~`, `(`, `)`). They agree on every
+ * other byte, INCLUDING `+` and `%` -- the characters that actually trigger the
+ * auth failure this module fixes -- so the encoder choice does not affect that
+ * bug. We use the form rules (`URLSearchParams`) regardless because:
+ *   1. they are precisely the Appendix B algorithm -- its worked example encodes
+ *      U+0020 (space) as `+`, which `URLSearchParams` reproduces; and
+ *   2. they are the same rules the token-request body uses, so a credential is
+ *      byte-identical whether sent in the Basic header or in the body.
+ * The two are only interchangeable against a server that form-url-decodes (as
+ * Account Manager does); a strict RFC 3986 decoder would read a form-encoded
+ * space (`+`) as a literal `+`, so matching the algorithm the RFC names is the
+ * safe choice rather than a coincidence that happens to work.
  */
 function formUrlEncodeComponent(value: string): string {
   // The name is empty, so the serialized "=value" is sliced to just the value.
@@ -29,10 +41,13 @@ function formUrlEncodeComponent(value: string): string {
  * The client identifier and client password are each form-url-encoded (RFC 6749
  * Appendix B) *before* being joined with a colon and Base64-encoded (RFC 7617
  * §2, the HTTP Basic scheme). Skipping the per-component encoding corrupts any
- * credential containing characters the server form-url-decodes -- most commonly
- * `+` (which a compliant server reads as a space) or a `%xx` sequence -- causing
- * `invalid_client` even though the same credential succeeds when sent in the
- * request body (which is form-url-encoded by construction).
+ * credential containing characters the server form-url-decodes: a raw `+` is
+ * read as a space and a valid `%xx` escape is decoded to another byte (both
+ * yield `invalid_client` -- a wrong-but-valid secret), while an invalid escape
+ * such as `%zz` makes a strict decoder error out (`unauthorized_client` /
+ * "Unexpected error when authenticating client"). The same credential succeeds
+ * when sent in the request body, which is form-url-encoded by construction --
+ * the "body works, Basic fails" symptom.
  *
  * @param clientId - The OAuth client identifier
  * @param clientSecret - The OAuth client password/secret

--- a/packages/b2c-tooling-sdk/src/auth/client-credentials.ts
+++ b/packages/b2c-tooling-sdk/src/auth/client-credentials.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+/**
+ * Encoding of OAuth client credentials for the HTTP Basic `Authorization` header.
+ *
+ * @module auth/client-credentials
+ */
+
+/**
+ * Form-url-encode a single value per the `application/x-www-form-urlencoded`
+ * escaping rules that RFC 6749 Appendix B references (W3C HTML 4.01, UTF-8
+ * first). `URLSearchParams` implements exactly these rules -- notably a space
+ * becomes `+` (not `%20`), matching Appendix B's own worked example. This is
+ * intentionally the same encoder the token-request body uses, so a credential
+ * is encoded identically whether it is sent in the Basic header or the body.
+ */
+function formUrlEncodeComponent(value: string): string {
+  // The name is empty, so the serialized "=value" is sliced to just the value.
+  return new URLSearchParams([['', value]]).toString().slice(1);
+}
+
+/**
+ * Builds the base64 payload for an `Authorization: Basic` header carrying OAuth
+ * client credentials, per RFC 6749 §2.3.1.
+ *
+ * The client identifier and client password are each form-url-encoded (RFC 6749
+ * Appendix B) *before* being joined with a colon and Base64-encoded (RFC 7617
+ * §2, the HTTP Basic scheme). Skipping the per-component encoding corrupts any
+ * credential containing characters the server form-url-decodes -- most commonly
+ * `+` (which a compliant server reads as a space) or a `%xx` sequence -- causing
+ * `invalid_client` even though the same credential succeeds when sent in the
+ * request body (which is form-url-encoded by construction).
+ *
+ * @param clientId - The OAuth client identifier
+ * @param clientSecret - The OAuth client password/secret
+ * @returns The Base64 string to place after `Basic ` in the `Authorization` header
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-B
+ */
+export function encodeBasicClientCredentials(clientId: string, clientSecret: string): string {
+  const userPass = `${formUrlEncodeComponent(clientId)}:${formUrlEncodeComponent(clientSecret)}`;
+  return Buffer.from(userPass).toString('base64');
+}

--- a/packages/b2c-tooling-sdk/src/auth/index.ts
+++ b/packages/b2c-tooling-sdk/src/auth/index.ts
@@ -75,6 +75,9 @@ export type {
 } from './types.js';
 export {ALL_AUTH_METHODS} from './types.js';
 
+// Client credential encoding (RFC 6749 §2.3.1)
+export {encodeBasicClientCredentials} from './client-credentials.js';
+
 // Strategies
 export {BasicAuthStrategy} from './basic.js';
 export {OAuthStrategy, decodeJWT} from './oauth.js';

--- a/packages/b2c-tooling-sdk/src/auth/oauth.ts
+++ b/packages/b2c-tooling-sdk/src/auth/oauth.ts
@@ -9,6 +9,7 @@ import {wrapNetworkError} from '../errors/network-error.js';
 import {getLogger} from '../logging/logger.js';
 import {DEFAULT_ACCOUNT_MANAGER_HOST} from '../defaults.js';
 import {globalAuthMiddlewareRegistry, applyAuthRequestMiddleware, applyAuthResponseMiddleware} from './middleware.js';
+import {encodeBasicClientCredentials} from './client-credentials.js';
 
 // Module-level token cache to support multiple instances with same clientId
 const ACCESS_TOKEN_CACHE: Map<string, AccessTokenResponse> = new Map();
@@ -286,7 +287,7 @@ export class OAuthStrategy implements AuthStrategy {
       params.append('scope', this.config.scopes.join(' '));
     }
 
-    const credentials = Buffer.from(`${this.config.clientId}:${this.config.clientSecret}`).toString('base64');
+    const credentials = encodeBasicClientCredentials(this.config.clientId, this.config.clientSecret);
 
     // Build request object for middleware
     let request = new Request(url, {

--- a/packages/b2c-tooling-sdk/src/slas/token.ts
+++ b/packages/b2c-tooling-sdk/src/slas/token.ts
@@ -12,6 +12,7 @@
  *
  * @module slas/token
  */
+import {encodeBasicClientCredentials} from '../auth/client-credentials.js';
 import {wrapNetworkError} from '../errors/network-error.js';
 import {getLogger} from '../logging/logger.js';
 import {generateCodeChallenge, generateCodeVerifier} from './pkce.js';
@@ -182,7 +183,7 @@ async function getPrivateClientGuestToken(config: SlasTokenConfig): Promise<Slas
   logger.debug({clientId: config.slasClientId}, '[SLAS] Using private client client_credentials guest flow');
 
   const baseUrl = buildBaseUrl(config.shortCode, config.organizationId);
-  const basicAuth = Buffer.from(`${config.slasClientId}:${config.slasClientSecret}`).toString('base64');
+  const basicAuth = encodeBasicClientCredentials(config.slasClientId, config.slasClientSecret!);
 
   const tokenBody = new URLSearchParams({
     grant_type: 'client_credentials',
@@ -294,7 +295,7 @@ export async function getRegisteredToken(config: SlasRegisteredLoginConfig): Pro
 
   const tokenHeaders: Record<string, string> = {'Content-Type': 'application/x-www-form-urlencoded'};
   if (isPrivate) {
-    const basicAuth = Buffer.from(`${config.slasClientId}:${config.slasClientSecret}`).toString('base64');
+    const basicAuth = encodeBasicClientCredentials(config.slasClientId, config.slasClientSecret!);
     tokenHeaders.Authorization = `Basic ${basicAuth}`;
   }
 

--- a/packages/b2c-tooling-sdk/test/auth/client-credentials.test.ts
+++ b/packages/b2c-tooling-sdk/test/auth/client-credentials.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {expect} from 'chai';
+import {encodeBasicClientCredentials} from '@salesforce/b2c-tooling-sdk/auth';
+
+/**
+ * Reverses the server side of RFC 6749 §2.3.1: base64-decode the Basic payload,
+ * split on the first colon, then form-url-decode each half. Used to prove that a
+ * compliant server recovers the original credentials byte-for-byte.
+ */
+function decodeBasicClientCredentials(basic: string): {id: string; secret: string} {
+  const decoded = Buffer.from(basic, 'base64').toString('utf8');
+  const idx = decoded.indexOf(':');
+  const rawId = decoded.slice(0, idx);
+  const rawSecret = decoded.slice(idx + 1);
+  const decode = (v: string): string => new URLSearchParams(`x=${v}`).get('x') ?? '';
+  return {id: decode(rawId), secret: decode(rawSecret)};
+}
+
+describe('auth/client-credentials', () => {
+  describe('encodeBasicClientCredentials', () => {
+    it('base64-encodes plain alphanumeric credentials unchanged (no-op case)', () => {
+      const result = encodeBasicClientCredentials('my-client-id', 'plainsecret123');
+      expect(result).to.equal(Buffer.from('my-client-id:plainsecret123').toString('base64'));
+    });
+
+    it('form-url-encodes a "+" in the secret to %2B before base64 (RFC 6749 §2.3.1)', () => {
+      // The bug: a raw "+" is decoded to a space by a compliant server, breaking auth.
+      const result = encodeBasicClientCredentials('my-client-id', 'Xy9+Kq2z');
+      expect(result).to.equal(Buffer.from('my-client-id:Xy9%2BKq2z').toString('base64'));
+    });
+
+    it('encodes a space as "+" per Appendix B (W3C form rules, not %20)', () => {
+      const result = encodeBasicClientCredentials('id', 'a b');
+      expect(Buffer.from(result, 'base64').toString('utf8')).to.equal('id:a+b');
+    });
+
+    it('encodes reserved characters in both id and secret', () => {
+      const result = encodeBasicClientCredentials('a:b', 'p&q=r');
+      // colon in id is escaped (keeps the Basic split unambiguous), & and = escaped
+      expect(Buffer.from(result, 'base64').toString('utf8')).to.equal('a%3Ab:p%26q%3Dr');
+    });
+
+    it('round-trips through a compliant server decode back to the originals', () => {
+      const id = 'aaaabbbb-cccc-dddd-eeee-ffff00001111';
+      const secret = 'Xy9+Kq/2z=';
+      const {id: gotId, secret: gotSecret} = decodeBasicClientCredentials(encodeBasicClientCredentials(id, secret));
+      expect(gotId).to.equal(id);
+      expect(gotSecret).to.equal(secret);
+    });
+  });
+});

--- a/packages/b2c-tooling-sdk/test/auth/oauth.test.ts
+++ b/packages/b2c-tooling-sdk/test/auth/oauth.test.ts
@@ -102,6 +102,27 @@ describe('auth/oauth', () => {
         expect(tokenResponse.expires).to.be.instanceOf(Date);
       });
 
+      it('form-url-encodes client credentials in the Basic header (RFC 6749 §2.3.1)', async () => {
+        // Regression: a secret containing "+" must be encoded to %2B before base64,
+        // otherwise a compliant server form-url-decodes it back to a space and auth fails.
+        const clientId = 'client+id';
+        const clientSecret = 'Xy9+Kq2z';
+        let capturedAuth: null | string = null;
+
+        server.use(
+          http.post(AM_URL, ({request}) => {
+            capturedAuth = request.headers.get('Authorization');
+            return HttpResponse.json({access_token: createMockJWT({sub: clientId}), expires_in: 1800});
+          }),
+        );
+
+        const strategy = new OAuthStrategy({clientId, clientSecret});
+        await strategy.getTokenResponse();
+
+        const expected = `Basic ${Buffer.from('client%2Bid:Xy9%2BKq2z').toString('base64')}`;
+        expect(capturedAuth).to.equal(expected);
+      });
+
       it('should handle token request without scopes', async () => {
         const mockToken = createMockJWT({sub: 'test-client-noscope'});
 


### PR DESCRIPTION
## Problem

Migrating from `sfcc-ci` to `@salesforce/b2c-cli`, a customer's Account Manager OAuth client failed the client-credentials grant over HTTP Basic (`client_secret_basic`) but succeeded with form-body credentials (`client_secret_post`) using the **same** client_id + client_secret:

```
POST https://account.demandware.com/dwsso/oauth2/access_token
Authorization: Basic base64(client_id:client_secret)
Content-Type: application/x-www-form-urlencoded

grant_type=client_credentials
-> 400 {"error":"unauthorized_client","error_description":"Unexpected error when authenticating client"}
```

The same credentials in the request body return `200`. This reproduces for any secret containing characters that require form-url-encoding – most commonly `+` or `%` – and does not reproduce for plain-alphanumeric secrets, which is why it presents intermittently.

## Root cause

RFC 6749 [§2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) requires the client_id and client_secret to each be form-url-encoded ([Appendix B](https://datatracker.ietf.org/doc/html/rfc6749#appendix-B)) *before* being joined and Base64-encoded into the HTTP Basic header:

> The client identifier is encoded using the "application/x-www-form-urlencoded" encoding algorithm per Appendix B, and the encoded value is used as the username; the client password is encoded using the same algorithm and used as the password.

`b2c` Base64-encodes the raw `clientId:clientSecret`. The token endpoint decodes each half per the spec, so a raw `+` is read as a space and a `%xx` sequence is decoded – and an invalid escape such as `%3Q` causes the decoder to error rather than mismatch. The body path is unaffected because body parameters are form-url-encoded by construction – hence "post works, basic fails".

The Appendix B (W3C form) vs. RFC 3986 distinction (space → `+` vs `%20`) does **not** affect `+` or `%` – both encoders emit `%2B` / `%25`. This PR uses `URLSearchParams`, matching Appendix B and the encoder the body path already uses.

## Change

Adds a shared `encodeBasicClientCredentials()` helper (form-url-encode each component via `URLSearchParams`, then `:`-join and Base64) and routes all Basic-auth credential sites through it:

- `OAuthStrategy` client-credentials grant – `src/auth/oauth.ts`
- `b2c auth client` command; stored `renewBase` is then correct, so `auth client renew` inherits the fix – `commands/auth/client/index.ts`
- SLAS private-client flows (guest + registered) – `src/slas/token.ts`

No-op for credentials limited to unreserved characters, so existing working setups are unchanged.

## Verification (live token endpoint)

Five API clients, one per character class, each exercised three ways: raw Basic (current `b2c` behavior), form-url-encoded Basic (this PR), and body credentials.

| Secret contains | Raw Basic (before) | Encoded Basic (this PR) | Body credentials |
|---|---|---|---|
| plain alphanumeric | ✅ 200 | ✅ 200 | ✅ 200 |
| `/` `=` `#` (form-safe) | ✅ 200 | ✅ 200 | ✅ 200 |
| `+` | ❌ 401 `invalid_client` | ✅ 200 | ✅ 200 |
| valid `%XX` escape | ❌ 401 `invalid_client` | ✅ 200 | ✅ 200 |
| invalid `%` escape | ❌ 400 `unauthorized_client` | ✅ 200 | ✅ 200 |

Both clean baselines pass unchanged (no regression); all three special-character clients fail before and pass after. Note the error code distinguishes the cause: `+` / valid `%XX` decode to valid-but-wrong bytes → `invalid_client`, whereas an invalid `%` escape makes the decoder error → `unauthorized_client` (matching the reported symptom).

## Notes / scope

- **`client_secret_post` is intentionally out of scope.** RFC 6749 §2.3.1 states that sending credentials in the request body is "NOT RECOMMENDED and SHOULD be limited to clients unable to directly utilize the HTTP Basic authentication scheme." This change makes the Basic method spec-compliant rather than adding the discouraged body-credential method.
- **Changing the client's configured token-endpoint auth method does nothing.** The token endpoint accepts credentials via HTTP Basic or the request body regardless of the method configured on the API client. All five test clients above were configured `client_secret_basic`, yet body credentials succeeded for every one. The encoding fix is required independent of that setting, which appears to do nothing at all.

## Testing

Unit tests for `encodeBasicClientCredentials` (no-op, `+`→`%2B`, space→`+`, reserved chars in id and secret, full server-side round-trip) and an `OAuthStrategy` regression test asserting the exact `Authorization: Basic` bytes for a `+`-bearing credential. `typecheck:agent` and `lint:agent` clean; SDK + CLI auth suites pass. A changeset (`patch` for SDK + CLI) is included.

## Dependencies

- [x] No net-new third-party dependencies were added


