### PR TITLE
Fix docs read of Salesforce Help articles

### DIFF
--- a/.changeset/fix-help-corpus-read.md
+++ b/.changeset/fix-help-corpus-read.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+Fix `b2c docs read` failing to load Salesforce Help (Business Manager) articles. Help content is served online but its index entries carried a bundled-file path, so reads tried a nonexistent local file and failed instead of fetching from the source URL. Reads now fetch help articles online as intended.

--- a/packages/b2c-tooling-sdk/src/docs/search.ts
+++ b/packages/b2c-tooling-sdk/src/docs/search.ts
@@ -226,8 +226,12 @@ function loadCorpus(dataDir: string): DocEntry[] {
   for (const entry of parsed.entries) {
     if (entryById.has(entry.id)) continue; // first corpus wins on id collision
     entryById.set(entry.id, entry);
-    // Only record a data dir for entries whose content is bundled on disk.
-    if (entry.filePath) {
+    // Record a data dir only for entries whose content is actually bundled on
+    // disk. Some corpora (e.g. Salesforce Help) carry a `filePath` for
+    // parity/debug but ship online-only — their `.md` files are NOT packaged, so
+    // reading from disk would ENOENT. Existence-gating routes those to the
+    // online `sourceUrl` path in readEntryContent instead.
+    if (entry.filePath && fs.existsSync(path.join(dataDir, entry.filePath))) {
       entryDataDir.set(entry.id, dataDir);
     }
   }
@@ -484,7 +488,13 @@ export async function readEntryContent(entry: DocEntry): Promise<string> {
   const dataDir = entryDataDir.get(entry.id);
   if (dataDir && entry.filePath) {
     logger.debug({id: entry.id, source: 'bundled', filePath: entry.filePath}, 'Reading bundled documentation entry');
-    return fs.readFileSync(path.join(dataDir, entry.filePath), 'utf-8');
+    try {
+      return fs.readFileSync(path.join(dataDir, entry.filePath), 'utf-8');
+    } catch (err) {
+      // A registered bundled file should exist (loadCorpus existence-gates), but
+      // if it is unreadable, fall through to the online source rather than throw.
+      logger.debug({id: entry.id, filePath: entry.filePath, err}, 'Bundled read failed; trying online source');
+    }
   }
   // Online-only entries (guides): fetch the raw markdown. Prefer `sourceUrl`
   // (the `.md`); fall back to `url` for any entry that only carries one.

--- a/packages/b2c-tooling-sdk/test/docs/guides-corpus.test.ts
+++ b/packages/b2c-tooling-sdk/test/docs/guides-corpus.test.ts
@@ -25,8 +25,11 @@ const packageRoot = path.dirname(require.resolve('@salesforce/b2c-tooling-sdk/pa
 const GUIDES_INDEX = path.join(packageRoot, 'data/guides/index.json');
 const TOOLING_INDEX = path.join(packageRoot, 'data/tooling/index.json');
 
+const HELP_INDEX = path.join(packageRoot, 'data/help/index.json');
+
 const hasGuides = fs.existsSync(GUIDES_INDEX);
 const hasTooling = fs.existsSync(TOOLING_INDEX);
+const hasHelp = fs.existsSync(HELP_INDEX);
 
 describe('docs: Developer Center guides corpus', function () {
   before(function () {
@@ -348,6 +351,37 @@ describe('docs: tooling corpus', function () {
       const content = await readEntryContent(auth!);
       expect(content).to.equal('# Authentication\n\nfetched body');
       expect(fetchedUrl, 'content must be fetched from the .md sourceUrl').to.equal(auth!.sourceUrl);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe('docs: Salesforce Help corpus', function () {
+  before(function () {
+    if (!hasHelp) this.skip();
+  });
+
+  // Help entries carry a `filePath` for parity/debug, but the .md tree is NOT
+  // bundled in the package (it ships to the docs site only). Reads must therefore
+  // route to the online sourceUrl, never a (nonexistent) local file — regression
+  // for reads failing with "failed to load from the local doc cache".
+  it('reads help content online from sourceUrl despite carrying a filePath', async () => {
+    const entry = listDocs('help-admin').find((e) => Boolean(e.filePath && e.sourceUrl));
+    expect(entry, 'expected a help-admin entry with a filePath and sourceUrl').to.not.equal(undefined);
+    clearContentCache(true);
+    const originalFetch = globalThis.fetch;
+    let fetchedUrl = '';
+    globalThis.fetch = ((input: Parameters<typeof fetch>[0]) => {
+      fetchedUrl = String(input);
+      return Promise.resolve(new Response('# Help Article\n\nfetched body', {status: 200}));
+    }) as typeof fetch;
+    try {
+      const content = await readEntryContent(entry!);
+      // Real content, not the offline metadata fallback.
+      expect(content).to.equal('# Help Article\n\nfetched body');
+      expect(content).to.not.contain('could not be fetched');
+      expect(fetchedUrl, 'help content must be fetched from the online sourceUrl').to.equal(entry!.sourceUrl);
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## What

`b2c docs read` (and the MCP `docs_read` tool) failed to load Salesforce Help / Business Manager articles — e.g. *Import an Inventory List*, *Inventory List Object Import and Export* — reporting that they "failed to load from the local doc cache."

**Root cause:** The Salesforce Help corpus is **online-only** — its ~1000 `.md` files are served from GitHub Pages (`sourceUrl`) and are deliberately *not* bundled in the npm package (only `data/help/index.json` ships; the content lives in `docs/help-content.tar.gz` for the docs site). But every help index entry carries a `filePath` (kept "for parity/debug"), and `loadCorpus` registered any entry with a `filePath` as bundled-on-disk. So `readEntryContent` took the disk branch and `fs.readFileSync` hit a nonexistent file, with no fallback to the working online source.

This is distinct from the earlier guides-corpus 404 fix (#572) — different corpus, different mechanism (read routing, not URL generation).

**Fix:**
- `loadCorpus` now existence-gates the bundled-file registration: an entry is only treated as on-disk if its file actually exists. Online-only corpora (help) correctly route to their `sourceUrl`; genuinely bundled corpora (job-steps, xsd) are unaffected.
- Defense in depth: if a registered bundled read ever errors, fall through to the online source instead of throwing.
- Adds a help-corpus regression test asserting reads fetch from `sourceUrl` despite the `filePath`.

## Manual testing

- Before: reading `help-admin/b2c_importing_an_inventory_list` threw / returned the offline metadata stub.
- After (verified against the real index + live GitHub Pages): the same read returns the full article content (1630 chars) fetched from `sourceUrl`; a genuinely-bundled `job-step` entry still reads from disk.