### PR TITLE
feat(logs): support Logs/ subdirectory filters

### DIFF
--- a/.changeset/logs-subdirectory-filter.md
+++ b/.changeset/logs-subdirectory-filter.md
@@ -1,0 +1,8 @@
+---
+'@salesforce/b2c-tooling-sdk': minor
+'@salesforce/b2c-cli': minor
+'@salesforce/b2c-dx-mcp': minor
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Log commands and tools can now access logs in `Logs/` subdirectories (such as `internal/`). Pass a path-like `--filter`/`prefixes` value containing a `/` — e.g. `--filter internal/server` to target `server-*.log` files under `internal/`, or `--filter internal/` for everything in that subdirectory. Plain prefix filters (and the default listing) are unchanged and still only scan the top-level `Logs/` directory, so there is no performance impact unless you opt in with a path filter. Works across `logs list`, `logs get`, `logs tail`, and the corresponding MCP tools.

--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -26,7 +26,7 @@ b2c logs get
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--filter`, `-f` | Log prefixes to filter (can specify multiple) | `error`, `customerror` |
+| `--filter`, `-f` | Log prefixes to filter (can specify multiple). Use a path like `internal/server` to fetch logs from a subdirectory. | `error`, `customerror` |
 | `--count`, `-n` | Maximum number of entries to retrieve | `20` |
 | `--since` | Only show entries after this time (e.g., "5m", "1h", "2d", or ISO 8601) | - |
 | `--level` | Filter by log level (can specify multiple): ERROR, WARN, INFO, DEBUG, FATAL, TRACE | - |
@@ -47,6 +47,9 @@ b2c logs get --count 50
 
 # Get logs from specific types
 b2c logs get --filter error --filter debug --filter warn
+
+# Get logs from a subdirectory (e.g. internal/) using a path-like filter
+b2c logs get --filter internal/server
 
 # Filter by time - last 5 minutes
 b2c logs get --since 5m
@@ -118,7 +121,7 @@ b2c logs list
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--filter`, `-f` | Filter by log prefix (can specify multiple) | All logs |
+| `--filter`, `-f` | Filter by log prefix (can specify multiple). Use a path like `internal/server` to list logs in a subdirectory. | All logs |
 | `--sort` | Sort field: `name`, `date`, `size` | `date` |
 | `--order`, `-o` | Sort order: `asc`, `desc` | `desc` |
 | `--columns`, `-c` | Columns to display (comma-separated). Available: name, prefix, size, modified | - |
@@ -133,6 +136,9 @@ b2c logs list
 
 # List only error logs
 b2c logs list --filter error --filter customerror
+
+# List logs in the internal/ subdirectory (path-like filter)
+b2c logs list --filter internal/server
 
 # Sort by size
 b2c logs list --sort size --order desc
