### PR TITLE
fix(mrt-welcome-app): supply import.meta.url in CJS bundle to fix Lambda cold-start (@W-23240802)

### DIFF
--- a/packages/mrt-welcome-app/scripts/build.mjs
+++ b/packages/mrt-welcome-app/scripts/build.mjs
@@ -72,6 +72,8 @@ async function build() {
   const esmRequireBanner =
     "import {createRequire as __mrtCreateRequire} from 'node:module';" +
     'const require = __mrtCreateRequire(import.meta.url);';
+  // CJS has no real import.meta; derive import.meta.url from __filename.
+  const cjsMetaBanner = 'const __mrtImportMetaUrl=require("url").pathToFileURL(__filename).href;';
   await esbuild.build({
     bundle: true,
     platform: 'node',
@@ -82,12 +84,13 @@ async function build() {
     outdir: buildDir,
     define: {
       'process.env.NODE_ENV': '"production"',
+      ...(format === 'cjs' ? {'import.meta.url': '__mrtImportMetaUrl'} : {}),
     },
     plugins: [bundlePlugin],
     splitting: false,
     entryPoints: {ssr: path.join(pkgRoot, 'src', 'ssr.ts')},
     outExtension: {'.js': ssrExt},
-    ...(format === 'esm' ? {banner: {js: esmRequireBanner}} : {}),
+    ...(format === 'esm' ? {banner: {js: esmRequireBanner}} : {banner: {js: cjsMetaBanner}}),
   });
 
   const ssrStat = await fs.stat(path.join(buildDir, `ssr${ssrExt}`));


### PR DESCRIPTION
## What

Fixes a Lambda cold-start crash in the `mrt-welcome-app` CJS bundle (`build/ssr.js`).

esbuild emits an empty `import.meta` stub in CommonJS output, so at runtime `import.meta.url` (used in `src/app/server.ts` via `fileURLToPath(import.meta.url)`) resolves to `undefined`. `fileURLToPath(undefined)` then throws `ERR_INVALID_ARG_TYPE` at module load — every request to a target running the bundle returns HTTP 500.

## Why

The build script (`scripts/build.mjs`) only supplied an `import.meta`-based banner for the ESM output path. The default/shipped format is CJS, which had no shim. The CJS bundle has therefore been broken since the build script was introduced in #445 — it only surfaced now because the artifact is loaded as CJS at Lambda cold-start (`nodejs24.x`), and nothing in the repo's tests loads the built bundle (they run against the TS source via tsx, where `import.meta.url` works natively).

## How

Add a small CJS banner defining `__mrtImportMetaUrl` from `__filename`, and map `import.meta.url` → that identifier via esbuild `define` (gated to the CJS branch). ESM output is unchanged.

Note: esbuild's `define` value must be a bare identifier or literal, so the value is supplied via a banner const rather than an inline `require(...)` expression.

## Verification

- `node -e "require('./build/ssr.js')"` exits 0 (previously threw `ERR_INVALID_ARG_TYPE`); exports `app`, `get`, `processLambdaResponse` present.
- Bundle grep confirms `fileURLToPath(__mrtImportMetaUrl)` replaces the empty-object stub.
- ESM build (`MRT_EXPORT_TYPE=esm`) still builds and imports cleanly — no downgrade regression.
- `pnpm test:agent` (25 passing), `lint:agent`, `typecheck:agent` all pass.

## Screenshots (for reviewer)
Uploaded bundle to the following [environment](https://runtime-admin-dev.mobify-storefront.com/salesforce-internal/abc-d767f8/sample-env)

### Environment
<img width="1654" height="995" alt="Screenshot 2026-07-09 at 11 57 54 AM" src="https://github.com/user-attachments/assets/8063e261-2269-47aa-a161-892fd7a03055" />

### Site without HTML Injection
<img width="1654" height="995" alt="Screenshot 2026-07-09 at 11 58 03 AM" src="https://github.com/user-attachments/assets/bb9f1d98-f435-4ce7-a00b-99835baa6048" />

### Site with HTML Injection
<img width="1654" height="995" alt="Screenshot 2026-07-09 at 11 58 12 AM" src="https://github.com/user-attachments/assets/fbfd070b-b709-4d97-90d1-6b9ca28e3c90" />

