### PR TITLE
docs: add figma-to-sfnext-pagedesigner plugin to agent-skills guide

### DIFF
--- a/.changeset/figma-to-sfnext-pagedesigner-docs.md
+++ b/.changeset/figma-to-sfnext-pagedesigner-docs.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-dx-docs': patch
+---
+
+Document the figma-to-sfnext-pagedesigner plugin in the Agent Skills guide

--- a/docs/guide/agent-skills.md
+++ b/docs/guide/agent-skills.md
@@ -25,6 +25,8 @@ claude plugin install b2c-dx-mcp
 claude plugin install storefront-next
 # storefront-next-figma adds Figma design-kit workflows (requires the Figma MCP server)
 claude plugin install storefront-next-figma
+# figma-to-sfnext-pagedesigner converts Figma frames to Page Designer components (requires the Figma MCP server)
+claude plugin install figma-to-sfnext-pagedesigner
 ```
 
 ```bash [Codex]
@@ -59,6 +61,8 @@ copilot plugin install b2c@b2c-developer-tooling
 # Storefront Next (only for Storefront Next projects)
 copilot plugin install storefront-next@b2c-developer-tooling
 copilot plugin install storefront-next-figma@b2c-developer-tooling
+# figma-to-sfnext-pagedesigner converts Figma frames to Page Designer components (requires the Figma MCP server)
+copilot plugin install figma-to-sfnext-pagedesigner@b2c-developer-tooling
 ```
 
 ```bash [Agentforce Vibes]
@@ -100,6 +104,10 @@ npx @salesforce/b2c-cli setup skills
       <td>Figma design-kit workflows for Storefront Next verticals — duplicate the kit, sync brand variables from <code>brand.css</code>, edit components, and publish Code Connect. Requires the <a href="https://help.figma.com/hc/en-us/articles/32132100833559-Guide-to-the-Figma-MCP-server">Figma MCP server</a></td>
     </tr>
     <tr>
+      <td><a href="https://github.com/SalesforceCommerceCloud/b2c-developer-tooling/tree/main/skills/figma-to-sfnext-pagedesigner/skills"><code>figma-to-sfnext-pagedesigner</code></a></td>
+      <td>Convert a Figma frame into live Storefront Next Page Designer components — React components with decorator metadata, brand-token reconciliation, and SCAPI product loaders. Requires the <a href="https://help.figma.com/hc/en-us/articles/32132100833559-Guide-to-the-Figma-MCP-server">Figma MCP server</a></td>
+    </tr>
+    <tr>
       <td><a href="/mcp/"><code>b2c-dx-mcp</code></a></td>
       <td>Automatic project type detection and B2C Commerce workflows for your AI assistant. See <a href="/mcp/installation">MCP Installation</a></td>
     </tr>
@@ -128,6 +136,8 @@ claude plugin install b2c-dx-mcp
 claude plugin install storefront-next
 # storefront-next-figma adds Figma design-kit workflows (requires the Figma MCP server)
 claude plugin install storefront-next-figma
+# figma-to-sfnext-pagedesigner converts Figma frames to Page Designer components (requires the Figma MCP server)
+claude plugin install figma-to-sfnext-pagedesigner
 ```
 
 ```bash [Project Scope]
@@ -140,6 +150,8 @@ claude plugin install b2c-dx-mcp --scope project
 claude plugin install storefront-next --scope project
 # storefront-next-figma adds Figma design-kit workflows (requires the Figma MCP server)
 claude plugin install storefront-next-figma --scope project
+# figma-to-sfnext-pagedesigner converts Figma frames to Page Designer components (requires the Figma MCP server)
+claude plugin install figma-to-sfnext-pagedesigner --scope project
 ```
 
 :::
@@ -177,6 +189,8 @@ codex plugin marketplace remove b2c-developer-tooling
 > **Note:** The `b2c-dx-mcp` plugin is available only for Claude Code. For other clients, install the MCP server directly — see [MCP Installation](/mcp/installation).
 
 > **Note:** The `storefront-next-figma` plugin requires the [Figma MCP server](https://help.figma.com/hc/en-us/articles/32132100833559-Guide-to-the-Figma-MCP-server) to be configured in your AI tool — its skills drive the Figma design kit (duplicating the kit, syncing brand variables, and publishing Code Connect) through Figma's MCP tools. Install it alongside `storefront-next` when you also manage the design system in Figma.
+
+> **Note:** The `figma-to-sfnext-pagedesigner` plugin also requires the [Figma MCP server](https://help.figma.com/hc/en-us/articles/32132100833559-Guide-to-the-Figma-MCP-server). It reads your Figma frame through Figma's MCP tools, then generates Page Designer components, decorator metadata, and SCAPI loaders directly in your Storefront Next project. Install it alongside `storefront-next` when you want to drive homepage builds from Figma.
 
 ## Cursor
 
@@ -235,6 +249,8 @@ claude plugin install b2c-dx-mcp
 claude plugin install storefront-next
 # storefront-next-figma adds Figma design-kit workflows (requires the Figma MCP server)
 claude plugin install storefront-next-figma
+# figma-to-sfnext-pagedesigner converts Figma frames to Page Designer components (requires the Figma MCP server)
+claude plugin install figma-to-sfnext-pagedesigner
 ```
 
 ## Copilot
@@ -266,6 +282,8 @@ copilot plugin install b2c@b2c-developer-tooling
 # Storefront Next (only for Storefront Next projects)
 copilot plugin install storefront-next@b2c-developer-tooling
 copilot plugin install storefront-next-figma@b2c-developer-tooling
+# figma-to-sfnext-pagedesigner converts Figma frames to Page Designer components (requires the Figma MCP server)
+copilot plugin install figma-to-sfnext-pagedesigner@b2c-developer-tooling
 ```
 
 ## B2C CLI
@@ -283,6 +301,7 @@ b2c setup skills b2c --list
 b2c setup skills b2c-cli --list
 b2c setup skills storefront-next --list
 b2c setup skills storefront-next-figma --list
+b2c setup skills figma-to-sfnext-pagedesigner --list
 ```
 
 Install to specific IDEs:
@@ -382,3 +401,4 @@ Once installed, ask your AI assistant:
 - "Add a new route with a loader to my Storefront Next app"
 - "Deploy my Storefront Next storefront to Managed Runtime"
 - "Add Page Designer support to my storefront component"
+- "Convert this Figma frame into Page Designer components for my Storefront Next project"


### PR DESCRIPTION
## Summary

- Adds `figma-to-sfnext-pagedesigner` to the Available Plugins table in the Agent Skills guide
- Adds install commands for the plugin in all IDE sections (Claude Code, Copilot CLI, Cursor, B2C CLI)
- Adds a note about the Figma MCP server requirement (alongside the existing `storefront-next-figma` note)
- Adds a usage example prompt

This is a docs-only follow-up to #589 which merged the plugin itself.