### PR TITLE
fix: pin b2c-dx-mcp plugin to exact MCP version

### DIFF
--- a/.changeset/pin-mcp-plugin-version.md
+++ b/.changeset/pin-mcp-plugin-version.md
@@ -2,4 +2,4 @@
 '@salesforce/b2c-agent-plugins': patch
 ---
 
-Pin the `b2c-dx-mcp` Claude Code plugin to the exact published MCP server version instead of `@latest`. `npx` reuses a cached package for a floating tag, so users could keep running a stale server after an upgrade — pinning forces a fetch of the matching version. The pin is kept in sync automatically on each release.
+Pin the `b2c-dx-mcp` Claude Code plugin to the exact published MCP server version instead of `@latest`, and version its marketplace entry. `npx` reuses a cached package for a floating tag, so users could keep running a stale server (e.g. missing the latest docs tools) after an upgrade — an exact version forces a fetch, and versioning the marketplace entry makes clients re-pull the new pin. Both are kept in sync with the MCP release automatically.

--- a/.changeset/pin-mcp-plugin-version.md
+++ b/.changeset/pin-mcp-plugin-version.md
@@ -1,5 +1,6 @@
 ---
+'@salesforce/b2c-dx-mcp': patch
 '@salesforce/b2c-agent-plugins': patch
 ---
 
-Pin the `b2c-dx-mcp` Claude Code plugin to the exact published MCP server version instead of `@latest`, and version its marketplace entry. `npx` reuses a cached package for a floating tag, so users could keep running a stale server (e.g. missing the latest docs tools) after an upgrade — an exact version forces a fetch, and versioning the marketplace entry makes clients re-pull the new pin. Both are kept in sync with the MCP release automatically.
+Pin the `b2c-dx-mcp` Claude Code plugin to the exact published MCP server version instead of `@latest`, and version its marketplace entry. `npx` reuses a cached package for a floating tag, so users could keep running a stale server (e.g. missing the latest docs tools) after an upgrade — an exact version forces a fetch, and versioning the marketplace entry makes clients re-pull the new pin. The pin and marketplace version track the MCP release automatically.

--- a/.changeset/pin-mcp-plugin-version.md
+++ b/.changeset/pin-mcp-plugin-version.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Pin the `b2c-dx-mcp` Claude Code plugin to the exact published MCP server version instead of `@latest`. `npx` reuses a cached package for a floating tag, so users could keep running a stale server after an upgrade — pinning forces a fetch of the matching version. The pin is kept in sync automatically on each release.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,7 +40,8 @@
       "license": "Apache-2.0",
       "source": "./plugins/b2c-dx-mcp",
       "category": "productivity",
-      "strict": false
+      "strict": false,
+      "version": "1.5.0"
     },
     {
       "name": "storefront-next",

--- a/plugins/b2c-dx-mcp/.mcp.json
+++ b/plugins/b2c-dx-mcp/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "b2c-dx-mcp": {
       "command": "npx",
-      "args": ["-y", "@salesforce/b2c-dx-mcp@latest", "--allow-non-ga-tools"]
+      "args": ["-y", "@salesforce/b2c-dx-mcp@1.5.0", "--allow-non-ga-tools"]
     }
   }
 }

--- a/plugins/b2c-dx-mcp/.mcp.json
+++ b/plugins/b2c-dx-mcp/.mcp.json
@@ -2,7 +2,11 @@
   "mcpServers": {
     "b2c-dx-mcp": {
       "command": "npx",
-      "args": ["-y", "@salesforce/b2c-dx-mcp@1.5.0", "--allow-non-ga-tools"]
+      "args": [
+        "-y",
+        "@salesforce/b2c-dx-mcp@1.5.0",
+        "--allow-non-ga-tools"
+      ]
     }
   }
 }

--- a/scripts/sync-plugin-versions.mjs
+++ b/scripts/sync-plugin-versions.mjs
@@ -56,3 +56,29 @@ for (const rel of codexTargets) {
 }
 
 console.log(`Synced plugin manifests to version ${version}`);
+
+// b2c-dx-mcp plugin: pin the npx-launched server to the exact published MCP
+// version. npx reuses a cached package for a floating tag like @latest, so
+// users can get a stale server after an upgrade; an exact version forces a
+// fetch. changeset version has already bumped the MCP package.json by now.
+const mcpVersion = readJson(join(repoRoot, 'packages/b2c-dx-mcp/package.json')).version;
+if (!mcpVersion) {
+  console.error('packages/b2c-dx-mcp/package.json has no version field');
+  process.exit(1);
+}
+const mcpConfigPath = join(repoRoot, 'plugins/b2c-dx-mcp/.mcp.json');
+const mcpConfig = readJson(mcpConfigPath);
+const mcpArgs = mcpConfig.mcpServers?.['b2c-dx-mcp']?.args;
+if (!Array.isArray(mcpArgs)) {
+  console.error('plugins/b2c-dx-mcp/.mcp.json has no mcpServers["b2c-dx-mcp"].args array');
+  process.exit(1);
+}
+const pkgArgIndex = mcpArgs.findIndex((arg) => typeof arg === 'string' && arg.startsWith('@salesforce/b2c-dx-mcp@'));
+if (pkgArgIndex === -1) {
+  console.error('plugins/b2c-dx-mcp/.mcp.json args do not reference @salesforce/b2c-dx-mcp');
+  process.exit(1);
+}
+mcpArgs[pkgArgIndex] = `@salesforce/b2c-dx-mcp@${mcpVersion}`;
+writeJson(mcpConfigPath, mcpConfig);
+
+console.log(`Pinned b2c-dx-mcp plugin to @salesforce/b2c-dx-mcp@${mcpVersion}`);

