### PR TITLE
@W-23372198 fix: bound and short-circuit MCP workspace discovery on startup

### DIFF
--- a/.changeset/mcp-bounded-workspace-discovery.md
+++ b/.changeset/mcp-bounded-workspace-discovery.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+'@salesforce/b2c-dx-mcp': minor
+---
+
+Fix costly recursive filesystem scan on MCP server startup. Workspace auto-discovery previously did an unbounded `**/.project` walk from the launch directory, which could hang startup when the server was spawned from a home directory (as Cursor and Claude Code often do). Discovery is now skipped entirely when explicit `--toolsets`/`--tools` are provided, skipped for home and root directories, and otherwise depth-bounded and short-circuited at the first match. `findCartridges` gains optional `maxDepth` and `firstMatchOnly` options for callers that need a bounded search (existing callers are unaffected).

--- a/packages/b2c-dx-mcp/src/registry.ts
+++ b/packages/b2c-dx-mcp/src/registry.ts
@@ -4,6 +4,8 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import os from 'node:os';
+import path from 'node:path';
 import {getLogger} from '@salesforce/b2c-tooling-sdk/logging';
 import {detectWorkspaceType, type ProjectType} from '@salesforce/b2c-tooling-sdk/discovery';
 import {DOC_CATEGORIES, resolveEnabledCategories, type DocCategory} from '@salesforce/b2c-tooling-sdk/docs';
@@ -131,17 +133,51 @@ export function createToolRegistry(
 }
 
 /**
+ * Maximum directory depth workspace auto-discovery recurses when scanning the
+ * project directory. Bounding this is what keeps startup fast (and safe) when
+ * the server is launched from a broad root: a full `**` walk of a home
+ * directory can take many seconds and blocks the MCP handshake, since detection
+ * runs before the server connects.
+ *
+ * Depth is counted in path segments relative to the project directory. 5 covers
+ * the common layouts — a cartridge at `cartridges/<name>/.project` (depth 3) and
+ * a monorepo cartridge at `packages/<app>/cartridges/<name>/.project` (depth 5) —
+ * without descending into unrelated deep trees.
+ */
+const DISCOVERY_MAX_DEPTH = 5;
+
+/**
+ * Returns true when `dir` is a location that should never be recursively
+ * scanned for a workspace: the user's home directory or a filesystem root.
+ * These are the classic "MCP client spawned the server from ~" cases where an
+ * unbounded (or even bounded) scan is both pointless and expensive.
+ */
+function isUnscannableRoot(dir: string): boolean {
+  const resolved = path.resolve(dir);
+  // Filesystem root: parent equals self (handles `/` and Windows drive roots).
+  if (path.dirname(resolved) === resolved) {
+    return true;
+  }
+  const home = os.homedir();
+  return Boolean(home) && path.resolve(home) === resolved;
+}
+
+/**
  * Performs workspace auto-discovery and returns appropriate toolsets.
  * Always includes the BASE_TOOLSETS even if no project types are detected.
  *
+ * The scan is depth-bounded ({@link DISCOVERY_MAX_DEPTH}) and skipped entirely
+ * for home/root directories so it can never fan out across a whole home tree.
+ *
  * @param flags - Startup flags containing projectDirectory
- * @param reason - Reason for triggering auto-discovery (for logging)
- * @returns Array of toolsets to enable
+ * @returns Array of detected project types (empty if skipped or none found)
  */
 async function detectProjectTypes(flags: StartupFlags): Promise<ProjectType[]> {
   const logger = getLogger();
 
-  // Project directory from --project-directory flag or SFCC_PROJECT_DIRECTORY env var
+  // Project directory from --project-directory flag or SFCC_PROJECT_DIRECTORY env
+  // var, defaulting to cwd. We always attempt detection from cwd rather than
+  // skipping it — the depth bound and home/root guard below make that safe.
   const projectDirectory = flags.projectDirectory ?? process.cwd();
 
   // Warn if project directory wasn't explicitly configured
@@ -154,7 +190,18 @@ async function detectProjectTypes(flags: StartupFlags): Promise<ProjectType[]> {
     );
   }
 
