### PR TITLE
docs(vscode): document Marketplace + Open VSX install and official status

### DIFF
--- a/.changeset/vscode-open-vsx-install.md
+++ b/.changeset/vscode-open-vsx-install.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-dx-docs': patch
+---
+
+Update the VS Code extension docs for its Marketplace and Open VSX launch: lead with installing directly from the editor's Extensions view (search for "Salesforce B2C Commerce"), document Open VSX availability for Cursor, VSCodium, Windsurf, and other VS Code–compatible editors, and clarify that this is the official Salesforce B2C Commerce extension.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -77,11 +77,7 @@ See the [MCP Server Installation Guide](/mcp/installation) for full setup steps 
 
 ## Quick VS Code Extension Install
 
-The Salesforce B2C Commerce VS Code Extension brings sandbox management, code sync, content libraries, the SCAPI explorer, and a server-side debugger into VS Code. Install [Salesforce B2C Commerce](https://marketplace.visualstudio.com/items?itemName=Salesforce.b2c-vs-extension) from the Visual Studio Marketplace or run:
-
-```bash
-code --install-extension Salesforce.b2c-vs-extension
-```
+The Salesforce B2C Commerce VS Code Extension brings sandbox management, code sync, content libraries, the SCAPI explorer, and a server-side debugger into VS Code. Open the Extensions view in your editor and search for **Salesforce B2C Commerce** — VS Code installs from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Salesforce.b2c-vs-extension), while Cursor, VSCodium, Windsurf, and other VS Code–compatible editors install from the [Open VSX Registry](https://open-vsx.org/extension/salesforce/b2c-vs-extension).
 
 See the [VS Code Extension](/vscode-extension/) section for the full overview, [installation](/vscode-extension/installation), and [configuration](/vscode-extension/configuration).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ features:
       width: 48
       height: 48
     title: VS Code Extension
-    details: Activity-bar tools for sandbox lifecycle, cartridge code sync, WebDAV, content libraries, SCAPI, and a B2C script debugger — all driven by the same dw.json the CLI uses.
+    details: The official Salesforce B2C Commerce extension for VS Code. Activity-bar tools for sandbox lifecycle, cartridge code sync, WebDAV, content libraries, SCAPI, and a B2C script debugger. Shares configuration with the CLI, so it fits right into the rest of your toolkit.
     link: /vscode-extension/
     linkText: VS Code Extension
 ---
@@ -144,10 +144,6 @@ npx @salesforce/b2c-cli setup skills
 
 ## Install the VS Code Extension
 
-Install [Salesforce B2C Commerce](https://marketplace.visualstudio.com/items?itemName=Salesforce.b2c-vs-extension) from the Visual Studio Marketplace or run:
-
-```bash
-code --install-extension Salesforce.b2c-vs-extension
-```
+Open the Extensions view in your editor and search for **Salesforce B2C Commerce** — VS Code installs from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Salesforce.b2c-vs-extension), while Cursor, VSCodium, Windsurf, and other VS Code–compatible editors install from the [Open VSX Registry](https://open-vsx.org/extension/salesforce/b2c-vs-extension).
 
 Detailed setup: [Installation](/vscode-extension/installation) · [Configuration](/vscode-extension/configuration)

--- a/docs/vscode-extension/index.md
+++ b/docs/vscode-extension/index.md
@@ -1,10 +1,10 @@
 ---
-description: Salesforce B2C Commerce VS Code Extension — sandbox management, cartridge code sync, WebDAV browser, content libraries, SCAPI API browser, script debugger, and project scaffolding.
+description: The official Salesforce B2C Commerce VS Code Extension — sandbox management, cartridge code sync, WebDAV browser, content libraries, SCAPI API browser, script debugger, and project scaffolding.
 ---
 
 # Salesforce B2C Commerce VS Code Extension
 
-Manage your B2C Commerce sandboxes, sync cartridges, browse content libraries and SCAPI schemas, debug server-side scripts, and scaffold new projects — all from inside VS Code. If your project already works with the [B2C CLI](../guide/), the extension picks up the same connection automatically.
+The **official Salesforce B2C Commerce extension for VS Code**, published by Salesforce. Manage your B2C Commerce sandboxes, sync cartridges, browse content libraries and SCAPI schemas, debug server-side scripts, and scaffold new projects — all from inside VS Code. If your project already works with the [B2C CLI](../guide/), the extension picks up the same connection automatically.
 
 [![Salesforce B2C Commerce activity bar](./images/overview.png)](./images/overview.png)
 

--- a/docs/vscode-extension/installation.md
+++ b/docs/vscode-extension/installation.md
@@ -1,5 +1,5 @@
 ---
-description: Install the Salesforce B2C Commerce VS Code Extension from the Visual Studio Marketplace or a .vsix release artifact.
+description: Install the official Salesforce B2C Commerce VS Code Extension from the Visual Studio Marketplace, the Open VSX Registry, or a .vsix release artifact.
 ---
 
 <script setup>
@@ -8,19 +8,44 @@ import {data as release} from './release.data.ts';
 
 # Installation
 
-## Install from the Visual Studio Marketplace
+The **official Salesforce B2C Commerce extension**, published by Salesforce, is available on the Visual Studio Marketplace and the Open VSX Registry.
 
-Install [Salesforce B2C Commerce](https://marketplace.visualstudio.com/items?itemName=Salesforce.b2c-vs-extension) from the Visual Studio Marketplace, search for **Salesforce B2C Commerce** in the VS Code Extensions view, or run:
+## Install from your editor
+
+Most of the time you'll install directly from your editor's Extensions view:
+
+1. Open the Extensions view (**Cmd+Shift+X** / **Ctrl+Shift+X**).
+2. Search for **Salesforce B2C Commerce**.
+3. Pick the extension published by **Salesforce** and click **Install**.
+4. Reload the window when prompted.
+
+The extension's developer, operations, API, and sandbox views appear in the activity bar.
+
+Your editor pulls from the right registry automatically:
+
+- **VS Code** installs from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Salesforce.b2c-vs-extension).
+- **Cursor**, **VSCodium**, **Windsurf**, **Eclipse Theia**, and other VS Code–compatible editors install from the [Open VSX Registry](https://open-vsx.org/extension/salesforce/b2c-vs-extension).
+
+Each release is published to both registries at the same time, so they stay in sync.
+
+## Install from the command line
+
+If you prefer the terminal, use your editor's `--install-extension` command:
 
 ```bash
+# VS Code (Visual Studio Marketplace)
 code --install-extension Salesforce.b2c-vs-extension
-```
 
-Reload the window when prompted. The extension's developer, operations, API, and sandbox views appear in the activity bar.
+# Cursor (Open VSX)
+cursor --install-extension salesforce.b2c-vs-extension
+
+# VSCodium / Windsurf / other codium-based editors (Open VSX)
+codium --install-extension salesforce.b2c-vs-extension
+```
 
 ## Install from a VSIX
 
-GitHub Releases also provides a pre-built `.vsix` for offline installation and compatible editors that cannot install directly from the Visual Studio Marketplace.
+GitHub Releases also provides a pre-built `.vsix` for offline or air-gapped installs where neither registry is reachable.
 
 ### Get the latest build
 
@@ -71,7 +96,7 @@ cursor --install-extension b2c-vs-extension-X.Y.Z.vsix
 
 A few things to have ready:
 
-- **VS Code 1.105 or newer** (Cursor and VSCodium work too when installed from the `.vsix`).
+- **VS Code 1.105 or newer** (Cursor, VSCodium, Windsurf, and other VS Code–compatible editors work too — they install from [Open VSX](#install-from-your-editor)).
 - **Access to a B2C Commerce instance** for remote workflows.
 - **The B2C CLI is optional.** Install it when you want to run the same operations from the terminal or CI. See the [CLI Installation guide](../guide/installation) for installation options.
 


### PR DESCRIPTION
## Summary

The VS Code extension is now live on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=salesforce.b2c-vs-extension) and the [Open VSX Registry](https://open-vsx.org/extension/salesforce/b2c-vs-extension). This updates the docs site to match:

- **Lead with in-editor install.** The installation page now opens with installing directly from the editor's Extensions view (search for **Salesforce B2C Commerce**), with the CLI `--install-extension` commands broken out into their own secondary section and VSIX kept as the offline/air-gapped fallback.
- **Document Open VSX.** Cursor, VSCodium, Windsurf, and Eclipse Theia install from Open VSX rather than sideloading a `.vsix`; the docs now say so and note both registries publish each release in sync.
- **Official status for SEO.** The overview, installation, and homepage feature card now describe this as the official Salesforce B2C Commerce extension, published by Salesforce.
- Softened the homepage feature card closer (dropped the `dw.json` specifics in favor of toolkit-compatibility prose).

Doc-only change — includes a changeset targeting `@salesforce/b2c-dx-docs`.

## Testing

- `pnpm run docs:dev` and confirm the VS Code Extension → Installation page renders the new "Install from your editor" / "Install from the command line" sections and that the homepage feature card + overview intro read correctly.