--- a/scripts/sync-plugin-versions.mjs
+++ b/scripts/sync-plugin-versions.mjs
@@ -57,15 +57,24 @@ for (const rel of codexTargets) {
 
 console.log(`Synced plugin manifests to version ${version}`);
 
-// b2c-dx-mcp plugin: pin the npx-launched server to the exact published MCP
-// version. npx reuses a cached package for a floating tag like @latest, so
-// users can get a stale server after an upgrade; an exact version forces a
-// fetch. changeset version has already bumped the MCP package.json by now.
+// b2c-dx-mcp plugin: unlike the skills plugins, this one tracks the
+// @salesforce/b2c-dx-mcp npm package (changeset version has already bumped its
+// package.json by now), not the b2c-agent-plugins version. Two things must move
+// together on every MCP release:
+//
+//  1. Pin the npx-launched server to the exact published version. npx reuses a
+//     cached package for a floating tag like @latest, so users can get a stale
+//     server after an upgrade; an exact version forces a fetch.
+//  2. Bump the marketplace entry's `version` so Claude Code sees the plugin as
+//     changed and re-pulls the new pin. Without a version change the updated
+//     .mcp.json can sit on the marketplace and never reach installed plugins.
 const mcpVersion = readJson(join(repoRoot, 'packages/b2c-dx-mcp/package.json')).version;
 if (!mcpVersion) {
   console.error('packages/b2c-dx-mcp/package.json has no version field');
   process.exit(1);
 }
+
+// (1) Rewrite the pinned version in the plugin's .mcp.json.
 const mcpConfigPath = join(repoRoot, 'plugins/b2c-dx-mcp/.mcp.json');
 const mcpConfig = readJson(mcpConfigPath);
 const mcpArgs = mcpConfig.mcpServers?.['b2c-dx-mcp']?.args;
@@ -80,5 +89,14 @@ if (pkgArgIndex === -1) {
 }
 mcpArgs[pkgArgIndex] = `@salesforce/b2c-dx-mcp@${mcpVersion}`;
 writeJson(mcpConfigPath, mcpConfig);
+
+// (2) Stamp the MCP version onto its marketplace entry so clients re-pull.
+const mcpEntry = marketplace.plugins.find((plugin) => plugin.name === 'b2c-dx-mcp');
+if (!mcpEntry) {
+  console.error('.claude-plugin/marketplace.json has no b2c-dx-mcp plugin entry');
+  process.exit(1);
+}
+mcpEntry.version = mcpVersion;
+writeJson(marketplacePath, marketplace);
 
 console.log(`Pinned b2c-dx-mcp plugin to @salesforce/b2c-dx-mcp@${mcpVersion}`);


### PR DESCRIPTION
## What

Make the `b2c-dx-mcp` Claude Code plugin serve the exact published MCP server version, and ensure clients actually pick up changes. Two coordinated changes, both kept in sync automatically on every MCP release:

1. **Pin the launched server** — `plugins/b2c-dx-mcp/.mcp.json`: `@salesforce/b2c-dx-mcp@latest` → `@salesforce/b2c-dx-mcp@1.5.0`
2. **Version the marketplace entry** — `.claude-plugin/marketplace.json`: the `b2c-dx-mcp` entry gains a `version` field (it never had one), so clients see the plugin as changed and re-pull

`scripts/sync-plugin-versions.mjs` (already run during the root `version` script, i.e. `changeset version && node scripts/sync-plugin-versions.mjs`) is extended to stamp **both** of the above from the freshly-bumped `packages/b2c-dx-mcp/package.json`. No new workflow.

## Why

`npx` reuses a **cached** package for a floating tag like `@latest` — it does not reliably re-resolve the tag against the registry. So after a new MCP version published, users who had previously launched the server kept running the stale cached version (reported symptom: the updated docs tools never showed up).

- Pinning to an exact version changes npx's cache key, forcing a fetch of the matching package.
- But the pin only helps if the edited `.mcp.json` actually reaches installed plugins. The `b2c-dx-mcp` marketplace entry never carried a `version` field, and plugin clients gate re-pulls on that entry version changing — so the pin edit could sit on `main` and never propagate. Versioning the entry closes that gap.

## How it stays in sync

By the time `sync-plugin-versions.mjs` runs, `changeset version` has already bumped the MCP `package.json`. The script reads that version and writes it into both the pin and the marketplace entry, so the plugin tracks the MCP release automatically — no manual bump, and no cross-package changeset dependency needed (the `b2c-dx-mcp` plugin is file-sourced from the repo, not a published artifact).

## Manual testing

- Ran `node scripts/sync-plugin-versions.mjs` locally: confirmed it rewrites both the pin and the marketplace `b2c-dx-mcp` entry to match `packages/b2c-dx-mcp/package.json` (`1.5.0`), and is idempotent on re-run.
- Verified the script errors clearly if the `.mcp.json` args array, the `@salesforce/b2c-dx-mcp` reference, or the marketplace entry is missing.