### PR TITLE
@W-23604439 fix slas client update corrupting existing callback URIs

### DIFF
--- a/.changeset/slas-update-callback-uri-split.md
+++ b/.changeset/slas-update-callback-uri-split.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-cli': patch
+---
+
+Fix `slas client update` corrupting existing callback URIs. When merging with the current client, the command split the API's pipe-delimited `callbackUri` value on commas instead of pipes, so the entire list was sent back as a single string and the update was rejected with "CallbackURI must be a valid URL". Callback URIs are now parsed with the same shared helper used for redirect URIs everywhere in the SLAS commands, so the two paths can no longer disagree.

--- a/packages/b2c-cli/src/commands/slas/client/update.ts
+++ b/packages/b2c-cli/src/commands/slas/client/update.ts
@@ -10,6 +10,7 @@ import {
   type ClientRequest,
   type ClientOutput,
   normalizeClientResponse,
+  parseUriList,
   printClientDetails,
   formatApiError,
 } from '../../../utils/slas/client.js';
@@ -180,8 +181,8 @@ export default class SlasClientUpdate extends SlasClientCommand<typeof SlasClien
     },
   ): Partial<ClientRequest> {
     const existingScopes = this.normalizeScopes(existing.scopes);
-    const existingRedirectUri = this.normalizeUriArray(existing.redirectUri);
-    const existingCallbackUri = this.normalizeCallbackUri(existing.callbackUri);
+    const existingRedirectUri = parseUriList(existing.redirectUri);
+    const existingCallbackUri = parseUriList(existing.callbackUri);
 
     // Determine merged values
     const mergedChannels = this.mergeArrayValues(existing.channels ?? [], updates.channels, updates.replace);
@@ -224,13 +225,6 @@ export default class SlasClientUpdate extends SlasClientCommand<typeof SlasClien
   }
 
   /**
-   * Normalize callback URI from API response (comma-separated string).
-   */
-  private normalizeCallbackUri(value: string | undefined): string[] {
-    return value ? value.split(',').map((s) => s.trim()) : [];
-  }
-
-  /**
    * Normalize scopes from API response (may be space-separated string or array).
    */
   private normalizeScopes(scopes: string | string[] | undefined): string[] {
@@ -238,15 +232,5 @@ export default class SlasClientUpdate extends SlasClientCommand<typeof SlasClien
       return scopes.split(' ');
     }
     return Array.isArray(scopes) ? scopes : [];
-  }
-
-  /**
-   * Normalize URI values from API response (may be pipe-delimited string or array).
-   */
-  private normalizeUriArray(value: string | string[] | undefined): string[] {
-    if (Array.isArray(value)) {
-      return value.flatMap((uri) => (typeof uri === 'string' ? uri.split('|').map((s) => s.trim()) : []));
-    }
-    return typeof value === 'string' ? value.split('|').map((s) => s.trim()) : [];
   }
 }

--- a/packages/b2c-cli/src/commands/slas/token.ts
+++ b/packages/b2c-cli/src/commands/slas/token.ts
@@ -9,7 +9,7 @@ import {loadConfig, extractOAuthFlags} from '@salesforce/b2c-tooling-sdk/cli';
 import type {ResolvedB2CConfig} from '@salesforce/b2c-tooling-sdk/config';
 import {toOrganizationId, decodeJWT} from '@salesforce/b2c-tooling-sdk';
 import {getGuestToken, getRegisteredToken, type SlasTokenConfig} from '@salesforce/b2c-tooling-sdk/slas';
-import {SlasClientCommand, normalizeClientResponse, parseRedirectUris, type Client} from '../../utils/slas/client.js';
+import {SlasClientCommand, normalizeClientResponse, parseUriList, type Client} from '../../utils/slas/client.js';
 import {t, withDocs} from '../../i18n/index.js';
 
 const DEFAULT_REDIRECT_URI = 'http://localhost:3000/callback';
