### PR TITLE
docs(b2c-isml): document sf-toolkit="off" on isinclude

### DIFF
--- a/.changeset/isml-sf-toolkit-off.md
+++ b/.changeset/isml-sf-toolkit-off.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Document the `sf-toolkit="off"` attribute on `<isinclude>` in the b2c-isml skill, explaining how to disable Storefront Toolkit markers and when to use it.

--- a/skills/b2c/skills/b2c-isml/references/TAGS.md
+++ b/skills/b2c/skills/b2c-isml/references/TAGS.md
@@ -147,18 +147,23 @@ Include another template:
 
 **Max include depth:** 20 for local, 10 for URL includes.
 
-**Disabling Storefront Toolkit markers (`sf-toolkit="off"`):**
+**Disabling Storefront Toolkit markers (`sf-toolkit`):**
 
-When the Storefront Toolkit is active (in a Business Manager storefront preview),
-the platform injects extra HTML markers around each `<isinclude>` for its
-overlay/cache-info tooling. Add `sf-toolkit="off"` to suppress those markers for
-a single include when the injected markup would cause problems — e.g. non-HTML
-responses (JSON/XML/CSV), markup-sensitive contexts (`<head>`, `<script>`,
-`<table>`, attribute values), or snippets composed into a larger string.
+When the Storefront Toolkit is enabled, the content of every `<isinclude>` is
+wrapped in a `dwMarker` comment tag (`sf-toolkit="on"` is the default). This
+marker can push Internet Explorer into Quirks mode. Set `sf-toolkit="off"` to
+suppress the `dwMarker` tag for that include:
 
-The attribute only has an effect when the toolkit is active (safe to leave in
-production) and applies to that one tag only — it does not disable the toolkit
-globally or in nested includes.
+```html
+<isinclude template="test/customassets" sf-toolkit="off"/>
+```
+
+- Only supported on **local (template) includes** — remote (`url=`) includes do
+  not support the attribute.
+- Not applied recursively — the marker is suppressed for that tag only, not for
+  any child `<isinclude>` inside the included template.
+
+See the [isinclude Element docs](https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/b2c-isinclude.html).
 
 ### isdecorate / isreplace
 

--- a/skills/b2c/skills/b2c-isml/references/TAGS.md
+++ b/skills/b2c/skills/b2c-isml/references/TAGS.md
@@ -141,11 +141,24 @@ Include another template:
 <!-- URL include (controller output) -->
 <isinclude url="${URLUtils.url('Header-Include')}"/>
 
-<!-- Include with specific file -->
+<!-- Disable Storefront Toolkit markers for this include -->
 <isinclude sf-toolkit="off" template="checkout/billing"/>
 ```
 
 **Max include depth:** 20 for local, 10 for URL includes.
+
+**Disabling Storefront Toolkit markers (`sf-toolkit="off"`):**
+
+When the Storefront Toolkit is active (in a Business Manager storefront preview),
+the platform injects extra HTML markers around each `<isinclude>` for its
+overlay/cache-info tooling. Add `sf-toolkit="off"` to suppress those markers for
+a single include when the injected markup would cause problems — e.g. non-HTML
+responses (JSON/XML/CSV), markup-sensitive contexts (`<head>`, `<script>`,
+`<table>`, attribute values), or snippets composed into a larger string.
+
+The attribute only has an effect when the toolkit is active (safe to leave in
+production) and applies to that one tag only — it does not disable the toolkit
+globally or in nested includes.
 
 ### isdecorate / isreplace
 


### PR DESCRIPTION
## Summary

Expands the `isinclude` entry in the b2c-isml skill's `TAGS.md` reference to document the `sf-toolkit="off"` attribute — how it disables the Storefront Toolkit's injected markers on a single include and when to use it (non-HTML responses, markup-sensitive contexts, snippets composed into larger strings).

Includes a changeset targeting `@salesforce/b2c-agent-plugins`.

## Testing

No manual testing required — documentation/skill content only.