### PR TITLE
Fix VS Code workspace discovery and code activation

### DIFF
--- a/.changeset/detect-nested-vscode-config.md
+++ b/.changeset/detect-nested-vscode-config.md
@@ -1,0 +1,6 @@
+---
+'b2c-vs-extension': patch
+'@salesforce/b2c-dx-docs': patch
+---
+
+Detect nested `dw.json` project roots in VS Code workspaces and allow nested folders to be pinned from Explorer, so parent-folder and multi-root layouts connect to the intended project.

--- a/.changeset/idempotent-code-version-activation.md
+++ b/.changeset/idempotent-code-version-activation.md
@@ -1,0 +1,9 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+'@salesforce/b2c-cli': patch
+'b2c-vs-extension': patch
+'@salesforce/b2c-dx-docs': patch
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Treat activation of an already-active code version as success, preserve useful OCAPI fault details, and avoid redundant activation choices in VS Code.

--- a/docs/cli/code.md
+++ b/docs/cli/code.md
@@ -156,6 +156,8 @@ export SFCC_PASSWORD=my-access-key
 b2c code deploy
 ```
 
+`--activate` is idempotent: if the target version is already active, deployment succeeds and no activation change is made. Use `--reload` when you need to force the instance to reload code that was uploaded to the active version.
+
 ### Cartridge Discovery
 
 Cartridges are discovered by searching for `.project` files (Eclipse project markers commonly used in SFCC development). The directory containing the `.project` file is considered a cartridge.
@@ -278,7 +280,7 @@ b2c code activate --code-version v2
 
 ### Reload vs Activate
 
-- **Activate**: Sets the specified code version as the active version
+- **Activate**: Sets the specified code version as active. If it is already active, the command succeeds without making a change.
 - **Reload**: Forces the instance to reload the code by temporarily activating a different version, then re-activating the target version
 
 Use `--reload` when you've made changes via WebDAV and need the instance to pick up the changes without deploying again.

--- a/docs/vscode-extension/configuration.md
+++ b/docs/vscode-extension/configuration.md
@@ -4,23 +4,26 @@ description: Connect the Salesforce B2C Commerce VS Code Extension to a B2C Comm
 
 # Configuration
 
-The extension reuses the [B2C CLI](../guide/configuration)'s configuration system, so anything that works with `b2c` works here — `dw.json`, `SFCC_*` environment variables, and active-instance selection.
+The extension shares the [B2C CLI](../guide/configuration)'s configuration system. This page focuses on the extension's connection requirements, project selection, and settings.
 
 This page covers:
 
 - [Connecting to a B2C Instance](#connecting-to-a-b2c-instance) — credentials per feature.
+- [How the Extension Chooses a Project](#how-the-extension-chooses-a-project) — parent folders and multi-root workspaces.
 - [Switching the Active Instance](#switching-the-active-instance) — single-workspace, multi-instance.
 - [Settings Reference](#settings-reference) — the `b2c-dx.*` toggles and verbosity controls.
 
 ## Connecting to a B2C Instance
 
-The extension needs different credentials depending on which feature you use. **A `dw.json` at your workspace root is the recommended setup** — populate the fields each feature needs, and the extension picks them up automatically.
+The extension uses the same configuration resolver as the B2C CLI. Environment variables, a project `.env`, `dw.json`, supported settings under `package.json#b2c`, shared CLI credential storage, and configuration sources added by installed B2C CLI plugins are all honored. The [CLI Configuration guide](../guide/configuration) is the reference for available fields and precedence.
+
+**A `dw.json` at your project root is the conventional setup** and is the easiest way for the extension to locate a B2C project nested inside a larger workspace. It is not required when another configuration source provides what you need.
 
 ### Per-feature requirements
 
-A summary by feature:
+A summary by feature, regardless of which configuration source provides the values:
 
-| Feature                    | Required `dw.json` fields                                                                                                   |
+| Feature                    | Required configuration                                                                                                      |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | **Sandbox Realm Explorer** | OAuth (browser login by default; `client-id` + `client-secret` for headless). `Sandbox API User` role with a tenant filter. |
 | **WebDAV Browser**         | `hostname`, `username`, `password` (WebDAV access key). OAuth (`client-id` + `client-secret`) also accepted.                |
@@ -55,9 +58,23 @@ A summary by feature:
 }
 ```
 
-You can also set any of these via `SFCC_*` environment variables (`SFCC_SERVER`, `SFCC_USERNAME`, `SFCC_CLIENT_ID`, `SFCC_TENANT_ID`, etc.). See the [CLI Configuration guide](../guide/configuration) for the complete list and precedence rules, and the [Authentication Setup guide](../guide/authentication) for OAuth scope requirements and Account Manager API client setup.
+See the [Authentication Setup guide](../guide/authentication) for OAuth scope requirements and Account Manager API client setup.
 
 <!-- TODO(screenshot): replace ./images/settings.svg with ./images/settings.png — Settings UI filtered to b2c-dx -->
+
+## How the Extension Chooses a Project
+
+You do not need to open the exact project directory for the extension to find it. These common layouts work automatically:
+
+- **Project folder open:** configuration is resolved from that folder using all supported sources.
+- **Parent folder open:** the extension searches its subfolders. For example, a workspace containing `react/` and `sfra/dw.json` uses `sfra/` as the B2C project.
+- **Multi-root workspace:** folders containing `dw.json` are checked in the order shown in Explorer. If none contains one, root-level `.env` and `package.json#b2c` configuration are also considered.
+
+If one workspace folder contains more than one B2C project, the project closest to that workspace folder is selected. Open the intended project directly when sibling projects are equally close.
+
+`dw.json` is the conventional nested-project discovery signal. When a project uses only environment variables, `.env`, `package.json`, or a plugin-provided source, open that project as a workspace folder so the extension has the correct project root.
+
+To keep a particular project directory selected, right-click that folder in Explorer and choose **B2C DX > Use as B2C Commerce Root**. This works for nested folders such as `sfra/` as well as top-level folders in a multi-root workspace. Run **B2C DX: Reset B2C Commerce Root to Auto-Detect** from the Command Palette to return to automatic selection.
 
 ## Switching the Active Instance
 