-  const detectionResult = await detectWorkspaceType(projectDirectory);
+  // Never recursively scan a home directory or filesystem root — the scan would
+  // be expensive and would not identify a meaningful workspace anyway.
+  if (isUnscannableRoot(projectDirectory)) {
+    logger.warn(
+      {projectDirectory},
+      'Project directory is a home or root directory; skipping workspace auto-discovery. ' +
+        'Set --project-directory or SFCC_PROJECT_DIRECTORY to the project path to enable it.',
+    );
+    return [];
+  }
+
+  const detectionResult = await detectWorkspaceType(projectDirectory, {maxDepth: DISCOVERY_MAX_DEPTH});
   logger.info(
     {projectTypes: detectionResult.projectTypes, matchedPatterns: detectionResult.matchedPatterns},
     `Workspace detection: project types: ${detectionResult.projectTypes.join(', ') || 'none'}`,
@@ -201,12 +248,6 @@ export async function registerToolsets(
   const allowNonGaTools = flags.allowNonGaTools ?? false;
   const logger = getLogger();
 
-  // Detect the workspace type once up front. It informs both the
-  // docs tools (favoring the current workspace's docs and surfacing it in the
-  // tool descriptions) and toolset auto-discovery below, so we only hit the
-  // filesystem a single time.
-  const detectedWorkspaces = await detectProjectTypes(flags);
-
   // Resolve the launch-time docs topic allowlist (bounds the whole docs corpus).
   const enabledDocCategories = resolveEnabledCategories(flags.docsTopics, (invalid) =>
     logger.warn(
@@ -221,13 +262,18 @@ export async function registerToolsets(
     );
   }
 
-  // Create the tool registry (all available tools)
-  const toolRegistry = createToolRegistry(loadServices, serverContext, detectedWorkspaces, enabledDocCategories);
-
-  // Build flat list of all tools for lookup
-  const allTools = Object.values(toolRegistry).flat();
-  const allToolsByName = new Map(allTools.map((tool) => [tool.name, tool]));
-  const existingToolNames = new Set(allToolsByName.keys());
+  // Build the tool registry to validate flag input. The set of available tools
+  // (names, toolsets) does NOT depend on the detected workspace — only the docs
+  // tool descriptions do — so we can resolve flag validity before deciding
+  // whether workspace detection is even needed. If auto-discovery later runs,
+  // we rebuild the registry with the detected workspaces so the docs tools pick
+  // up the workspace hint.
+  let toolRegistry = createToolRegistry(loadServices, serverContext, [], enabledDocCategories);
+  const existingToolNames = new Set(
+    Object.values(toolRegistry)
+      .flat()
+      .map((tool) => tool.name),
+  );
 
   // Determine valid individual tools
   const invalidTools = individualTools.filter((name) => !existingToolNames.has(name));
@@ -261,11 +307,14 @@ export async function registerToolsets(
   );
   const toolsetsToEnable = new Set<Toolset>(toolsets.includes(ALL_TOOLSETS) ? allNonDeprecatedToolsets : validToolsets);
 
-  // Auto-discovery: If no valid toolsets AND no valid individual tools, map the
-  // already-detected workspace type(s) to toolsets. This handles both: (1) no
-  // flags provided, and (2) all provided flags are invalid. Always enables at
-  // least the BASE_TOOLSETS even if no project types are detected.
+  // Auto-discovery: only when no valid toolsets AND no valid individual tools
+  // were provided. This handles both (1) no flags provided, and (2) all
+  // provided flags are invalid. Skip workspace detection entirely otherwise —
+  // when the user has explicitly chosen toolsets/tools, the filesystem scan
+  // cannot change which tools are registered, so paying for it (and risking a
+  // costly recursive walk) would be pointless.
   if (toolsetsToEnable.size === 0 && validIndividualTools.length === 0) {
+    const detectedWorkspaces = await detectProjectTypes(flags);
     const discoveredToolsets = getToolsetsForProjectTypes(detectedWorkspaces);
     logger.info(
       {projectTypes: detectedWorkspaces, enabledToolsets: discoveredToolsets},
@@ -273,6 +322,11 @@ export async function registerToolsets(
     );
     for (const toolset of discoveredToolsets) {
       toolsetsToEnable.add(toolset);
+    }
+    // Rebuild so the docs tools reflect the detected workspace in their
+    // descriptions and default workspace resolution.
+    if (detectedWorkspaces.length > 0) {
+      toolRegistry = createToolRegistry(loadServices, serverContext, detectedWorkspaces, enabledDocCategories);
     }
   }
 
@@ -292,7 +346,13 @@ export async function registerToolsets(
     }
   }
 
-  // Step 2: Add individual tools from --tools (can be from any toolset)
+  // Step 2: Add individual tools from --tools (can be from any toolset).
+  // Look up against the final registry (which may have been rebuilt above).
+  const allToolsByName = new Map(
+    Object.values(toolRegistry)
+      .flat()
+      .map((tool) => [tool.name, tool]),
+  );
   for (const toolName of validIndividualTools) {
     const tool = allToolsByName.get(toolName);
     if (tool && !registeredToolNames.has(toolName)) {

--- a/packages/b2c-dx-mcp/test/registry.test.ts
+++ b/packages/b2c-dx-mcp/test/registry.test.ts
@@ -5,6 +5,9 @@
  */
 
 import {expect} from 'chai';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import {createToolRegistry, registerToolsets} from '../src/registry.js';
 import {Services} from '../src/services.js';
 import {B2CDxMcpServer} from '../src/server.js';
@@ -534,6 +537,77 @@ describe('registry', () => {
         expect(server.registeredTools).to.include('cartridge_deploy');
         // Should not have tools from other toolsets unless explicitly requested
         expect(server.registeredTools).to.not.include('pwakit_create_storefront');
+      });
+
+      it('should NOT scan the filesystem when explicit toolsets are provided', async () => {
+        // If detection ran, it would auto-enable CARTRIDGES from the .project
+        // fixture below. With explicit toolsets it must be skipped entirely, so
+        // only SCAPI tools (the requested toolset) are registered.
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-mcp-registry-'));
+        try {
+          const cartridge = path.join(dir, 'cartridges', 'app_storefront_base');
+          fs.mkdirSync(cartridge, {recursive: true});
+          fs.writeFileSync(path.join(cartridge, '.project'), '<xml/>');
+
+          const server = createMockServer();
+          const flags: StartupFlags = {
+            toolsets: ['SCAPI'],
+            projectDirectory: dir,
+            allowNonGaTools: true,
+          };
+          await registerToolsets(flags, server, createMockLoadServicesWrapper());
+
+          expect(server.registeredTools).to.include('scapi_schemas_list');
+          // cartridge_deploy would only appear if detection had auto-enabled CARTRIDGES.
+          expect(server.registeredTools).to.not.include('cartridge_deploy');
+        } finally {
+          fs.rmSync(dir, {recursive: true, force: true});
+        }
+      });
+
+      it('should auto-discover CARTRIDGES from a shallow .project within the depth bound', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-mcp-registry-'));
+        try {
+          const cartridge = path.join(dir, 'cartridges', 'app_storefront_base');
+          fs.mkdirSync(cartridge, {recursive: true});
+          fs.writeFileSync(path.join(cartridge, '.project'), '<xml/>');
+
+          const server = createMockServer();
+          const flags: StartupFlags = {projectDirectory: dir, allowNonGaTools: true};
+          await registerToolsets(flags, server, createMockLoadServicesWrapper());
+
+          expect(server.registeredTools).to.include('cartridge_deploy');
+        } finally {
+          fs.rmSync(dir, {recursive: true, force: true});
+        }
+      });
+
+      it('should skip auto-discovery when the project directory is the home directory', async () => {
+        // Place a cartridge in HOME; detection must be skipped so it is not found
+        // and only the base fallback (SCAPI) is registered. Use a temp dir as a
+        // fake HOME to avoid touching the real one.
+        const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-mcp-home-'));
+        const originalHome = os.homedir();
+        try {
+          const cartridge = path.join(fakeHome, 'cartridges', 'app_storefront_base');
+          fs.mkdirSync(cartridge, {recursive: true});
+          fs.writeFileSync(path.join(cartridge, '.project'), '<xml/>');
+
+          // os.homedir() reads $HOME on POSIX; override for the duration of the test.
+          process.env.HOME = fakeHome;
+          expect(os.homedir(), 'sanity: os.homedir reflects the overridden HOME').to.equal(fakeHome);
+
+          const server = createMockServer();
+          const flags: StartupFlags = {projectDirectory: fakeHome, allowNonGaTools: true};
+          await registerToolsets(flags, server, createMockLoadServicesWrapper());
+
+          // Base fallback still registers, but the cartridge was never scanned.
+          expect(server.registeredTools).to.include('scapi_schemas_list');
+          expect(server.registeredTools).to.not.include('cartridge_deploy');
+        } finally {
+          process.env.HOME = originalHome;
+          fs.rmSync(fakeHome, {recursive: true, force: true});
+        }
       });
     });
   });