@@ -167,7 +173,7 @@ b2c logs tail
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--filter`, `-f` | Log prefixes to filter (can specify multiple) | `error`, `customerror` |
+| `--filter`, `-f` | Log prefixes to filter (can specify multiple). Use a path like `internal/server` to tail logs in a subdirectory. | `error`, `customerror` |
 | `--interval` | Polling interval in milliseconds | `3000` |
 | `--last`, `-l` | Show last N entries per file on startup (0 to skip) | `1` |
 | `--level` | Filter by log level (can specify multiple): ERROR, WARN, INFO, DEBUG, FATAL, TRACE | - |
@@ -185,6 +191,9 @@ b2c logs tail
 
 # Tail specific log types
 b2c logs tail --filter debug --filter error --filter warn
+
+# Tail a log in the internal/ subdirectory (path-like filter)
+b2c logs tail --filter internal/server
 
 # Faster polling (1 second)
 b2c logs tail --interval 1000

--- a/docs/mcp/tools/logs.md
+++ b/docs/mcp/tools/logs.md
@@ -36,11 +36,11 @@ See [Configuration](../configuration) for credential setup.
 
 List log files on the instance via WebDAV.
 
-| Parameter    | Type                         | Required | Default | Description                                             |
-| ------------ | ---------------------------- | -------- | ------- | ------------------------------------------------------- |
-| `prefixes`   | string[]                     | No       | all     | Filter by log prefix (e.g., `["error", "customerror"]`) |
-| `sort_by`    | `"date" \| "name" \| "size"` | No       | `date`  | Sort field                                              |
-| `sort_order` | `"asc" \| "desc"`            | No       | `desc`  | Sort order                                              |
+| Parameter    | Type                         | Required | Default | Description                                                                                                                          |
+| ------------ | ---------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `prefixes`   | string[]                     | No       | all     | Filter by log prefix (e.g., `["error", "customerror"]`). A path-like value such as `"internal/server"` lists logs in a subdirectory. |
+| `sort_by`    | `"date" \| "name" \| "size"` | No       | `date`  | Sort field                                                                                                                         |
+| `sort_order` | `"asc" \| "desc"`            | No       | `desc`  | Sort order                                                                                                                         |
 
 **Returns:** `{count, files: [{name, prefix, size, lastModified, path}]}`.
 
@@ -48,13 +48,13 @@ List log files on the instance via WebDAV.
 
 Fetch recent log entries in a single request/response. Filters (`since`, `level`, `search`) are applied client-side after fetching.
 
-| Parameter  | Type     | Required | Default                    | Description                                              |
-| ---------- | -------- | -------- | -------------------------- | -------------------------------------------------------- |
-| `prefixes` | string[] | No       | `["error", "customerror"]` | Log prefixes to read                                     |
-| `count`    | number   | No       | `50`                       | Maximum entries to return                                |
-| `since`    | string   | No       |                            | Relative time (`"5m"`, `"1h"`, `"2d"`) or ISO 8601       |
-| `level`    | string[] | No       |                            | Filter by level (ERROR, WARN, INFO, DEBUG, FATAL, TRACE) |
-| `search`   | string   | No       |                            | Case-insensitive substring filter                        |
+| Parameter  | Type     | Required | Default                    | Description                                                                                          |
+| ---------- | -------- | -------- | -------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `prefixes` | string[] | No       | `["error", "customerror"]` | Log prefixes to read. A path-like value such as `"internal/server"` reads logs from a subdirectory.  |
+| `count`    | number   | No       | `50`                       | Maximum entries to return                                                                            |
+| `since`    | string   | No       |                            | Relative time (`"5m"`, `"1h"`, `"2d"`) or ISO 8601                                                   |
+| `level`    | string[] | No       |                            | Filter by level (ERROR, WARN, INFO, DEBUG, FATAL, TRACE)                                             |
+| `search`   | string   | No       |                            | Case-insensitive substring filter                                                                    |
 
 **Returns:** `{count, entries: [{file, level, timestamp, message, raw}]}`.
 
@@ -66,7 +66,7 @@ Start a background log watch. Returns a `watch_id` immediately. Buffers entries 
 
 | Parameter          | Type     | Required | Default                    | Description                                                                                                           |
 | ------------------ | -------- | -------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `prefixes`         | string[] | No       | `["error", "customerror"]` | Log prefixes to watch                                                                                                 |
+| `prefixes`         | string[] | No       | `["error", "customerror"]` | Log prefixes to watch. A path-like value such as `"internal/server"` watches logs in a subdirectory.                  |
 | `last_entries`     | number   | No       | `0`                        | Pre-existing entries per file to emit on startup. `0` (default) captures only new entries; set >0 for recent context. |
 | `poll_interval_ms` | number   | No       | `3000`                     | How often the underlying tail polls WebDAV                                                                            |
 | `level`            | string[] | No       |                            | Drop entries not matching level before buffering                                                                      |

--- a/packages/b2c-cli/src/commands/logs/get.ts
+++ b/packages/b2c-cli/src/commands/logs/get.ts
@@ -48,7 +48,8 @@ export default class LogsGet extends InstanceCommand<typeof LogsGet> {
     ...InstanceCommand.baseFlags,
     filter: Flags.string({
       char: 'f',
-      description: 'Log prefixes to filter (can specify multiple)',
+      description:
+        'Log prefixes to filter (can specify multiple). Use a path like "internal/server" to fetch logs from a subdirectory.',
       multiple: true,
       default: DEFAULT_PREFIXES,
     }),

--- a/packages/b2c-cli/src/commands/logs/list.ts
+++ b/packages/b2c-cli/src/commands/logs/list.ts
@@ -72,7 +72,8 @@ export default class LogsList extends InstanceCommand<typeof LogsList> {
     ...InstanceCommand.baseFlags,
     filter: Flags.string({
       char: 'f',
-      description: 'Filter by log prefix (can specify multiple)',
+      description:
+        'Filter by log prefix (can specify multiple). Use a path like "internal/server" to list logs in a subdirectory.',
       multiple: true,
     }),
     sort: Flags.string({

--- a/packages/b2c-cli/src/commands/logs/tail.ts
+++ b/packages/b2c-cli/src/commands/logs/tail.ts
@@ -42,7 +42,8 @@ export default class LogsTail extends InstanceCommand<typeof LogsTail> {
     ...InstanceCommand.baseFlags,
     filter: Flags.string({
       char: 'f',
-      description: 'Log prefixes to filter (can specify multiple)',
+      description:
+        'Log prefixes to filter (can specify multiple). Use a path like "internal/server" to tail logs in a subdirectory.',
       multiple: true,
       default: DEFAULT_PREFIXES,
     }),

--- a/packages/b2c-dx-mcp/src/tools/diagnostics/logs-get-recent.ts
+++ b/packages/b2c-dx-mcp/src/tools/diagnostics/logs-get-recent.ts
@@ -60,7 +60,9 @@ export function createLogsGetRecentTool(
         prefixes: z
           .array(z.string())
           .optional()
-          .describe('Log prefixes to read. Defaults to ["error", "customerror"].'),
+          .describe(
+            'Log prefixes to read. Defaults to ["error", "customerror"]. Use a path like "internal/server" to read logs from a subdirectory.',
+          ),
         count: z.number().int().positive().optional().describe('Maximum number of entries to return. Defaults to 50.'),
         since: z
           .string()

--- a/packages/b2c-dx-mcp/src/tools/diagnostics/logs-list-files.ts
+++ b/packages/b2c-dx-mcp/src/tools/diagnostics/logs-list-files.ts
@@ -45,7 +45,9 @@ export function createLogsListFilesTool(
         prefixes: z
           .array(z.string())
           .optional()
-          .describe('Filter by log prefixes (e.g., ["error", "customerror"]). Returns all when omitted.'),
+          .describe(
+            'Filter by log prefixes (e.g., ["error", "customerror"]). Returns all when omitted. Use a path like "internal/server" to list logs in a subdirectory.',
+          ),
         sort_by: z.enum(['date', 'name', 'size']).optional().describe('Sort field. Defaults to "date".'),
         sort_order: z.enum(['asc', 'desc']).optional().describe('Sort order. Defaults to "desc".'),
       },

--- a/packages/b2c-dx-mcp/src/tools/diagnostics/logs-watch-start.ts
+++ b/packages/b2c-dx-mcp/src/tools/diagnostics/logs-watch-start.ts
@@ -61,7 +61,9 @@ export function createLogsWatchStartTool(
         prefixes: z
           .array(z.string())
           .optional()
-          .describe('Log prefixes to watch. Defaults to ["error", "customerror"].'),
+          .describe(
+            'Log prefixes to watch. Defaults to ["error", "customerror"]. Use a path like "internal/server" to watch logs in a subdirectory.',
+          ),
         last_entries: z
           .number()
           .int()

--- a/packages/b2c-tooling-sdk/src/operations/logs/list.ts
+++ b/packages/b2c-tooling-sdk/src/operations/logs/list.ts
@@ -74,35 +74,33 @@ export function extractPrefix(filename: string): string {
 }
 
 /**
- * Lists log files on a B2C Commerce instance.
+ * Lists the `.log` files in a single Logs directory (depth 1, non-recursive).
  *
  * @param instance - B2C instance to list logs from
- * @param options - Listing options (filters, sorting)
- * @returns Array of log files
+ * @param relativeDir - Directory relative to `Logs/` (e.g. "internal"); "" for the root Logs directory
+ * @returns Array of log files found directly in that directory
  *
- * @example
- * ```typescript
- * // List all error and customerror logs
- * const logs = await listLogFiles(instance, {
- *   prefixes: ['error', 'customerror'],
- *   sortBy: 'date',
- *   sortOrder: 'desc'
- * });
- * ```
+ * For nested directories the returned {@link LogFile.name} and {@link LogFile.path}
+ * include the relative directory so file identities stay unique across subdirectories
+ * (e.g. `internal/server-...log`) and reads target the correct WebDAV path.
  */
-export async function listLogFiles(instance: B2CInstance, options: ListLogsOptions = {}): Promise<LogFile[]> {
+async function listLogFilesInDir(instance: B2CInstance, relativeDir: string): Promise<LogFile[]> {
   const logger = getLogger();
-  const {prefixes, sortBy = 'date', sortOrder = 'desc'} = options;
+  const propfindPath = relativeDir ? `Logs/${relativeDir}` : 'Logs';
 
-  logger.debug({prefixes, sortBy, sortOrder}, 'Listing log files');
+  let entries;
+  try {
+    entries = await instance.webdav.propfind(propfindPath, '1');
+  } catch (error) {
+    // A non-existent subdirectory (e.g. a typo'd path filter) should not abort the
+    // whole listing — log and treat it as empty.
+    logger.debug({error, dir: propfindPath}, `Failed to list log directory: ${propfindPath}`);
+    return [];
+  }
 
-  // Get all files from Logs directory
-  const entries = await instance.webdav.propfind('Logs', '1');
-
-  // Filter to only log files (not directories, not the Logs directory itself)
-  const logFiles: LogFile[] = entries
+  return entries
     .filter((entry) => {
-      // Skip directories
+      // Skip directories (including the listed directory itself)
       if (entry.isCollection) return false;
 
       // Skip if not a .log file
@@ -112,34 +110,101 @@ export async function listLogFiles(instance: B2CInstance, options: ListLogsOptio
       return true;
     })
     .map((entry) => {
-      const name = entry.displayName || entry.href.split('/').pop() || '';
-      const prefix = extractPrefix(name);
+      const basename = entry.displayName || entry.href.split('/').pop() || '';
+      const relativeName = relativeDir ? `${relativeDir}/${basename}` : basename;
 
       return {
-        name,
-        prefix,
+        name: relativeName,
+        prefix: extractPrefix(basename),
         size: entry.contentLength || 0,
         lastModified: entry.lastModified || new Date(0),
-        path: `Logs/${name}`,
+        path: `Logs/${relativeName}`,
       };
     });
+}
 
-  // Filter by prefix if specified
-  let filtered = logFiles;
-  if (prefixes && prefixes.length > 0) {
-    const prefixSet = new Set(prefixes.map((p) => p.toLowerCase()));
-    filtered = logFiles.filter((file) => {
-      // Check exact prefix match
-      if (prefixSet.has(file.prefix.toLowerCase())) return true;
+/**
+ * Lists log files on a B2C Commerce instance.
+ *
+ * Filters in {@link ListLogsOptions.prefixes} are matched in one of two ways:
+ *
+ * - **Prefix filters** (no `/`, e.g. `"error"`) match the extracted log-category
+ *   prefix of files in the top-level `Logs/` directory.
+ * - **Path filters** (contain a `/`, e.g. `"internal/server"`) recurse into the
+ *   named subdirectory of `Logs/` and match against each file's path relative to
+ *   `Logs/`. This is the only case that lists subdirectories — by default only the
+ *   top-level `Logs/` directory is scanned.
+ *
+ * @param instance - B2C instance to list logs from
+ * @param options - Listing options (filters, sorting)
+ * @returns Array of log files
+ *
+ * @example
+ * ```typescript
+ * // List all error and customerror logs (top-level)
+ * const logs = await listLogFiles(instance, {
+ *   prefixes: ['error', 'customerror'],
+ *   sortBy: 'date',
+ *   sortOrder: 'desc'
+ * });
+ *
+ * // List server logs in the internal/ subdirectory
+ * const internal = await listLogFiles(instance, {prefixes: ['internal/server']});
+ * ```
+ */
+export async function listLogFiles(instance: B2CInstance, options: ListLogsOptions = {}): Promise<LogFile[]> {
+  const logger = getLogger();
+  const {prefixes, sortBy = 'date', sortOrder = 'desc'} = options;
 
-      // Also check if the prefix starts with any of the specified prefixes
-      // This handles cases like "custom-mylog" matching "custom"
+  logger.debug({prefixes, sortBy, sortOrder}, 'Listing log files');
+
+  // Partition filters: path-like filters (containing "/") select files in a
+  // subdirectory by relative path; the rest match the top-level category prefix.
+  const allFilters = prefixes ?? [];
+  const pathFilters = allFilters.filter((p) => p.includes('/'));
+  const prefixFilters = allFilters.filter((p) => !p.includes('/'));
+
+  // Always scan the top-level Logs directory.
+  const topLevel = await listLogFilesInDir(instance, '');
+
+  // Recurse only when a path-like filter is present, and only into the
+  // subdirectory that filter names (the segment before its last "/").
+  const subDirs = new Set(pathFilters.map((p) => p.slice(0, p.lastIndexOf('/'))).filter((dir) => dir.length > 0));
+  const nested: LogFile[] = [];
+  for (const dir of subDirs) {
+    nested.push(...(await listLogFilesInDir(instance, dir)));
+  }
+
+  // Filter by prefix and/or path if any filters were specified.
+  let filtered: LogFile[];
+  if (allFilters.length === 0) {
+    filtered = topLevel;
+  } else {
+    const prefixSet = new Set(prefixFilters.map((p) => p.toLowerCase()));
+    const pathSet = pathFilters.map((p) => p.toLowerCase());
+
+    // Top-level files match by category prefix (exact or startsWith, e.g. "custom" → "custom-mylog").
+    const matchedTopLevel = topLevel.filter((file) => {
+      const prefix = file.prefix.toLowerCase();
+      if (prefixSet.has(prefix)) return true;
       for (const p of prefixSet) {
-        if (file.prefix.toLowerCase().startsWith(p)) return true;
+        if (prefix.startsWith(p)) return true;
       }
-
       return false;
     });
+
+    // Nested files match by relative path (exact or startsWith, e.g. "internal/server").
+    const matchedNested = nested.filter((file) => {
+      const relativePath = file.name.toLowerCase();
+      return pathSet.some((p) => relativePath === p || relativePath.startsWith(p));
+    });
+
+    // Dedupe by path in case multiple filters select the same file.
+    const byPath = new Map<string, LogFile>();
+    for (const file of [...matchedTopLevel, ...matchedNested]) {
+      byPath.set(file.path, file);
+    }
+    filtered = [...byPath.values()];
   }
 
   // Sort the results

--- a/packages/b2c-tooling-sdk/src/operations/logs/types.ts
+++ b/packages/b2c-tooling-sdk/src/operations/logs/types.ts
@@ -42,7 +42,11 @@ export interface LogEntry {
 export interface ListLogsOptions {
   /**
    * Filter by log prefixes (e.g., ["error", "customerror"]).
-   * If not specified, returns all log files.
+   *
+   * A filter containing a "/" (e.g. "internal/server") is treated as a path
+   * filter: it recurses into that subdirectory of `Logs/` and matches files by
+   * their path relative to `Logs/`. Filters without a "/" match the top-level
+   * log-category prefix. If not specified, returns all top-level log files.
    */
   prefixes?: string[];
   /**

--- a/packages/b2c-tooling-sdk/test/operations/logs/list.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/logs/list.test.ts
@@ -17,14 +17,17 @@ const BASE_URL = `https://${TEST_HOST}/on/demandware.servlet/webdav/Sites`;
 /**
  * Generates a PROPFIND XML response for testing.
  */