--- a/packages/b2c-cli/src/commands/code/activate.ts
+++ b/packages/b2c-cli/src/commands/code/activate.ts
@@ -93,10 +93,22 @@ export default class CodeActivate extends InstanceCommand<typeof CodeActivate> {
       );
 
       try {
-        await activateCodeVersion(this.instance, codeVersion);
-        this.log(
-          t('commands.code.activate.activated', 'Code version {{codeVersion}} activated successfully', {codeVersion}),
-        );
+        const activation = await activateCodeVersion(this.instance, codeVersion);
+        if (activation.alreadyActive) {
+          this.log(
+            t(
+              'commands.code.activate.alreadyActive',
+              'Code version {{codeVersion}} is already active; no changes made',
+              {
+                codeVersion,
+              },
+            ),
+          );
+        } else {
+          this.log(
+            t('commands.code.activate.activated', 'Code version {{codeVersion}} activated successfully', {codeVersion}),
+          );
+        }
       } catch (error) {
         if (error instanceof Error) {
           this.error(

--- a/packages/b2c-cli/src/commands/code/deploy.ts
+++ b/packages/b2c-cli/src/commands/code/deploy.ts
@@ -200,20 +200,38 @@ export default class CodeDeploy extends CartridgeCommand<typeof CodeDeploy> {
       let reloaded = false;
       try {
         if (this.flags.activate) {
-          await this.operations.activateCodeVersion(this.instance, version);
+          const activation = await this.operations.activateCodeVersion(this.instance, version);
           activated = true;
+          if (activation?.alreadyActive) {
+            this.log(
+              t(
+                'commands.code.deploy.alreadyActive',
+                'Code version "{{version}}" is already active; no activation was needed.',
+                {version},
+              ),
+            );
+          }
         } else if (this.flags.reload) {
           await this.operations.reloadCodeVersion(this.instance, version);
           activated = true;
           reloaded = true;
         }
       } catch (error) {
-        const clientId = this.resolvedConfig.values.clientId ?? 'unknown';
+        const message = error instanceof Error ? error.message : String(error);
+        if (this.flags.reload) {
+          this.error(
+            t(
+              'commands.code.deploy.reloadFailed',
+              'Cartridges were deployed, but code version "{{version}}" could not be reloaded: {{message}}',
+              {version, message},
+            ),
+          );
+        }
         this.error(
           t(
             'commands.code.deploy.activateFailed',
-            'Failed to activate code version "{{version}}": {{message}}\n\nEnsure your OCAPI client ({{clientId}}) is configured with Data API permissions.\nSee: https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/authentication.html#ocapi-configuration',
-            {version, message: error instanceof Error ? error.message : String(error), clientId},
+            'Cartridges were deployed, but code version "{{version}}" could not be activated: {{message}}',
+            {version, message},
           ),
         );
       }

--- a/packages/b2c-cli/src/i18n/locales/en.ts
+++ b/packages/b2c-cli/src/i18n/locales/en.ts
@@ -91,6 +91,7 @@ export const en = {
         description: 'Activate or reload a code version',
         activating: 'Activating code version {{codeVersion}} on {{hostname}}...',
         activated: 'Code version {{codeVersion}} activated successfully',
+        alreadyActive: 'Code version {{codeVersion}} is already active; no changes made',
         reloading: 'Reloading code version{{version}} on {{hostname}}...',
         reloaded: 'Code version{{version}} reloaded successfully',
         failed: 'Failed to activate code version: {{message}}',

--- a/packages/b2c-cli/test/commands/code/activate.test.ts
+++ b/packages/b2c-cli/test/commands/code/activate.test.ts
@@ -46,6 +46,33 @@ describe('code activate', () => {
     expect(options?.body).to.deep.equal({active: true});
   });
 
+  it('reports an already-active version without failing', async () => {
+    const command: any = await createCommand({}, {codeVersion: 'v1'});
+
+    sinon.stub(command, 'requireOAuthCredentials').returns(void 0);
+    const logStub = sinon.stub(command, 'log').returns(void 0);
+    sinon.stub(command, 'resolvedConfig').get(() => ({values: {hostname: 'example.com', codeVersion: undefined}}));
+    sinon.stub(command, 'instance').get(() => ({
+      ocapi: {
+        PATCH: sinon.stub().resolves({
+          data: undefined,
+          error: {
+            fault: {
+              arguments: {codeVersionId: 'v1'},
+              type: 'CodeVersionModificationException',
+              message: "The code version 'v1' is active and can't be changed.",
+            },
+          },
+          response: {status: 400, statusText: 'Bad Request'},
+        }),
+      },
+    }));
+
+    await command.run();
+
+    expect(logStub.calledWithMatch(/already active/i)).to.be.true;
+  });
+
   it('errors when no code version is provided for activate mode', async () => {
     const command: any = await createCommand({}, {});
 

--- a/packages/b2c-cli/test/commands/code/deploy.test.ts
+++ b/packages/b2c-cli/test/commands/code/deploy.test.ts
@@ -116,6 +116,24 @@ describe('code deploy', () => {
     expect(result).to.deep.include({codeVersion: 'v1', activated: true, reloaded: false});
   });
 
+  it('reports an already-active version as a successful no-op', async () => {
+    const command: any = await createCommand({activate: true}, {cartridgePath: '.'});
+    stubCommon(command);
+
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    sinon.stub(command, 'runAfterHooks').resolves(void 0);
+    sinon.stub(command, 'findCartridgesWithProviders').resolves([{name: 'c1', src: '/tmp/c1', dest: 'c1'}]);
+
+    const uploadStub = sinon.stub().resolves(void 0);
+    const activateStub = sinon.stub().resolves({alreadyActive: true});
+    command.operations = {...command.operations, uploadCartridges: uploadStub, activateCodeVersion: activateStub};
+
+    const result = await command.run();
+
+    expect(result).to.deep.include({codeVersion: 'v1', activated: true, reloaded: false});
+    expect(command.log.calledWithMatch(/already active/i)).to.be.true;
+  });
+
   it('errors when activate fails', async () => {
     const command: any = await createCommand({activate: true}, {cartridgePath: '.'});
     stubCommon(command);
@@ -137,7 +155,8 @@ describe('code deploy', () => {
     expect(errorStub.called).to.be.true;
     const errorMessage = errorStub.firstCall.args[0];
     expect(errorMessage).to.include('activate failed');
-    expect(errorMessage).to.include('OCAPI');
+    expect(errorMessage).to.include('Cartridges were deployed');
+    expect(errorMessage).not.to.include('permissions');
   });
 
   it('errors when reload fails', async () => {
@@ -161,7 +180,7 @@ describe('code deploy', () => {
     expect(errorStub.called).to.be.true;
     const errorMessage = errorStub.firstCall.args[0];
     expect(errorMessage).to.include('reload failed');
-    expect(errorMessage).to.include('OCAPI');
+    expect(errorMessage).to.include('Cartridges were deployed');
   });
 
   it('errors when no code version and no OAuth credentials', async () => {

--- a/packages/b2c-tooling-sdk/src/index.ts
+++ b/packages/b2c-tooling-sdk/src/index.ts
@@ -225,6 +225,7 @@ export type {
   CartridgeMapping,
   FindCartridgesOptions,
   CodeVersion,
+  CodeVersionActivationResult,
   CodeVersionResult,
   DeployOptions,
   DeployResult,

--- a/packages/b2c-tooling-sdk/src/operations/code/index.ts
+++ b/packages/b2c-tooling-sdk/src/operations/code/index.ts
@@ -79,7 +79,7 @@ export {
   deleteCodeVersion,
   createCodeVersion,
 } from './versions.js';
-export type {CodeVersion, CodeVersionResult} from './versions.js';
+export type {CodeVersion, CodeVersionActivationResult, CodeVersionResult} from './versions.js';
 
 // Deployment
 export {findAndDeployCartridges, uploadCartridges, deleteCartridges} from './deploy.js';

--- a/packages/b2c-tooling-sdk/src/operations/code/versions.ts
+++ b/packages/b2c-tooling-sdk/src/operations/code/versions.ts
@@ -4,7 +4,7 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 import type {B2CInstance} from '../../instance/index.js';
-import {type OcapiComponents} from '../../clients/index.js';
+import {getApiErrorMessage, type OcapiComponents} from '../../clients/index.js';
 import {getLogger} from '../../logging/logger.js';
 
 /** Code version type from OCAPI */
@@ -12,6 +12,29 @@ export type CodeVersion = OcapiComponents['schemas']['code_version'];
 
 /** Result of listing code versions */
 export type CodeVersionResult = OcapiComponents['schemas']['code_version_result'];
+
+/** Result of requesting code-version activation. */
+export interface CodeVersionActivationResult {
+  /** Whether the target was already active and no server-side change was needed. */
+  alreadyActive: boolean;
+}
+
+function isAlreadyActiveFault(error: unknown, status: number, codeVersionId: string): boolean {
+  if (status !== 400 || !error || typeof error !== 'object') return false;
+
+  const fault = (error as {fault?: unknown}).fault;
+  if (!fault || typeof fault !== 'object') return false;
+
+  const typedFault = fault as {
+    arguments?: {codeVersionId?: unknown};
+    type?: unknown;
+  };
+  const faultCodeVersionId = typedFault.arguments?.codeVersionId;
+  return (
+    typedFault.type === 'CodeVersionModificationException' &&
+    (faultCodeVersionId === undefined || faultCodeVersionId === codeVersionId)
+  );
+}
 
 /**
  * Lists all code versions on an instance.
@@ -62,7 +85,9 @@ export async function getActiveCodeVersion(instance: B2CInstance): Promise<CodeV
  *
  * @param instance - B2C instance
  * @param codeVersionId - Code version ID to activate
- * @returns Promise that resolves when the code version is activated
+ * Activating the current active version is treated as an idempotent success.
+ *
+ * @returns Whether the code version was already active
  * @throws Error if activation fails
  *
  * @example
@@ -71,20 +96,30 @@ export async function getActiveCodeVersion(instance: B2CInstance): Promise<CodeV
  * console.log('Code version v2 is now active');
  * ```
  */
-export async function activateCodeVersion(instance: B2CInstance, codeVersionId: string): Promise<void> {
+export async function activateCodeVersion(
+  instance: B2CInstance,
+  codeVersionId: string,
+): Promise<CodeVersionActivationResult> {
   const logger = getLogger();
   logger.debug({codeVersionId}, `Activating code version ${codeVersionId}`);
 
-  const {error} = await instance.ocapi.PATCH('/code_versions/{code_version_id}', {
+  const {error, response} = await instance.ocapi.PATCH('/code_versions/{code_version_id}', {
     params: {path: {code_version_id: codeVersionId}},
     body: {active: true},
   });
 
   if (error) {
-    throw new Error('Failed to activate code version', {cause: error});
+    if (isAlreadyActiveFault(error, response.status, codeVersionId)) {
+      logger.debug({codeVersionId}, `Code version ${codeVersionId} is already active`);
+      return {alreadyActive: true};
+    }
+    throw new Error(`Could not activate code version "${codeVersionId}": ${getApiErrorMessage(error, response)}`, {
+      cause: error,
+    });
   }
 
   logger.debug({codeVersionId}, `Code version ${codeVersionId} activated`);
+  return {alreadyActive: false};
 }
 
 /**

--- a/packages/b2c-tooling-sdk/test/operations/code/versions.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/code/versions.test.ts
@@ -163,11 +163,33 @@ describe('operations/code/versions', () => {
         }),
       );
 
-      await activateCodeVersion(mockInstance, 'v2');
-      // Success - no error thrown
+      const result = await activateCodeVersion(mockInstance, 'v2');
+
+      expect(result).to.deep.equal({alreadyActive: false});
     });
 
-    it('should throw error when activation fails', async () => {
+    it('should treat activating the active version as an idempotent success', async () => {
+      server.use(
+        http.patch(`${BASE_URL}/code_versions/v2`, () => {
+          return HttpResponse.json(
+            {
+              fault: {
+                arguments: {codeVersionId: 'v2'},
+                type: 'CodeVersionModificationException',
+                message: "The code version 'v2' is active and can't be changed.",
+              },
+            },
+            {status: 400},
+          );
+        }),
+      );
+
+      const result = await activateCodeVersion(mockInstance, 'v2');
+
+      expect(result).to.deep.equal({alreadyActive: true});
+    });
+
+    it('should throw an informative error when activation fails', async () => {
       server.use(
         http.patch(`${BASE_URL}/code_versions/nonexistent`, () => {
           return HttpResponse.json({fault: {message: 'Version not found'}}, {status: 404});
@@ -178,7 +200,31 @@ describe('operations/code/versions', () => {
         await activateCodeVersion(mockInstance, 'nonexistent');
         expect.fail('Should have thrown error');
       } catch (error: any) {
-        expect(error.message).to.include('Failed to activate code version');
+        expect(error.message).to.equal('Could not activate code version "nonexistent": Version not found');
+      }
+    });
+
+    it('should not swallow a modification fault for a different code version', async () => {
+      server.use(
+        http.patch(`${BASE_URL}/code_versions/v2`, () => {
+          return HttpResponse.json(
+            {
+              fault: {
+                arguments: {codeVersionId: 'other'},
+                type: 'CodeVersionModificationException',
+                message: 'Modification failed',
+              },
+            },
+            {status: 400},
+          );
+        }),
+      );
+
+      try {
+        await activateCodeVersion(mockInstance, 'v2');
+        expect.fail('Should have thrown error');
+      } catch (error: any) {
+        expect(error.message).to.equal('Could not activate code version "v2": Modification failed');
       }
     });
   });

--- a/packages/b2c-vs-extension/.vscode-test.mjs
+++ b/packages/b2c-vs-extension/.vscode-test.mjs
@@ -49,4 +49,26 @@ export default defineConfig([
       timeout: 20000,
     },
   },
+  {
+    label: 'nested-dw-json',
+    files: 'out/test/config-provider.test.js',
+    version: 'stable',
+    workspaceFolder: 'src/test/fixtures/nested-workspace',
+    launchArgs: ['--user-data-dir', shortUserDataDir('nested-dw-json')],
+    mocha: {
+      ui: 'tdd',
+      timeout: 20000,
+    },
+  },
+  {
+    label: 'multi-root-dw-json',
+    files: 'out/test/config-provider.test.js',
+    version: 'stable',
+    workspaceFolder: 'src/test/fixtures/multi-root.code-workspace',
+    launchArgs: ['--user-data-dir', shortUserDataDir('multi-root-dw-json')],
+    mocha: {
+      ui: 'tdd',
+      timeout: 20000,
+    },
+  },
 ]);

--- a/packages/b2c-vs-extension/README.md
+++ b/packages/b2c-vs-extension/README.md
@@ -53,7 +53,7 @@ Tail sandbox logs into a VS Code output channel, install Commerce App Packages, 
 ## Get started
 
 1. Open a B2C Commerce project in VS Code.
-2. Add a `dw.json` file at the workspace root or use an existing B2C CLI configuration.
+2. Add a `dw.json` file at the project root or use an existing B2C CLI configuration. The project can be nested inside an open workspace folder.
 3. Select the active instance from the cloud icon in the status bar.
 4. Open an extension view from the activity bar or run an extension command from the Command Palette.
 

--- a/packages/b2c-vs-extension/package.json
+++ b/packages/b2c-vs-extension/package.json
@@ -44,7 +44,7 @@
     "workspaceContains:**/commerce-app.json",
     "workspaceContains:**/cartridge/*.properties",
     "workspaceContains:**/.project",
-    "workspaceContains:dw.json"
+    "workspaceContains:**/dw.json"
   ],
   "main": "./dist/extension.cjs",
   "contributes": {
@@ -1872,6 +1872,11 @@
           "command": "b2c-dx.cap.install",
           "when": "explorerResourceIsFolder && resource in b2c-dx.capDirectories",
           "group": "3_cap"
+        },
+        {
+          "command": "b2c-dx.setProjectRoot",
+          "when": "explorerResourceIsFolder && resourceScheme == file && !explorerResourceIsRoot",
+          "group": "9_configuration"
         }
       ],
       "commandPalette": [

--- a/packages/b2c-vs-extension/src/code-sync/cartridge-commands.ts
+++ b/packages/b2c-vs-extension/src/code-sync/cartridge-commands.ts
@@ -23,6 +23,7 @@ import * as vscode from 'vscode';
 import type {B2CExtensionConfig} from '../config-provider.js';
 import {registerSafeCommand} from '../safety.js';
 import {CartridgeItem, type CartridgeTreeItem, type CartridgeTreeProvider} from './cartridge-tree-provider.js';
+import {getActivationCandidates} from './code-version-actions.js';
 
 function getInstance(configProvider: B2CExtensionConfig): B2CInstance | undefined {
   const instance = configProvider.getInstance();
@@ -263,14 +264,20 @@ function createListCodeVersionsCommand(
       const versionId = picked.version.id;
 
       if (actionPick.action === 'activate') {
+        let activationAlreadyActive = false;
         await vscode.window.withProgress(
           {location: vscode.ProgressLocation.Notification, title: `Activating "${versionId}"...`},
           async () => {
-            await activateCodeVersion(instance, versionId);
+            const activation = await activateCodeVersion(instance, versionId);
+            activationAlreadyActive = activation.alreadyActive;
             treeView.description = `v: ${versionId}`;
           },
         );
-        vscode.window.showInformationMessage(`B2C DX: Code version "${versionId}" activated.`);
+        vscode.window.showInformationMessage(
+          activationAlreadyActive
+            ? `B2C DX: Code version "${versionId}" is already active. No changes were needed.`
+            : `B2C DX: Code version "${versionId}" activated.`,
+        );
       } else if (actionPick.action === 'reload') {
         await vscode.window.withProgress(
           {location: vscode.ProgressLocation.Notification, title: `Reloading "${versionId}"...`},
@@ -335,9 +342,18 @@ function createActivateCodeVersionCommand(
 
     try {
       const versions = await listCodeVersions(instance);
-      const items = versions.map((v) => ({
+      const candidates = getActivationCandidates(versions);
+      if (candidates.length === 0) {
+        const activeVersion = versions.find((version) => version.active)?.id;
+        vscode.window.showInformationMessage(
+          activeVersion
+            ? `B2C DX: Code version "${activeVersion}" is already active. No other versions are available to activate.`
+            : 'B2C DX: No inactive code versions are available to activate.',
+        );
+        return;
+      }
+      const items = candidates.map((v) => ({
         label: v.id ?? 'unknown',
-        description: v.active ? '$(star-full) Active' : '',
         version: v,
       }));
 
@@ -347,15 +363,25 @@ function createActivateCodeVersionCommand(
       });
       if (!picked || !picked.version.id) return;
 
+      let activationAlreadyActive = false;
       await vscode.window.withProgress(
         {location: vscode.ProgressLocation.Notification, title: `Activating "${picked.version.id}"...`},
         async () => {
-          await activateCodeVersion(instance, picked.version.id!);
+          const activation = await activateCodeVersion(instance, picked.version.id!);
+          activationAlreadyActive = activation.alreadyActive;
           treeView.description = `v: ${picked.version.id}`;
         },
       );
-      outputChannel.appendLine(`[Code Version] Activated "${picked.version.id}"`);
-      vscode.window.showInformationMessage(`B2C DX: Code version "${picked.version.id}" activated.`);
+      outputChannel.appendLine(
+        activationAlreadyActive
+          ? `[Code Version] "${picked.version.id}" was already active`
+          : `[Code Version] Activated "${picked.version.id}"`,
+      );
+      vscode.window.showInformationMessage(
+        activationAlreadyActive
+          ? `B2C DX: Code version "${picked.version.id}" is already active. No changes were needed.`
+          : `B2C DX: Code version "${picked.version.id}" activated.`,
+      );
     } catch (err) {
       showError(err, outputChannel);
     }

--- a/packages/b2c-vs-extension/src/code-sync/code-version-actions.ts
+++ b/packages/b2c-vs-extension/src/code-sync/code-version-actions.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import type {CodeVersion} from '@salesforce/b2c-tooling-sdk/operations/code';
+
+export type PostDeployAction = 'none' | 'activate' | 'reload';
+
+export interface PostDeployActionItem {
+  action: PostDeployAction;
+  description?: string;
+  label: string;
+}
+
+export function getPostDeployActions(targetIsActive: boolean): PostDeployActionItem[] {
+  const actions: PostDeployActionItem[] = [{label: 'Deploy only', action: 'none'}];
+  if (!targetIsActive) {
+    actions.push({label: 'Deploy & Activate', action: 'activate'});
+  }
+  actions.push({label: 'Deploy & Reload', description: 'Toggle activation to force reload', action: 'reload'});
+  return actions;
+}
+
+export function getActivationCandidates(versions: CodeVersion[]): CodeVersion[] {
+  return versions.filter((version) => !version.active && typeof version.id === 'string');
+}

--- a/packages/b2c-vs-extension/src/code-sync/deploy-command.ts
+++ b/packages/b2c-vs-extension/src/code-sync/deploy-command.ts
@@ -12,6 +12,7 @@ import {
 } from '@salesforce/b2c-tooling-sdk/operations/code';
 import * as vscode from 'vscode';
 import type {B2CExtensionConfig} from '../config-provider.js';
+import {getPostDeployActions} from './code-version-actions.js';
 
 export function createDeployCommand(
   configProvider: B2CExtensionConfig,
@@ -26,16 +27,18 @@ export function createDeployCommand(
 
     // Resolve code version
     let codeVersion = instance.config.codeVersion;
-    if (!codeVersion) {
-      try {
-        const active = await getActiveCodeVersion(instance);
+    let activeCodeVersionId: string | undefined;
+    try {
+      const active = await getActiveCodeVersion(instance);
+      activeCodeVersionId = active?.id;
+      if (!codeVersion) {
         if (active?.id) {
           codeVersion = active.id;
           instance.config.codeVersion = codeVersion;
         }
-      } catch {
-        // fall through
       }
+    } catch {
+      // The configured version can still be deployed when OCAPI discovery is unavailable.
     }
     if (!codeVersion) {
       vscode.window.showErrorMessage(
@@ -64,14 +67,9 @@ export function createDeployCommand(
     }
 
     // Choose post-deploy action
-    const actionPick = await vscode.window.showQuickPick(
-      [
-        {label: 'Deploy only', action: 'none' as const},
-        {label: 'Deploy & Activate', action: 'activate' as const},
-        {label: 'Deploy & Reload', description: 'Toggle activation to force reload', action: 'reload' as const},
-      ],
-      {title: 'Post-deploy action'},
-    );
+    const actionPick = await vscode.window.showQuickPick(getPostDeployActions(activeCodeVersionId === codeVersion), {
+      title: 'Post-deploy action',
+    });
     if (!actionPick) return;
 
     const hostname = instance.config.hostname ?? 'unknown';
@@ -100,8 +98,12 @@ export function createDeployCommand(
 
           if (actionPick.action === 'activate') {
             progress.report({message: 'Activating code version...'});
-            await activateCodeVersion(instance, codeVersion);
-            outputChannel.appendLine(`Code version "${codeVersion}" activated`);
+            const activation = await activateCodeVersion(instance, codeVersion);
+            outputChannel.appendLine(
+              activation.alreadyActive
+                ? `Code version "${codeVersion}" is already active; activation skipped`
+                : `Code version "${codeVersion}" activated`,
+            );
           } else if (actionPick.action === 'reload') {
             progress.report({message: 'Reloading code version...'});
             await reloadCodeVersion(instance, codeVersion);

--- a/packages/b2c-vs-extension/src/config-provider.ts
+++ b/packages/b2c-vs-extension/src/config-provider.ts
@@ -14,6 +14,7 @@ import type {B2CInstance} from '@salesforce/b2c-tooling-sdk/instance';
 import {readFile} from 'fs/promises';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import {findWorkspaceDwJson} from './workspace-discovery.js';
 
 const DW_JSON = 'dw.json';
 const DOT_ENV = '.env';
@@ -30,15 +31,13 @@ async function pathExists(p: string): Promise<boolean> {
 }
 
 /**
- * Detect the best workspace folder for B2C config resolution.
+ * Detect the best project directory for B2C config resolution.
  *
  * Scans all workspace folders for B2C indicators in priority order:
- * 1. Folder containing dw.json (strongest signal)
+ * 1. Directory containing dw.json (strongest signal; nested directories included)
  * 2. Folder containing .env with SFCC_* variables
  * 3. Folder containing package.json with `b2c` key
  * 4. Falls back to first folder (current behavior)
- *
- * Single-folder workspaces skip scanning (fast path).
  */
 async function detectWorkingDirectory(log: vscode.OutputChannel): Promise<string> {
   const folders = vscode.workspace.workspaceFolders;
@@ -47,23 +46,14 @@ async function detectWorkingDirectory(log: vscode.OutputChannel): Promise<string
     return process.cwd();
   }
 
-  // Single-folder workspace — fast path
-  if (folders.length === 1) {
-    return folders[0].uri.fsPath;
-  }
-
-  // Multi-root: scan for B2C indicators
   const folderNames = folders.map((f) => f.uri.fsPath).join(', ');
-  log.appendLine(
-    `[Config] Multi-root workspace detected (${folders.length} folders: ${folderNames}), scanning for B2C project...`,
-  );
+  log.appendLine(`[Config] Scanning workspace folders for a B2C project (${folderNames})...`);
 
-  for (const folder of folders) {
-    const dwJsonPath = path.join(folder.uri.fsPath, DW_JSON);
-    if (await pathExists(dwJsonPath)) {
-      log.appendLine(`[Config] Selected workspace folder via dw.json: ${folder.uri.fsPath}`);
-      return folder.uri.fsPath;
-    }
+  const dwJson = await findWorkspaceDwJson();
+  if (dwJson) {
+    const projectDirectory = path.dirname(dwJson.fsPath);
+    log.appendLine(`[Config] Selected project directory via dw.json: ${projectDirectory}`);
+    return projectDirectory;
   }
 
   for (const folder of folders) {
@@ -173,7 +163,7 @@ export class B2CExtensionConfig implements vscode.Disposable {
 
   /**
    * Returns the working directory used for config resolution.
-   * Either the pinned project root or the auto-detected workspace folder.
+   * Either the pinned project root or the auto-detected project directory.
    */
   getWorkingDirectory(): string {
     return this.detectedDirectory;

--- a/packages/b2c-vs-extension/src/extension.ts
+++ b/packages/b2c-vs-extension/src/extension.ts
@@ -12,6 +12,7 @@ import * as https from 'https';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {B2CExtensionConfig} from './config-provider.js';
+import {workspaceHasDwJson} from './workspace-discovery.js';
 import {CartridgeService} from './cartridges/cartridge-service.js';
 import {registerCap} from './cap/index.js';
 import {registerJobLogViewer} from './job-log-viewer.js';
@@ -527,18 +528,7 @@ async function activateInner(context: vscode.ExtensionContext, log: vscode.Outpu
   configProvider.onDidReset(() => updateInstanceConnectedContext());
 
   const updateDwJsonContext = async () => {
-    const folders = vscode.workspace.workspaceFolders ?? [];
-    let exists = false;
-    for (const folder of folders) {
-      try {
-        await vscode.workspace.fs.stat(vscode.Uri.joinPath(folder.uri, 'dw.json'));
-        exists = true;
-        break;
-      } catch {
-        // not in this folder
-      }
-    }
-    await vscode.commands.executeCommand('setContext', 'b2c-dx.dwJsonExists', exists);
+    await vscode.commands.executeCommand('setContext', 'b2c-dx.dwJsonExists', await workspaceHasDwJson());
   };
   void updateDwJsonContext();
   const dwJsonWatcher = vscode.workspace.createFileSystemWatcher('**/dw.json');
@@ -857,19 +847,7 @@ async function activateInner(context: vscode.ExtensionContext, log: vscode.Outpu
   // Drop the per-workspace onboarding panel state (persona + step records)
   // when the workspace has no dw.json, so the deep-dive panel reopens with no
   // selection. Cheap to call: workspaceState writes are local.
-  const workspaceHasDwJson = await (async () => {
-    const folders = vscode.workspace.workspaceFolders ?? [];
-    for (const folder of folders) {
-      try {
-        await vscode.workspace.fs.stat(vscode.Uri.joinPath(folder.uri, 'dw.json'));
-        return true;
-      } catch {
-        // keep checking
-      }
-    }
-    return false;
-  })();
-  if (!workspaceHasDwJson) {
+  if (!(await workspaceHasDwJson())) {
     await onboardingStore.reset();
   }
 

--- a/packages/b2c-vs-extension/src/test/code-version-actions.test.ts
+++ b/packages/b2c-vs-extension/src/test/code-version-actions.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import * as assert from 'assert';
+import {getActivationCandidates, getPostDeployActions} from '../code-sync/code-version-actions.js';
+
+suite('code version actions', () => {
+  test('omits activate when the deployment target is already active', () => {
+    assert.deepStrictEqual(
+      getPostDeployActions(true).map((item) => item.action),
+      ['none', 'reload'],
+    );
+  });
+
+  test('offers activate when the deployment target is not known to be active', () => {
+    assert.deepStrictEqual(
+      getPostDeployActions(false).map((item) => item.action),
+      ['none', 'activate', 'reload'],
+    );
+  });
+
+  test('excludes the active version and invalid entries from activation candidates', () => {
+    const candidates = getActivationCandidates([
+      {id: 'active', active: true},
+      {id: 'inactive', active: false},
+      {active: false},
+    ]);
+
+    assert.deepStrictEqual(
+      candidates.map((version) => version.id),
+      ['inactive'],
+    );
+  });
+});

--- a/packages/b2c-vs-extension/src/test/config-provider.test.ts
+++ b/packages/b2c-vs-extension/src/test/config-provider.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {B2CExtensionConfig} from '../config-provider.js';
+
+suite('B2CExtensionConfig workspace discovery', () => {
+  test('selects the expected project root for the open workspace shape', async () => {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    assert.ok(workspaceFolders?.length, 'test workspace should be open');
+
+    let expected = workspaceFolders[0].uri.fsPath;
+    if (workspaceFolders[0].name === 'nested-workspace') {
+      expected = path.join(expected, 'sfra');
+    } else if (workspaceFolders[0].name === 'first-workspace-folder') {
+      expected = path.join(expected, 'projects', 'sfra');
+    }
+    const log = vscode.window.createOutputChannel('B2C Config Discovery Test');
+    const provider = new B2CExtensionConfig(log);
+
+    try {
+      await provider.ensureResolved();
+      assert.strictEqual(provider.getWorkingDirectory(), expected);
+    } finally {
+      provider.dispose();
+      log.dispose();
+    }
+  });
+
+  test('a pinned root overrides multi-root workspace ordering', async function () {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders || workspaceFolders.length < 2) {
+      this.skip();
+      return;
+    }
+
+    const pinnedRoot = workspaceFolders[1].uri.fsPath;
+    const workspaceState = {
+      keys: () => ['b2c-dx.projectRoot'],
+      get: (key: string) => (key === 'b2c-dx.projectRoot' ? pinnedRoot : undefined),
+      update: async () => {},
+    } as vscode.Memento;
+    const log = vscode.window.createOutputChannel('B2C Config Pin Test');
+    const provider = new B2CExtensionConfig(log, workspaceState);
+
+    try {
+      await provider.ensureResolved();
+      assert.strictEqual(provider.getWorkingDirectory(), pinnedRoot);
+      assert.strictEqual(provider.isProjectRootPinned(), true);
+    } finally {
+      provider.dispose();
+      log.dispose();
+    }
+  });
+});

--- a/packages/b2c-vs-extension/src/test/fixtures/multi-root.code-workspace
+++ b/packages/b2c-vs-extension/src/test/fixtures/multi-root.code-workspace
@@ -1,0 +1,12 @@
+{
+  "folders": [
+    {
+      "name": "first-workspace-folder",
+      "path": "multi-root/first",
+    },
+    {
+      "name": "second-workspace-folder",
+      "path": "multi-root/second",
+    },
+  ],
+}

--- a/packages/b2c-vs-extension/src/test/fixtures/multi-root/first/projects/sfra/dw.json
+++ b/packages/b2c-vs-extension/src/test/fixtures/multi-root/first/projects/sfra/dw.json
@@ -1,0 +1,6 @@
+{
+  "hostname": "first-workspace-test-fixture.invalid",
+  "username": "fixture-user",
+  "password": "not-a-real-password",
+  "code-version": "version1"
+}

--- a/packages/b2c-vs-extension/src/test/fixtures/multi-root/second/dw.json
+++ b/packages/b2c-vs-extension/src/test/fixtures/multi-root/second/dw.json
@@ -1,0 +1,6 @@
+{
+  "hostname": "second-workspace-test-fixture.invalid",
+  "username": "fixture-user",
+  "password": "not-a-real-password",
+  "code-version": "version1"
+}

--- a/packages/b2c-vs-extension/src/test/fixtures/nested-workspace/react/commerce/sfra/dw.json
+++ b/packages/b2c-vs-extension/src/test/fixtures/nested-workspace/react/commerce/sfra/dw.json
@@ -1,0 +1,6 @@
+{
+  "hostname": "deeper-test-fixture.invalid",
+  "username": "fixture-user",
+  "password": "not-a-real-password",
+  "code-version": "version1"
+}

--- a/packages/b2c-vs-extension/src/test/fixtures/nested-workspace/sfra/dw.json
+++ b/packages/b2c-vs-extension/src/test/fixtures/nested-workspace/sfra/dw.json
@@ -1,0 +1,6 @@
+{
+  "hostname": "nested-test-fixture.invalid",
+  "username": "fixture-user",
+  "password": "not-a-real-password",
+  "code-version": "version1"
+}

--- a/packages/b2c-vs-extension/src/test/integration/activation.test.ts
+++ b/packages/b2c-vs-extension/src/test/integration/activation.test.ts
@@ -21,12 +21,17 @@ interface ContributedView {
   name: string;
   when?: string;
 }
+interface ContributedMenuItem {
+  command?: string;
+  when?: string;
+}
 interface PackageJson {
+  activationEvents: string[];
   contributes: {
     commands: ContributedCommand[];
     views: Record<string, ContributedView[]>;
     debuggers: Array<{type: string}>;
-    menus?: {commandPalette?: Array<{command: string; when?: string}>};
+    menus?: Record<string, ContributedMenuItem[]>;
     walkthroughs?: Array<{id: string; when?: string}>;
   };
 }
@@ -51,6 +56,22 @@ suite('extension activation', () => {
   test('extension activates without throwing', () => {
     const ext = vscode.extensions.getExtension(EXTENSION_ID);
     assert.ok(ext?.isActive, 'extension should be active after suiteSetup activate()');
+  });
+
+  test('nested dw.json files activate the extension', () => {
+    assert.ok(
+      pkg.activationEvents.includes('workspaceContains:**/dw.json'),
+      'activation events should include nested dw.json files',
+    );
+  });
+
+  test('nested folders expose the project-root command in Explorer', () => {
+    const submenu = pkg.contributes.menus?.['b2c-dx.submenu'] ?? [];
+    const projectRootItem = submenu.find((item) => item.command === 'b2c-dx.setProjectRoot');
+    assert.strictEqual(
+      projectRootItem?.when,
+      'explorerResourceIsFolder && resourceScheme == file && !explorerResourceIsRoot',
+    );
   });
 
   // This is the workhorse check. The extension's top-level try/catch
@@ -109,7 +130,7 @@ suite('extension activation', () => {
   });
 
   test('preview-feature palette commands are gated by their feature setting', () => {
-    const palette: Array<{command: string; when?: string}> = pkg.contributes.menus?.commandPalette ?? [];
+    const palette = pkg.contributes.menus?.commandPalette ?? [];
     const whenFor = (cmd: string) => palette.find((e) => e.command === cmd)?.when;
     const cases: Array<[string, string]> = [
       ['b2c-dx.jobs.run', 'config.b2c-dx.features.jobsExplorer'],

--- a/packages/b2c-vs-extension/src/walkthrough/commands.ts
+++ b/packages/b2c-vs-extension/src/walkthrough/commands.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import * as cp from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import {workspaceHasDwJson} from '../workspace-discovery.js';
 
 /**
  * Template for a basic dw.json configuration file.
@@ -1583,14 +1584,7 @@ async function addToGitignore(workspaceRoot: string): Promise<void> {
 export async function resetWorkspaceOnboardingIfFresh(context: vscode.ExtensionContext): Promise<void> {
   const folders = vscode.workspace.workspaceFolders ?? [];
   if (folders.length === 0) return;
-  for (const folder of folders) {
-    try {
-      await fs.access(path.join(folder.uri.fsPath, 'dw.json'));
-      return; // workspace already configured — leave state alone
-    } catch {
-      // keep checking
-    }
-  }
+  if (await workspaceHasDwJson()) return;
   await context.workspaceState.update('b2c-dx.setup.activeInstance', undefined);
   await context.workspaceState.update('b2c-dx.gettingStarted.autoOpened', undefined);
   void vscode.commands.executeCommand('setContext', 'b2c-dx.setupSessionActive', false);
@@ -1613,14 +1607,9 @@ export async function showWalkthroughOnFirstActivation(context: vscode.Extension
 
   // Skip auto-open when the workspace already has a dw.json — the user is
   // returning, not starting fresh.
-  for (const folder of folders) {
-    try {
-      await fs.access(path.join(folder.uri.fsPath, 'dw.json'));
-      await context.workspaceState.update(SEEN_KEY, true);
-      return;
-    } catch {
-      // not present here, keep checking
-    }
+  if (await workspaceHasDwJson()) {
+    await context.workspaceState.update(SEEN_KEY, true);
+    return;
   }
 
   setTimeout(() => {

--- a/packages/b2c-vs-extension/src/walkthrough/onboardingPanel.ts
+++ b/packages/b2c-vs-extension/src/walkthrough/onboardingPanel.ts
@@ -404,7 +404,8 @@ export class OnboardingPanel {
       return {persona: null, personas, steps: [], activeStepId: null, setupInstance};
     }
     const defs = resolveSteps(personaDef.id);
-    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const workspaceRoot =
+      this.getConfigProvider?.()?.getWorkingDirectory() || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     const detectionSummary = await detectStepConfigurations(workspaceRoot);
     const rawSteps = await Promise.all(defs.map((def) => this.buildStepView(personaDef.id, def, detectionSummary)));
     // Sequential gating: a step is locked until every step before it is done
@@ -572,7 +573,8 @@ export class OnboardingPanel {
    * caller can disable the primary action).
    */
   private async buildDeployBanner(): Promise<{html: string; alreadyDeployed: boolean; cartridgeName?: string} | null> {
-    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const workspaceRoot =
+      this.getConfigProvider?.()?.getWorkingDirectory() || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     const ctx = await readDeployContext(workspaceRoot);
     const lastScaffolded = this.context.workspaceState.get<string>('b2c-dx.scaffold.lastCartridgeName');
 

--- a/packages/b2c-vs-extension/src/workspace-discovery.ts
+++ b/packages/b2c-vs-extension/src/workspace-discovery.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const DW_JSON_GLOB = '**/dw.json';
+const DISCOVERY_EXCLUDE_GLOB = '**/{node_modules,.git}/**';
+
+function pathDepth(relativePath: string): number {
+  return relativePath.split(path.sep).length;
+}
+
+/**
+ * Find the first dw.json in workspace-folder order.
+ *
+ * Within each workspace folder, the shallowest file wins. Ties are resolved
+ * lexically so discovery remains stable when a folder contains multiple B2C
+ * projects.
+ */
+export async function findWorkspaceDwJson(): Promise<vscode.Uri | undefined> {
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    const matches = await vscode.workspace.findFiles(
+      new vscode.RelativePattern(folder, DW_JSON_GLOB),
+      DISCOVERY_EXCLUDE_GLOB,
+    );
+    matches.sort((left, right) => {
+      const leftRelative = path.relative(folder.uri.fsPath, left.fsPath);
+      const rightRelative = path.relative(folder.uri.fsPath, right.fsPath);
+      return pathDepth(leftRelative) - pathDepth(rightRelative) || leftRelative.localeCompare(rightRelative);
+    });
+    if (matches.length > 0) {
+      return matches[0];
+    }
+  }
+  return undefined;
+}
+
+export async function workspaceHasDwJson(): Promise<boolean> {
+  return (await findWorkspaceDwJson()) !== undefined;
+}

--- a/skills/b2c-cli/skills/b2c-code/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-code/SKILL.md
@@ -103,7 +103,7 @@ b2c code activate <version-name>
 b2c code activate --reload
 ```
 
-**Note:** Activating a code version triggers Custom API endpoint registration. If you've added or modified Custom APIs, use `--reload` with deploy or activate to register them. Check registration status with the `b2c-cli:b2c-scapi-custom` skill.
+**Note:** Activation is idempotent. If the version is already active, the command succeeds without making a change. If you've uploaded code or changed Custom APIs in the active version, use `--reload` with deploy or activate to force a refresh and register the endpoints. Check registration status with the `b2c-cli:b2c-scapi-custom` skill.
 
 ### Delete Code Version
 


### PR DESCRIPTION
## Summary

- Discover nested `dw.json` files in parent-folder and multi-root VS Code workspaces, preferring workspace order and the shallowest project configuration.
- Allow nested project folders such as `sfra/` to be pinned as the B2C Commerce root from Explorer and document all supported CLI configuration sources.
- Treat activation of an already-active code version as an idempotent success across the SDK, CLI, and VS Code extension. Preserve actual OCAPI fault details and hide redundant activation choices when the active version is known.

## Testing

- `pnpm --filter @salesforce/b2c-tooling-sdk run test:agent` (2,045 passing, 7 pending)
- `pnpm --filter @salesforce/b2c-cli run test:agent` (1,425 passing)
- `pnpm --filter b2c-vs-extension run test` (full workspace-shape and activation matrix)
- `pnpm run lint:agent`
- `pnpm run typecheck:agent`
- `pnpm run docs:build`
- Built and inspected `b2c-vs-extension-1.0.2.vsix`

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Relevant package tests pass
- [x] Code is formatted and lint passes