--- a/packages/b2c-dx-mcp/test/registry.test.ts
+++ b/packages/b2c-dx-mcp/test/registry.test.ts
@@ -8,6 +8,7 @@ import {expect} from 'chai';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import {stub, restore} from 'sinon';
 import {createToolRegistry, registerToolsets} from '../src/registry.js';
 import {Services} from '../src/services.js';
 import {B2CDxMcpServer} from '../src/server.js';
@@ -583,19 +584,18 @@ describe('registry', () => {
       });
 
       it('should skip auto-discovery when the project directory is the home directory', async () => {
-        // Place a cartridge in HOME; detection must be skipped so it is not found
-        // and only the base fallback (SCAPI) is registered. Use a temp dir as a
-        // fake HOME to avoid touching the real one.
+        // Place a cartridge in the "home" directory; detection must be skipped so
+        // it is not found and only the base fallback (SCAPI) is registered. Stub
+        // os.homedir() directly rather than overriding an env var — the backing
+        // env differs by platform ($HOME on POSIX, USERPROFILE on Windows) and
+        // Windows may return a short (8.3) path that would not string-match.
         const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-mcp-home-'));
-        const originalHome = os.homedir();
         try {
           const cartridge = path.join(fakeHome, 'cartridges', 'app_storefront_base');
           fs.mkdirSync(cartridge, {recursive: true});
           fs.writeFileSync(path.join(cartridge, '.project'), '<xml/>');
 
-          // os.homedir() reads $HOME on POSIX; override for the duration of the test.
-          process.env.HOME = fakeHome;
-          expect(os.homedir(), 'sanity: os.homedir reflects the overridden HOME').to.equal(fakeHome);
+          stub(os, 'homedir').returns(fakeHome);
 
           const server = createMockServer();
           const flags: StartupFlags = {projectDirectory: fakeHome, allowNonGaTools: true};
@@ -605,7 +605,7 @@ describe('registry', () => {
           expect(server.registeredTools).to.include('scapi_schemas_list');
           expect(server.registeredTools).to.not.include('cartridge_deploy');
         } finally {
-          process.env.HOME = originalHome;
+          restore();
           fs.rmSync(fakeHome, {recursive: true, force: true});
         }
       });

--- a/packages/b2c-tooling-sdk/src/discovery/detector.ts
+++ b/packages/b2c-tooling-sdk/src/discovery/detector.ts
@@ -9,7 +9,7 @@
  * @module discovery/detector
  */
 import {getLogger} from '../logging/logger.js';
-import type {DetectionResult, DetectionPattern, DetectOptions, ProjectType} from './types.js';
+import type {DetectionResult, DetectionPattern, DetectOptions, DetectionContext, ProjectType} from './types.js';
 import {DEFAULT_PATTERNS} from './patterns/index.js';
 
 /**
@@ -41,6 +41,7 @@ import {DEFAULT_PATTERNS} from './patterns/index.js';
 export class WorkspaceTypeDetector {
   private workspacePath: string;
   private patterns: DetectionPattern[];
+  private context: DetectionContext;
 
   /**
    * Creates a new WorkspaceTypeDetector.
@@ -51,6 +52,7 @@ export class WorkspaceTypeDetector {
   constructor(workspacePath: string, options: DetectOptions = {}) {
     this.workspacePath = workspacePath;
     this.patterns = this.resolvePatterns(options);
+    this.context = {maxDepth: options.maxDepth};
   }
 
   /**
@@ -76,7 +78,7 @@ export class WorkspaceTypeDetector {
 
     for (const pattern of this.patterns) {
       try {
-        const matched = await pattern.detect(this.workspacePath);
+        const matched = await pattern.detect(this.workspacePath, this.context);
         logger.trace({pattern: pattern.name, projectType: pattern.projectType, matched}, 'Detection pattern evaluated');
         if (matched) {
           matchedPatterns.push(pattern.name);

--- a/packages/b2c-tooling-sdk/src/discovery/index.ts
+++ b/packages/b2c-tooling-sdk/src/discovery/index.ts
@@ -66,7 +66,7 @@
 export {WorkspaceTypeDetector, detectWorkspaceType} from './detector.js';
 
 // Types
-export type {ProjectType, DetectionPattern, DetectionResult, DetectOptions} from './types.js';
+export type {ProjectType, DetectionContext, DetectionPattern, DetectionResult, DetectOptions} from './types.js';
 export {PROJECT_TYPES} from './types.js';
 
 // Patterns (for customization)

--- a/packages/b2c-tooling-sdk/src/discovery/patterns/cartridges.ts
+++ b/packages/b2c-tooling-sdk/src/discovery/patterns/cartridges.ts
@@ -23,8 +23,10 @@ import {findCartridges} from '../../operations/code/cartridges.js';
 export const cartridgesPattern: DetectionPattern = {
   name: 'cartridges',
   projectType: 'cartridges',
-  detect: async (workspacePath) => {
-    const cartridges = findCartridges(workspacePath);
+  detect: async (workspacePath, context) => {
+    // Existence check only — stop at the first cartridge and honor the depth
+    // bound so a broad root (e.g. a home directory) is not fully scanned.
+    const cartridges = findCartridges(workspacePath, {firstMatchOnly: true, maxDepth: context?.maxDepth});
     return cartridges.length > 0;
   },
 };

--- a/packages/b2c-tooling-sdk/src/discovery/patterns/sfra.ts
+++ b/packages/b2c-tooling-sdk/src/discovery/patterns/sfra.ts
@@ -43,12 +43,17 @@ import {readPackageJson} from '../utils.js';
 export const sfraPattern: DetectionPattern = {
   name: 'sfra',
   projectType: 'sfra',
-  detect: async (workspacePath) => {
+  detect: async (workspacePath, context) => {
     // Primary check: Look for app_storefront_base cartridge (the core SFRA cartridge)
-    // This is the definitive indicator per Salesforce documentation
-    const cartridges = findCartridges(workspacePath);
-    const hasSfraCartridge = cartridges.some((cartridge) => cartridge.name === 'app_storefront_base');
-    if (hasSfraCartridge) {
+    // This is the definitive indicator per Salesforce documentation. Filter to
+    // that name and stop at the first hit so we don't enumerate every cartridge,
+    // and honor the depth bound so a broad root isn't fully scanned.
+    const cartridges = findCartridges(workspacePath, {
+      include: ['app_storefront_base'],
+      firstMatchOnly: true,
+      maxDepth: context?.maxDepth,
+    });
+    if (cartridges.length > 0) {
       return true;
     }
 

--- a/packages/b2c-tooling-sdk/src/discovery/types.ts
+++ b/packages/b2c-tooling-sdk/src/discovery/types.ts
@@ -39,6 +39,19 @@ export const PROJECT_TYPES = [
 ] as const satisfies readonly ProjectType[];
 
 /**
+ * Context passed to a detection pattern's `detect` function.
+ */
+export interface DetectionContext {
+  /**
+   * Maximum directory depth (in path segments, relative to the workspace root)
+   * that filesystem-scanning patterns should recurse. Undefined means unbounded.
+   * Bounding this protects against costly walks when the workspace root is broad
+   * (e.g. an MCP server launched from a home directory).
+   */
+  maxDepth?: number;
+}
+
+/**
  * Detection pattern definition.
  */
 export interface DetectionPattern {
@@ -47,7 +60,7 @@ export interface DetectionPattern {
   /** Project type this pattern detects */
   projectType: ProjectType;
   /** Detection function */
-  detect: (workspacePath: string) => Promise<boolean>;
+  detect: (workspacePath: string, context?: DetectionContext) => Promise<boolean>;
 }
 
 /**
@@ -72,4 +85,11 @@ export interface DetectOptions {
   additionalPatterns?: DetectionPattern[];
   /** Patterns to exclude by name */
   excludePatterns?: string[];
+  /**
+   * Maximum directory depth (in path segments, relative to the workspace root)
+   * that filesystem-scanning patterns recurse. Undefined means unbounded.
+   * Passed to each pattern via {@link DetectionContext}. Set this when detecting
+   * from a potentially broad root to keep the scan bounded.
+   */
+  maxDepth?: number;
 }

--- a/packages/b2c-tooling-sdk/src/operations/code/cartridges.ts
+++ b/packages/b2c-tooling-sdk/src/operations/code/cartridges.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
-import {globSync} from 'glob';
+import {globSync, globIterateSync} from 'glob';
 import path from 'node:path';
 
 /**
@@ -26,6 +26,24 @@ export interface FindCartridgesOptions {
   include?: string[];
   /** Cartridge names to exclude */
   exclude?: string[];
+  /**
+   * Maximum directory depth to recurse when searching for `.project` files,
+   * counted in path segments relative to the search directory (so a cartridge
+   * at `cartridges/<name>/.project` is depth 3). When omitted the search is
+   * unbounded (default), preserving behavior for callers that expect a full
+   * recursive walk. Bound this for untrusted/broad roots (e.g. an MCP server
+   * that may be launched from a home directory) to avoid scanning the whole
+   * filesystem tree.
+   */
+  maxDepth?: number;
+  /**
+   * When true, stop at the first matching cartridge and return only that one.
+   * Useful for existence checks (e.g. workspace-type detection) where the full
+   * list is not needed — it lets the underlying scan short-circuit instead of
+   * enumerating every `.project` file. Filters from `include`/`exclude` are
+   * applied while scanning, so the returned cartridge always satisfies them.
+   */
+  firstMatchOnly?: boolean;
 }
 
 /**
@@ -56,9 +74,9 @@ export interface FindCartridgesOptions {
 export function findCartridges(directory?: string, options: FindCartridgesOptions = {}): CartridgeMapping[] {
   const searchDir = directory ? path.resolve(directory) : process.cwd();
 
-  // Find all .project files (Eclipse project markers).
-  // Ignore common non-cartridge dirs to keep discovery fast when projectRoot is broad (e.g. MCP working directory).
-  const projectFiles = globSync('**/.project', {
+  // Ignore common non-cartridge dirs to keep discovery fast when the search
+  // root is broad (e.g. an MCP server's working directory).
+  const globOptions = {
     cwd: searchDir,
     ignore: [
       '**/node_modules/**',
@@ -70,27 +88,38 @@ export function findCartridges(directory?: string, options: FindCartridgesOption
       '**/tmp/**',
       '**/temp/**',
     ],
-  });
+    // maxDepth is only forwarded when set so unbounded callers keep prior behavior.
+    ...(options.maxDepth === undefined ? {} : {maxDepth: options.maxDepth}),
+  };
 