-function generatePropfindXml(entries: {name: string; size: number; date: Date; isDir?: boolean}[]): string {
+function generatePropfindXml(
+  entries: {name: string; size: number; date: Date; isDir?: boolean}[],
+  dirHref = 'Logs',
+): string {
   const responses = entries.map(({name, size, date, isDir}) => {
     const resourceType = isDir ? '<D:collection/>' : '';
     const contentLength = isDir ? '' : `<D:getcontentlength>${size}</D:getcontentlength>`;
 
     return `
     <D:response>
-      <D:href>/on/demandware.servlet/webdav/Sites/Logs/${name}</D:href>
+      <D:href>/on/demandware.servlet/webdav/Sites/${dirHref}/${name}</D:href>
       <D:propstat>
         <D:prop>
           <D:displayname>${name}</D:displayname>
@@ -245,6 +248,120 @@ describe('operations/logs/list', () => {
       const files = await listLogFiles(instance as never, {prefixes: ['debug']});
 
       expect(files).to.have.length(0);
+    });
+
+    /**
+     * Routes PROPFIND requests by their target directory so subdirectory
+     * recursion can be exercised. Maps a relative dir ("" = root) to its entries.
+     */
+    function useDirHandlers(dirs: Record<string, {name: string; size: number; date: Date; isDir?: boolean}[]>): void {
+      server.use(
+        http.all(`${BASE_URL}/*`, ({request}) => {
+          if (request.method !== 'PROPFIND') {
+            return new HttpResponse(null, {status: 404});
+          }
+          // Determine which dir is being listed from the URL suffix after /Logs
+          const url = new URL(request.url);
+          const afterLogs = url.pathname.split('/Logs')[1]?.replace(/^\/|\/$/g, '') ?? '';
+          const entries = dirs[afterLogs];
+          if (!entries) {
+            return new HttpResponse(null, {status: 404});
+          }
+          const dirHref = afterLogs ? `Logs/${afterLogs}` : 'Logs';
+          return new HttpResponse(generatePropfindXml(entries, dirHref), {
+            status: 207,
+            headers: {'Content-Type': 'application/xml'},
+          });
+        }),
+      );
+    }
+
+    it('does not recurse into subdirectories without a path filter', async () => {
+      const now = new Date();
+      useDirHandlers({
+        '': [
+          {name: 'error-blade1-20250125.log', size: 1234, date: now},
+          {name: 'internal', size: 0, date: now, isDir: true},
+        ],
+        internal: [{name: 'server-blade1-20250125.log', size: 5678, date: now}],
+      });
+
+      const instance = createMockInstance();
+      const files = await listLogFiles(instance as never);
+
+      // Only the top-level file; the directory entry is excluded and not recursed.
+      expect(files).to.have.length(1);
+      expect(files[0].name).to.equal('error-blade1-20250125.log');
+    });
+
+    it('recurses into a subdirectory for a path-like filter', async () => {
+      const now = new Date();
+      useDirHandlers({
+        '': [{name: 'error-blade1-20250125.log', size: 1234, date: now}],
+        internal: [
+          {name: 'server-blade1-20250125.log', size: 5678, date: now},
+          {name: 'ccp-blade1-20250125.log', size: 90, date: now},
+        ],
+      });
+
+      const instance = createMockInstance();
+      const files = await listLogFiles(instance as never, {prefixes: ['internal/server']});
+
+      expect(files).to.have.length(1);
+      expect(files[0].name).to.equal('internal/server-blade1-20250125.log');
+      expect(files[0].path).to.equal('Logs/internal/server-blade1-20250125.log');
+    });
+
+    it('matches all files in a subdirectory with a trailing-slash path filter', async () => {
+      const now = new Date();
+      useDirHandlers({
+        '': [{name: 'error-blade1-20250125.log', size: 1234, date: now}],
+        internal: [
+          {name: 'server-blade1-20250125.log', size: 5678, date: now},
+          {name: 'ccp-blade1-20250125.log', size: 90, date: now},
+        ],
+      });
+
+      const instance = createMockInstance();
+      const files = await listLogFiles(instance as never, {prefixes: ['internal/']});
+
+      expect(files.map((f) => f.name).sort()).to.deep.equal([
+        'internal/ccp-blade1-20250125.log',
+        'internal/server-blade1-20250125.log',
+      ]);
+    });
+
+    it('combines top-level prefix filters with path filters', async () => {
+      const now = new Date();
+      useDirHandlers({
+        '': [
+          {name: 'error-blade1-20250125.log', size: 1234, date: now},
+          {name: 'debug-blade1-20250125.log', size: 1, date: now},
+        ],
+        internal: [{name: 'server-blade1-20250125.log', size: 5678, date: now}],
+      });
+
+      const instance = createMockInstance();
+      const files = await listLogFiles(instance as never, {prefixes: ['error', 'internal/server']});
+
+      expect(files.map((f) => f.name).sort()).to.deep.equal([
+        'error-blade1-20250125.log',
+        'internal/server-blade1-20250125.log',
+      ]);
+    });
+
+    it('treats a missing subdirectory as empty without failing', async () => {
+      const now = new Date();
+      useDirHandlers({
+        '': [{name: 'error-blade1-20250125.log', size: 1234, date: now}],
+        // no "nonexistent" dir -> PROPFIND returns 404
+      });
+
+      const instance = createMockInstance();
+      const files = await listLogFiles(instance as never, {prefixes: ['error', 'nonexistent/foo']});
+
+      expect(files).to.have.length(1);
+      expect(files[0].name).to.equal('error-blade1-20250125.log');
     });
   });
 });

--- a/skills/b2c-cli/skills/b2c-logs/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-logs/SKILL.md
@@ -93,6 +93,9 @@ b2c logs list
 # List specific log types
 b2c logs list --filter error --filter customerror
 
+# List logs in a subdirectory (path-like filter)
+b2c logs list --filter internal/server
+
 # JSON output
 b2c logs list --json
 ```
@@ -170,6 +173,23 @@ Common log file prefixes:
 | `api` | API problems and violations |
 | `deprecation` | Deprecated API usage |
 | `quota` | Quota warnings |
+
+## Logs in Subdirectories
+
+The `Logs/` directory contains subdirectories such as `internal/` (e.g. `server`, `ccp`, `health`, `csrf-violations`, `internalquota`). These are **not** listed by default. To reach them, pass a path-like `--filter` (one containing a `/`): the tooling then recurses into that subdirectory and matches files by their path relative to `Logs/`.
+
+```bash
+# All "server" logs under internal/
+b2c logs list --filter internal/server
+
+# Everything under internal/ (trailing slash)
+b2c logs tail --filter internal/
+
+# Mix a subdirectory filter with normal prefix filters
+b2c logs get --filter error --filter internal/server
+```
+
+This works the same across `logs list`, `logs get`, and `logs tail` (and the equivalent MCP tools).
 
 ## More Commands
 


### PR DESCRIPTION
## What

Log commands and tools can now access logs in `Logs/` subdirectories (such as `internal/`) via a path-like filter.

Pass a `--filter` / `prefixes` value containing a `/`:
- `--filter internal/server` targets `server-*.log` files under `internal/`
- `--filter internal/` targets everything in that subdirectory

Plain prefix filters (e.g. `--filter error`) and the default listing are unchanged — they still scan only the top-level `Logs/` directory, so there is **no performance impact** unless you opt in with a path filter.

Applies across `logs list`, `logs get`, `logs tail`, and the corresponding MCP tools (`logs_list_files`, `logs_get_recent`, `logs_watch_start`).

## Why

B2C instances write some logs (notably `internal/`) into subdirectories of `Logs/`. Previously these were unreachable via the CLI/MCP log tooling, which only listed the top-level directory.

## Changes

- **SDK** (`operations/logs`): `list` partitions filters into prefix vs. path-like, and recurses only into the named subdirectory when a path filter is present; new tests cover the behavior.
- **CLI**: `logs get/list/tail` flag help/plumbing.
- **MCP**: `logs-get-recent`, `logs-list-files`, `logs-watch-start` tool descriptions.
- **Docs**: `docs/cli/logs.md`, `docs/mcp/tools/logs.md`.
- **Skill**: `b2c-logs` SKILL.md.
- Changeset: minor for SDK/CLI/MCP, patch for agent-plugins.

## Testing

- Target a log subdirectory and confirm files/entries are returned:
  - `b2c logs list --filter internal/`
  - `b2c logs get --filter internal/server`
  - `b2c logs tail --filter internal/server`
- Confirm a plain prefix filter (`b2c logs list --filter error`) and the default listing still return only top-level `Logs/` files.