### PR TITLE
@W-23442668 fixing the failing e2e mcp test

### DIFF
--- a/packages/b2c-tooling-sdk/src/discovery/patterns/storefront-next.ts
+++ b/packages/b2c-tooling-sdk/src/discovery/patterns/storefront-next.ts
@@ -15,14 +15,12 @@ import {readPackageJson, globDirs} from '../utils.js';
 import {packageIndicatesPwaKit} from './pwa-kit.js';
 
 /**
- * The Storefront Next dev toolchain dependency — the definitive dependency
- * signal that a project is Storefront Next.
- *
- * We deliberately do NOT match the broader `@salesforce/storefront-next*` prefix:
- * `@salesforce/storefront-next-runtime` is now also pulled in by PWA Kit projects
- * for unrelated reasons, and matching the prefix produced false positives there.
+ * Storefront Next marker dependencies. A project that has either the dev
+ * toolchain or the runtime is considered Storefront Next — provided the PWA Kit
+ * guard below doesn't disqualify it first (PWA Kit apps may also pull in the
+ * runtime for unrelated reasons).
  */
-const STOREFRONT_NEXT_DEV_DEP = '@salesforce/storefront-next-dev';
+const STOREFRONT_NEXT_MARKERS = ['@salesforce/storefront-next-dev', '@salesforce/storefront-next-runtime'];
 
 /**
  * Returns true if this package.json (deps or name) indicates a Storefront Next project.
@@ -36,7 +34,7 @@ function packageIndicatesStorefrontNext(pkg: PackageJson): boolean {
   if (packageIndicatesPwaKit(pkg)) return false;
 
   const deps = Object.keys({...pkg.dependencies, ...pkg.devDependencies});
-  if (deps.includes(STOREFRONT_NEXT_DEV_DEP)) {
+  if (STOREFRONT_NEXT_MARKERS.some((marker) => deps.includes(marker))) {
     return true;
   }
   const name = pkg.name;

--- a/packages/b2c-tooling-sdk/test/discovery/patterns/storefront-next.test.ts
+++ b/packages/b2c-tooling-sdk/test/discovery/patterns/storefront-next.test.ts
@@ -35,15 +35,14 @@ describe('discovery/patterns/storefront-next', () => {
       expect(result).to.be.true;
     });
 
-    it('does NOT detect on @salesforce/storefront-next-runtime alone (shared with PWA Kit)', async () => {
-      // -runtime is now pulled in by PWA Kit projects too, so it is no longer a
-      // Storefront Next signal on its own — only -dev is.
+    it('detects @salesforce/storefront-next-runtime dependency (when not a PWA Kit project)', async () => {
+      // -runtime alone is a valid signal when the PWA Kit guard doesn't disqualify.
       const pkg = {name: 'x', dependencies: {'@salesforce/storefront-next-runtime': 'workspace:*'}};
       await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify(pkg));
 
       const result = await storefrontNextPattern.detect(tempDir);
 
-      expect(result).to.be.false;
+      expect(result).to.be.true;
     });
 
     it('does NOT detect a PWA Kit project even if it depends on storefront-next-runtime', async () => {


### PR DESCRIPTION
## Summary

Fixing the failing e2e mcp test

## Dependencies

- [x] No net-new third-party dependencies were added
- [x] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`)
- [x] Code is formatted (`pnpm run format`)