-  let cartridges = projectFiles.map((f) => {
+  const toCartridge = (f: string): CartridgeMapping => {
     const dirname = path.resolve(searchDir, path.dirname(f));
     const cartridgeName = path.basename(dirname);
-    return {
-      name: cartridgeName,
-      dest: cartridgeName,
-      src: dirname,
-    };
-  });
+    return {name: cartridgeName, dest: cartridgeName, src: dirname};
+  };
 
-  // Apply include filter
-  if (options.include && options.include.length > 0) {
-    cartridges = cartridges.filter((c) => options.include!.includes(c.name));
+  const matches = (c: CartridgeMapping): boolean => {
+    if (options.include && options.include.length > 0 && !options.include.includes(c.name)) {
+      return false;
+    }
+    if (options.exclude && options.exclude.length > 0 && options.exclude.includes(c.name)) {
+      return false;
+    }
+    return true;
+  };
+
+  // Existence-check fast path: stream matches and stop at the first one that
+  // passes the filters, so a large tree isn't fully enumerated.
+  if (options.firstMatchOnly) {
+    for (const f of globIterateSync('**/.project', globOptions)) {
+      const cartridge = toCartridge(f);
+      if (matches(cartridge)) {
+        return [cartridge];
+      }
+    }
+    return [];
   }
 
-  // Apply exclude filter
-  if (options.exclude && options.exclude.length > 0) {
-    cartridges = cartridges.filter((c) => !options.exclude!.includes(c.name));
-  }
-
-  return cartridges;
+  // Find all .project files (Eclipse project markers).
+  return globSync('**/.project', globOptions).map(toCartridge).filter(matches);
 }

