### PR TITLE
fix: lazy-activate VS Code extension and add opt-in WebDAV auto-mount

### DIFF
--- a/.changeset/extension-lazy-activation.md
+++ b/.changeset/extension-lazy-activation.md
@@ -1,0 +1,7 @@
+---
+'b2c-vs-extension': minor
+---
+
+The extension no longer activates on every VS Code startup. It now activates on demand when you open a B2C Commerce workspace (detected via `dw.json`, `.project`, `cartridge/*.properties`, or `commerce-app.json`), open a B2C view, or run a B2C command — reducing startup overhead in unrelated projects.
+
+Adds an opt-in `b2c-dx.features.sandboxFilesystem` setting (default off) that automatically mounts the active instance's WebDAV filesystem as a workspace folder.

--- a/packages/b2c-vs-extension/package.json
+++ b/packages/b2c-vs-extension/package.json
@@ -23,7 +23,6 @@
     "connectionString": "InstrumentationKey=6fcc215f-0b11-4864-ad5c-3945ae19e2f3;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=a60f17ec-265a-4dfc-b8df-03a64695697d"
   },
   "activationEvents": [
-    "onStartupFinished",
     "onView:b2cWebdavExplorer",
     "onView:b2cContentExplorer",
     "onFileSystem:b2c-webdav",
@@ -32,7 +31,10 @@
     "onView:b2cSandboxExplorer",
     "onView:b2cCartridgeExplorer",
     "onDebugResolve:b2c-script",
-    "workspaceContains:**/commerce-app.json"
+    "workspaceContains:**/commerce-app.json",
+    "workspaceContains:**/cartridge/*.properties",
+    "workspaceContains:**/.project",
+    "workspaceContains:dw.json"
   ],
   "main": "./dist/extension.cjs",
   "contributes": {
@@ -55,6 +57,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enable the WebDAV Browser."
+        },
+        "b2c-dx.features.sandboxFilesystem": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically mount the active instance's WebDAV filesystem as a workspace folder on startup. Requires the WebDAV Browser to be enabled."
         },
         "b2c-dx.features.contentLibraries": {
           "type": "boolean",

--- a/packages/b2c-vs-extension/src/extension.ts
+++ b/packages/b2c-vs-extension/src/extension.ts
@@ -23,7 +23,7 @@ import {registerApiBrowser} from './api-browser/index.js';
 import {registerDebugger} from './debugger/index.js';
 import {registerCodeSync} from './code-sync/index.js';
 import {registerScriptTypes} from './script-types/index.js';
-import {registerWebDavTree} from './webdav-tree/index.js';
+import {mountSandboxFilesystem, registerWebDavTree} from './webdav-tree/index.js';
 import {disposeTelemetry, initTelemetry, sendEvent, sendException} from './telemetry.js';
 
 function applyLogLevel(log: vscode.OutputChannel): void {
@@ -300,7 +300,8 @@ async function activateInner(context: vscode.ExtensionContext, log: vscode.Outpu
 
   const settings = vscode.workspace.getConfiguration('b2c-dx');
 
-  if (settings.get<boolean>('features.webdavBrowser', true)) {
+  const webdavBrowserEnabled = settings.get<boolean>('features.webdavBrowser', true);
+  if (webdavBrowserEnabled) {
     registerWebDavTree(context, configProvider);
   }
   if (settings.get<boolean>('features.contentLibraries', true)) {
@@ -329,6 +330,21 @@ async function activateInner(context: vscode.ExtensionContext, log: vscode.Outpu
   }
 
   registerDebugger(context, configProvider);
+
+  // Auto-mount the active instance's WebDAV filesystem as a workspace folder.
+  // Requires the WebDAV browser (which registers the b2c-webdav FileSystemProvider)
+  // and must happen after activation so the provider is live before VS Code reads
+  // the folder.
+  if (webdavBrowserEnabled && settings.get<boolean>('features.sandboxFilesystem', false)) {
+    try {
+      if (mountSandboxFilesystem()) {
+        log.appendLine('[Workspace] Mounted active instance WebDAV filesystem as a workspace folder.');
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.appendLine(`[Workspace] Failed to auto-mount WebDAV filesystem: ${message}`);
+    }
+  }
 
   // React to configuration changes
   const configChangeListener = vscode.workspace.onDidChangeConfiguration((e) => {

--- a/packages/b2c-vs-extension/src/webdav-tree/index.ts
+++ b/packages/b2c-vs-extension/src/webdav-tree/index.ts
@@ -48,3 +48,26 @@ export function registerWebDavTree(context: vscode.ExtensionContext, configProvi
 
   context.subscriptions.push(fsRegistration, treeView, ...commandDisposables);
 }
+
+/** Well-known URI for the active instance mounted as a workspace folder root. */
+export function sandboxFilesystemRootUri(): vscode.Uri {
+  return vscode.Uri.from({scheme: WEBDAV_SCHEME, authority: 'active-instance', path: '/'});
+}
+
+/**
+ * Mount the active instance's WebDAV filesystem as a workspace folder, if not
+ * already present. Appends at the end of the folder list so VS Code does not
+ * force a window reload (only mutating index 0, or going single→multi-root,
+ * triggers a reload). Returns true if a folder was added.
+ */
+export function mountSandboxFilesystem(): boolean {
+  const uri = sandboxFilesystemRootUri();
+  const folders = vscode.workspace.workspaceFolders;
+  if (folders?.some((f) => f.uri.scheme === WEBDAV_SCHEME)) {
+    return false;
+  }
+  return vscode.workspace.updateWorkspaceFolders(folders?.length ?? 0, 0, {
+    uri,
+    name: 'B2C Sandbox (WebDAV)',
+  });
+}


### PR DESCRIPTION
## Summary

- Removes `onStartupFinished` from the VS Code extension so it no longer activates on every window. Activation is now on-demand via `workspaceContains` markers — `dw.json` (top-level), `**/.project`, `**/cartridge/*.properties`, and the existing `**/commerce-app.json` — plus the existing `onView:*`, `onFileSystem:*`, and `onDebugResolve:b2c-script` events, and VS Code's implicit `onCommand:` activation.
- The sidebar icons, views, and welcome-view buttons are all declarative contributions, so they still render with the extension inactive; clicking any of them (or opening a B2C workspace) activates it.
- Adds an opt-in `b2c-dx.features.sandboxFilesystem` setting (default `false`) that auto-mounts the active instance's WebDAV filesystem as a workspace folder at activation. Gated on the WebDAV Browser feature being enabled. Mirrors Prophet's `sandbox.filesystem.enabled` behavior but follows the live active instance and appends the folder (no window reload).

## Why

The extension previously loaded the SDK and ran full config resolution on every VS Code startup, even in non-B2C projects. The new markers cover the real B2C project shapes (CAP, cartridge, SFRA/`dw.json`) so eager work happens only where it's relevant, while auto-deploy-on-save and the new auto-mount still arm at workspace open.

## Testing

- Open an unrelated (non-B2C) folder → extension stays dormant (no status bar / B2C output).
- Open a workspace containing a top-level `dw.json` (or a cartridge / `.project` / `commerce-app.json`) → extension activates at open without clicking anything.
- With code-sync auto-upload enabled, edit + save a cartridge file as the first action after opening a B2C workspace → change deploys on the first save.
- Set `b2c-dx.features.sandboxFilesystem: true`, reload → "B2C Sandbox (WebDAV)" folder appears mounted.
- With the extension inactive, confirm the B2C sidebar icons and welcome buttons still render and activate on click.
