### PR TITLE
changeset: bump VS Code extension to 1.0

### DIFF
--- a/.changeset/vscode-extension-1-0-release.md
+++ b/.changeset/vscode-extension-1-0-release.md
@@ -1,0 +1,5 @@
+---
+'b2c-vs-extension': major
+---
+
+Release the B2C Commerce VS Code extension 1.0.


### PR DESCRIPTION
## Summary
Adds a changeset to bump the B2C Commerce VS Code extension from `0.11.0` to `1.0.0` for its 1.0 release. Since the extension is pre-1.0, a `major` bump produces the `1.0.0` version.

The extension is packaged as a VSIX and versioned via git tags (not published to npm).

## Testing
No manual testing required — this is a changeset-only change that drives the version bump on merge of the version PR.