--- a/packages/b2c-tooling-sdk/test/discovery/detector.test.ts
+++ b/packages/b2c-tooling-sdk/test/discovery/detector.test.ts
@@ -101,6 +101,43 @@ describe('discovery/detector', () => {
         expect(result.matchedPatterns).to.deep.equal(['good-pattern']);
       });
 
+      it('passes maxDepth from options to patterns via context', async () => {
+        let seenMaxDepth: number | undefined = -1;
+        const capturingPattern: DetectionPattern = {
+          name: 'capture',
+          projectType: 'cartridges',
+          detect: async (_workspacePath, context) => {
+            seenMaxDepth = context?.maxDepth;
+            return true;
+          },
+        };
+        const detector = new WorkspaceTypeDetector('/test/path', {
+          patterns: [capturingPattern],
+          maxDepth: 5,
+        });
+
+        await detector.detect();
+
+        expect(seenMaxDepth).to.equal(5);
+      });
+
+      it('passes undefined maxDepth when not configured', async () => {
+        let seenMaxDepth: number | undefined = -1;
+        const capturingPattern: DetectionPattern = {
+          name: 'capture',
+          projectType: 'cartridges',
+          detect: async (_workspacePath, context) => {
+            seenMaxDepth = context?.maxDepth;
+            return true;
+          },
+        };
+        const detector = new WorkspaceTypeDetector('/test/path', {patterns: [capturingPattern]});
+
+        await detector.detect();
+
+        expect(seenMaxDepth).to.equal(undefined);
+      });
+
       it('preserves pattern order in results', async () => {
         const detector = new WorkspaceTypeDetector('/test/path', {
           patterns: [

--- a/packages/b2c-tooling-sdk/test/discovery/patterns/cartridges.test.ts
+++ b/packages/b2c-tooling-sdk/test/discovery/patterns/cartridges.test.ts
@@ -71,5 +71,16 @@ describe('discovery/patterns/cartridges', () => {
       const result = await cartridgesPattern.detect(tempDir);
       expect(result).to.equal(true);
     });
+
+    it('should not detect a cartridge deeper than the maxDepth in context', async () => {
+      // a/b/c/deep_cart/.project => depth 5 relative to tempDir
+      const deep = path.join(tempDir, 'a', 'b', 'c', 'deep_cart');
+      fs.mkdirSync(deep, {recursive: true});
+      fs.writeFileSync(path.join(deep, '.project'), '');
+
+      expect(await cartridgesPattern.detect(tempDir, {maxDepth: 3})).to.equal(false);
+      // Without a bound it is found.
+      expect(await cartridgesPattern.detect(tempDir)).to.equal(true);
+    });
   });
 });

--- a/packages/b2c-tooling-sdk/test/operations/code/cartridges.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/code/cartridges.test.ts
@@ -98,5 +98,94 @@ describe('operations/code/cartridges', () => {
         fs.rmSync(dir, {recursive: true, force: true});
       }
     });