@@ -268,7 +268,7 @@ export default class SlasToken extends SlasClientCommand<typeof SlasToken> {
       discovered.siteId = publicClient.channels[0];
     }
     if (!options.redirectUri && publicClient.redirectUri) {
-      const uris = parseRedirectUris(publicClient.redirectUri);
+      const uris = parseUriList(publicClient.redirectUri);
       if (uris.length > 0) {
         discovered.redirectUri = uris[0];
       }

--- a/packages/b2c-cli/src/utils/slas/client.ts
+++ b/packages/b2c-cli/src/utils/slas/client.ts
@@ -75,14 +75,14 @@ export function printClientDetails(output: ClientOutput, showSecret = true): voi
   ui.div({text: 'Channels:', width: labelWidth}, {text: output.channels.join(', ')});
   ui.div({text: 'Scopes:', width: labelWidth}, {text: output.scopes.join('\n' + ' '.repeat(labelWidth))});
 
-  const redirectUris = parseRedirectUris(output.redirectUri);
+  const redirectUris = parseUriList(output.redirectUri);
   ui.div(
     {text: 'Redirect URIs:', width: labelWidth},
     {text: redirectUris.length > 0 ? redirectUris.join('\n' + ' '.repeat(labelWidth)) : ''},
   );
 
   if (output.callbackUri) {
-    const callbackUris = parseRedirectUris(output.callbackUri);
+    const callbackUris = parseUriList(output.callbackUri);
     ui.div(
       {text: 'Callback URIs:', width: labelWidth},
       {text: callbackUris.length > 0 ? callbackUris.join('\n' + ' '.repeat(labelWidth)) : output.callbackUri},
@@ -104,22 +104,36 @@ export function printClientDetails(output: ClientOutput, showSecret = true): voi
 }
 
 /**
- * Parse a redirectUri string into individual URIs.
- * The SLAS API returns redirect URIs as a pipe-delimited string (e.g. "http://a|http://b"),
- * while normalizeClientResponse may produce comma-separated values from an array response.
- * This helper handles both formats.
+ * Parse a SLAS URI list (redirect URIs or callback URIs) into individual URIs.
+ *
+ * The SLAS API returns both fields as a single pipe-delimited string (e.g. "http://a|http://b").
+ * This helper also accepts:
+ * - an array response, where each element is a URI (and may itself be pipe-delimited); and
+ * - a comma-delimited string, which is what {@link normalizeClientResponse} produces when it
+ *   joins an array response for display.
+ *
+ * This is the single source of truth for splitting SLAS URI lists — both the display path and
+ * the update request-building path use it, so the two cannot drift (as they previously did when
+ * update split callback URIs on commas instead of pipes).
+ *
+ * Empty segments are dropped.
  */
-export function parseRedirectUris(redirectUri: string): string[] {
-  if (redirectUri.includes('|')) {
-    return redirectUri
-      .split('|')
+export function parseUriList(value: null | string | string[] | undefined): string[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    // Each element is a URI, but a single element may itself be pipe-delimited.
+    return value
+      .filter((s): s is string => typeof s === 'string')
+      .flatMap((s) => s.split('|'))
       .map((s) => s.trim())
       .filter(Boolean);
   }
-  return redirectUri
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
+  // A single string is pipe-delimited from the API, or comma-delimited when produced by
+  // normalizeClientResponse joining an array response.
+  const parts = value.includes('|') ? value.split('|') : value.split(',');
+  return parts.map((s) => s.trim()).filter(Boolean);
 }
 
 // Backwards-compatible alias for SDK's getApiErrorMessage; existing call sites

--- a/packages/b2c-cli/test/commands/slas/client/update.test.ts
+++ b/packages/b2c-cli/test/commands/slas/client/update.test.ts
@@ -89,6 +89,45 @@ describe('slas client update', () => {
     expect(result.clientId).to.equal('my-client');
   });
 
+  it('splits pipe-delimited callbackUri from the API into individual URLs', async () => {
+    const command: any = await createCommand(
+      {
+        'tenant-id': 'abcd_123',
+        channels: ['NewSite'],
+      },
+      {clientId: 'my-client'},
+    );
+
+    stubAuthAndJson(command);
+
+    // The API returns callbackUri as a single pipe-delimited string, same as redirectUri.
+    const getStub = sinon.stub().resolves({
+      data: {
+        clientId: 'my-client',
+        name: 'Existing',
+        channels: ['OldSite'],
+        scopes: 'old.scope',
+        redirectUri: 'http://old/cb',
+        callbackUri: 'https://a.example.com/cb|https://b.example.com/reset|https://c.example.com/pwl',
+        isPrivateClient: true,
+      },
+      error: undefined,
+    });
+
+    const putStub = sinon.stub().resolves({data: {clientId: 'my-client'}, error: undefined});
+
+    sinon.stub(command, 'getSlasClient').returns({GET: getStub, PUT: putStub} as any);
+
+    await command.run();
+
+    const [, options] = putStub.firstCall.args as [string, any];
+    expect(options.body.callbackUri).to.deep.equal([
+      'https://a.example.com/cb',
+      'https://b.example.com/reset',
+      'https://c.example.com/pwl',
+    ]);
+  });
+
   it('appends list values with dedupe when --replace is false', async () => {
     const command: any = await createCommand(
       {

--- a/packages/b2c-cli/test/utils/slas/client.test.ts
+++ b/packages/b2c-cli/test/utils/slas/client.test.ts
@@ -6,7 +6,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import {ux} from '@oclif/core';
-import {normalizeClientResponse, printClientDetails} from '../../../src/utils/slas/client.js';
+import {normalizeClientResponse, parseUriList, printClientDetails} from '../../../src/utils/slas/client.js';
 
 describe('utils/slas/client', () => {
   afterEach(() => {
@@ -275,6 +275,45 @@ describe('utils/slas/client', () => {
       expect(lines.find((l) => l.includes('https://a.example.com/cb'))).to.exist;
       expect(lines.find((l) => l.includes('https://b.example.com/cb'))).to.exist;
       expect(lines.find((l) => l.includes('https://c.example.com/cb'))).to.exist;
+    });
+  });
+
+  describe('parseUriList', () => {
+    it('splits the pipe-delimited string the API returns', () => {
+      expect(parseUriList('https://a/cb|https://b/reset|https://c/pwl')).to.deep.equal([
+        'https://a/cb',
+        'https://b/reset',
+        'https://c/pwl',
+      ]);
+    });
+
+    it('splits comma-delimited values produced by normalizeClientResponse', () => {
+      expect(parseUriList('https://a/cb, https://b/cb')).to.deep.equal(['https://a/cb', 'https://b/cb']);
+    });
+
+    it('prefers pipe over comma so callback URLs with commas stay intact', () => {
+      // A single URL may legally contain a comma (e.g. in a query string); pipe is the list separator.
+      expect(parseUriList('https://a/cb?x=1,2|https://b/cb')).to.deep.equal(['https://a/cb?x=1,2', 'https://b/cb']);
+    });
+
+    it('flattens an array response, splitting any pipe-delimited elements', () => {
+      expect(parseUriList(['https://a/cb|https://b/cb', 'https://c/cb'])).to.deep.equal([
+        'https://a/cb',
+        'https://b/cb',
+        'https://c/cb',
+      ]);
+    });
+
+    it('trims whitespace and drops empty segments', () => {
+      expect(parseUriList(' https://a/cb | | https://b/cb ')).to.deep.equal(['https://a/cb', 'https://b/cb']);
+    });
+
+    it('returns an empty array for undefined, null, or empty input', () => {
+      expect(parseUriList(undefined)).to.deep.equal([]);
+      // The API may return callbackUri as null.
+      expect(parseUriList(null)).to.deep.equal([]);
+      expect(parseUriList('')).to.deep.equal([]);
+      expect(parseUriList([])).to.deep.equal([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

`b2c slas client update` failed with `Error: Failed to update SLAS client: CallbackURI must be a valid URL` for any SLAS client that already had callback URIs configured.

The SLAS API returns `callbackUri` as a **pipe-delimited** string (`https://a|https://b`), exactly like `redirectUri`. The update command's request-builder split it on **commas** instead, so the whole list was preserved as a single string and rejected as an invalid URL. The display path (`get`/`list`/`create`) was unaffected because it used a separate, tolerant helper — which is why `slas client get` always rendered these clients correctly.

## What changed

- Consolidated URI-list parsing into a single shared helper (`parseUriList`) in `utils/slas/client.ts`, used by the display path **and** the update request-builder, so the two implementations can no longer drift.
- Removed `update`'s private `normalizeUriArray`/`normalizeCallbackUri` (the comma-splitting one was the bug).
- `token.ts` and `printClientDetails` now use the same helper.

Verified empirically against 220 clients across `zzpq_011/013/019`: every populated `callbackUri` is pipe-delimited; none use commas.

## Manual verification

1. Pick a SLAS client that has existing callback URIs (e.g. a "Managed Private Client" on a sandbox).
2. Run `b2c slas client update <clientId> --tenant-id <tenant> --short-code <sc> --channels <existing>,<new>` (any update that merges with existing values).
3. Confirm the update succeeds and the client's existing callback URIs are preserved (previously returned HTTP 400 "CallbackURI must be a valid URL").

Fixes W-23604439.