+
+    describe('maxDepth option', () => {
+      it('finds cartridges within the depth bound and ignores deeper ones', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-sdk-cartridges-'));
+        try {
+          // cartridges/<name>/.project => depth 3 relative to dir
+          const shallow = path.join(dir, 'cartridges', 'app_storefront_base');
+          // a/b/c/deep_cart/.project => depth 5 relative to dir
+          const deep = path.join(dir, 'a', 'b', 'c', 'deep_cart');
+          fs.mkdirSync(shallow, {recursive: true});
+          fs.mkdirSync(deep, {recursive: true});
+          fs.writeFileSync(path.join(shallow, '.project'), '<xml/>');
+          fs.writeFileSync(path.join(deep, '.project'), '<xml/>');
+
+          const bounded = findCartridges(dir, {maxDepth: 3});
+          expect(bounded.map((c) => c.name)).to.deep.equal(['app_storefront_base']);
+
+          // Unbounded (default) still finds the deep cartridge.
+          const unbounded = findCartridges(dir);
+          expect(unbounded.map((c) => c.name).sort()).to.deep.equal(['app_storefront_base', 'deep_cart']);
+        } finally {
+          fs.rmSync(dir, {recursive: true, force: true});
+        }
+      });
+
+      it('returns empty when all cartridges are deeper than the bound', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-sdk-cartridges-'));
+        try {
+          const deep = path.join(dir, 'a', 'b', 'c', 'deep_cart');
+          fs.mkdirSync(deep, {recursive: true});
+          fs.writeFileSync(path.join(deep, '.project'), '<xml/>');
+
+          expect(findCartridges(dir, {maxDepth: 3})).to.deep.equal([]);
+        } finally {
+          fs.rmSync(dir, {recursive: true, force: true});
+        }
+      });
+    });
+
+    describe('firstMatchOnly option', () => {
+      it('returns a single cartridge that satisfies the filters', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-sdk-cartridges-'));
+        try {
+          const c1 = path.join(dir, 'a');
+          const c2 = path.join(dir, 'b');
+          fs.mkdirSync(c1, {recursive: true});
+          fs.mkdirSync(c2, {recursive: true});
+          fs.writeFileSync(path.join(c1, '.project'), '<xml/>');
+          fs.writeFileSync(path.join(c2, '.project'), '<xml/>');
+
+          const result = findCartridges(dir, {firstMatchOnly: true});
+          expect(result).to.have.length(1);
+          expect(['a', 'b']).to.include(result[0].name);
+        } finally {
+          fs.rmSync(dir, {recursive: true, force: true});
+        }
+      });
+
+      it('honors include filter while short-circuiting', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-sdk-cartridges-'));
+        try {
+          const c1 = path.join(dir, 'a');
+          const c2 = path.join(dir, 'app_storefront_base');
+          fs.mkdirSync(c1, {recursive: true});
+          fs.mkdirSync(c2, {recursive: true});
+          fs.writeFileSync(path.join(c1, '.project'), '<xml/>');
+          fs.writeFileSync(path.join(c2, '.project'), '<xml/>');
+
+          const result = findCartridges(dir, {firstMatchOnly: true, include: ['app_storefront_base']});
+          expect(result.map((c) => c.name)).to.deep.equal(['app_storefront_base']);
+        } finally {
+          fs.rmSync(dir, {recursive: true, force: true});
+        }
+      });
+
+      it('returns empty when no cartridge matches the filters', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-sdk-cartridges-'));
+        try {
+          const c1 = path.join(dir, 'a');
+          fs.mkdirSync(c1, {recursive: true});
+          fs.writeFileSync(path.join(c1, '.project'), '<xml/>');
+
+          const result = findCartridges(dir, {firstMatchOnly: true, include: ['does_not_exist']});
+          expect(result).to.deep.equal([]);
+        } finally {
+          fs.rmSync(dir, {recursive: true, force: true});
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

The `b2c-dx-mcp` server ran an **unbounded, synchronous recursive glob** (`**/.project`) during workspace auto-discovery on the critical startup path — before `server.connect()` — so a slow scan blocked the MCP `initialize` handshake. MCP clients (Cursor, Claude Code) commonly spawn servers from the user's home directory rather than the project directory, which triggered a full recursive walk of the entire home tree. The scan also ran even when explicit `--toolsets`/`--tools` were provided, where the result cannot change which tools get registered.

### Measured impact (this machine: 247G `$HOME`, 121G `~/code`; startup → `initialize` response)

| Directory | Before | After |
|---|---|---|
| `~/code` (121G) | ~24.3s | ~1.2s |
| `$HOME` (247G) | ~41.4s | ~0.9s |
| empty dir (baseline) | ~0.9s | ~0.9s |

These delays can exceed MCP client startup timeouts, appearing as a server that fails to come up.

## Changes

- **`registry.ts`**: skip workspace detection entirely when explicit `--toolsets`/`--tools` already determine registration; skip detection when the project directory is a home or filesystem-root directory; bound the discovery scan to `maxDepth: 5` (covers `cartridges/<name>/.project` and monorepo `packages/<app>/cartridges/<name>/.project` layouts).
- **SDK discovery** (`detector.ts`, `types.ts`, cartridge/SFRA patterns): thread `maxDepth` through a new `DetectionContext` into the filesystem-scanning patterns; use existence-check scanning (first match only).
- **`findCartridges`**: add opt-in `maxDepth` and `firstMatchOnly` options. The ~15 existing callers are unaffected (omitting the options preserves the prior unbounded full-list behavior).

Behavior preserved: tool-set auto-discovery still works for real project directories; the docs tools still pick up the detected workspace when auto-discovery runs.

## Test plan

Automated unit tests added for `findCartridges` (`maxDepth`, `firstMatchOnly`), discovery context threading, and the registry skip/guard behavior.

Manual verification performed (driving the built server end-to-end with an MCP `initialize` request):
- Launch with `--project-directory` = a real cartridge project, no `--toolsets` → detects `sfra, cartridges` and enables the CARTRIDGES toolset.
- Launch with `--project-directory` = `$HOME` → logs the home/root skip warning, registers only base toolsets, returns in ~baseline time.
- Launch with `--project-directory` = a real project **plus** `--toolsets SCAPI` → no workspace scan runs at all; only the requested toolset is registered.

Related: W-23372198