### PR TITLE
@W-23618508 fix VS Code extension blocking others on empty workspace

### DIFF
--- a/.changeset/vscode-empty-workspace-activation.md
+++ b/.changeset/vscode-empty-workspace-activation.md
@@ -1,0 +1,5 @@
+---
+'b2c-vs-extension': patch
+---
+
+Stop the VS Code extension from blocking other extensions in empty or non-B2C windows. Because the extension registers a TypeScript server plugin, VS Code activates it whenever any JavaScript/TypeScript file is opened — including windows with no folder. In that case the extension no longer falls back to the process working directory, and all cartridge/workspace discovery now runs only from a concrete workspace folder and never from a home or filesystem-root directory, so it can't trigger a recursive filesystem scan that stalls the extension host.

--- a/packages/b2c-vs-extension/src/cartridges/cartridge-service.ts
+++ b/packages/b2c-vs-extension/src/cartridges/cartridge-service.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
-import {findCartridges, type CartridgeMapping} from '@salesforce/b2c-tooling-sdk/operations/code';
+import {type CartridgeMapping} from '@salesforce/b2c-tooling-sdk/operations/code';
 
 import * as vscode from 'vscode';
 
 import type {B2CExtensionConfig} from '../config-provider.js';
+import {findCartridgesSafe} from '../workspace-discovery.js';
 
 // Cartridges that conventionally sit at the bottom of the cartridge path when
 // the user hasn't told us otherwise (no `cartridges` in dw.json/SFCC_CARTRIDGES).
@@ -103,14 +104,12 @@ export class CartridgeService implements vscode.Disposable {
 
   private reload(): void {
     const cwd = this.configProvider.getWorkingDirectory();
-    if (!cwd) {
-      this.cartridges = [];
-      this.loaded = true;
-      return;
-    }
+    // findCartridgesSafe returns [] for an empty/home/root working directory and
+    // depth-bounds the scan, so a workspace with no concrete B2C folder never
+    // triggers a recursive walk on the extension-host thread (W-23618508).
     let discovered: CartridgeMapping[];
     try {
-      discovered = findCartridges(cwd);
+      discovered = findCartridgesSafe(cwd);
     } catch {
       discovered = [];
     }

--- a/packages/b2c-vs-extension/src/code-sync/code-sync-manager.ts
+++ b/packages/b2c-vs-extension/src/code-sync/code-sync-manager.ts
@@ -4,7 +4,6 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 import {
-  findCartridges,
   uploadFiles,
   fileToCartridgePath,
   uploadCartridges,
@@ -15,6 +14,7 @@ import {
 import type {B2CInstance} from '@salesforce/b2c-tooling-sdk/instance';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import {findCartridgesSafe} from '../workspace-discovery.js';
 
 const DEBOUNCE_MS = 150;
 const ERROR_RATE_LIMIT_MS = 5000;
@@ -59,7 +59,7 @@ export class CodeSyncManager implements vscode.Disposable {
     this.instance = instance;
 
     // Discover cartridges
-    const cartridges = findCartridges(directory);
+    const cartridges = findCartridgesSafe(directory);
     if (cartridges.length === 0) {
       vscode.window.showWarningMessage('B2C DX: No cartridges found (no .project files in workspace).');
       return;
@@ -119,7 +119,7 @@ export class CodeSyncManager implements vscode.Disposable {
   refreshCartridges(directory: string): void {
     if (!this.watching) return;
 
-    const cartridges = findCartridges(directory);
+    const cartridges = findCartridgesSafe(directory);
     const existingNames = new Set(this.cartridges.map((c) => c.name));
     const newCartridges = cartridges.filter((c) => !existingNames.has(c.name));
 
@@ -217,7 +217,7 @@ export class CodeSyncManager implements vscode.Disposable {
   }
 
   async uploadFileOrFolder(instance: B2CInstance, uri: vscode.Uri, directory: string): Promise<void> {
-    const cartridges = this.cartridges.length > 0 ? this.cartridges : findCartridges(directory);
+    const cartridges = this.cartridges.length > 0 ? this.cartridges : findCartridgesSafe(directory);
     const filePath = uri.fsPath;
 
     const cartridge = cartridges.find((c) => filePath.startsWith(c.src));

--- a/packages/b2c-vs-extension/src/code-sync/deploy-command.ts
+++ b/packages/b2c-vs-extension/src/code-sync/deploy-command.ts
@@ -4,7 +4,6 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 import {
-  findCartridges,
   uploadCartridges,
   getActiveCodeVersion,
   activateCodeVersion,
@@ -12,6 +11,7 @@ import {
 } from '@salesforce/b2c-tooling-sdk/operations/code';
 import * as vscode from 'vscode';
 import type {B2CExtensionConfig} from '../config-provider.js';
+import {findCartridgesSafe} from '../workspace-discovery.js';
 import {getPostDeployActions} from './code-version-actions.js';
 
 export function createDeployCommand(
@@ -49,7 +49,7 @@ export function createDeployCommand(
 
     // Discover cartridges
     const directory = configProvider.getWorkingDirectory();
-    const cartridges = findCartridges(directory);
+    const cartridges = findCartridgesSafe(directory);
     if (cartridges.length === 0) {
       vscode.window.showWarningMessage('B2C DX: No cartridges found (no .project files in workspace).');
       return;
@@ -176,7 +176,7 @@ export function createDeployOneCommand(
     }
 
     const directory = configProvider.getWorkingDirectory();
-    const cartridges = findCartridges(directory);
+    const cartridges = findCartridgesSafe(directory);
     if (cartridges.length === 0) {
       vscode.window.showWarningMessage('B2C DX: No cartridges found.');
       return;

--- a/packages/b2c-vs-extension/src/config-provider.ts
+++ b/packages/b2c-vs-extension/src/config-provider.ts
@@ -14,7 +14,7 @@ import type {B2CInstance} from '@salesforce/b2c-tooling-sdk/instance';
 import {readFile} from 'fs/promises';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import {findWorkspaceDwJson} from './workspace-discovery.js';
+import {findWorkspaceDwJson, isUnscannableRoot} from './workspace-discovery.js';
 
 const DW_JSON = 'dw.json';
 const DOT_ENV = '.env';
@@ -42,8 +42,16 @@ async function pathExists(p: string): Promise<boolean> {
 async function detectWorkingDirectory(log: vscode.OutputChannel): Promise<string> {
   const folders = vscode.workspace.workspaceFolders;
   if (!folders || folders.length === 0) {
-    log.appendLine('[Config] No workspace folders open, falling back to process.cwd()');
-    return process.cwd();
+    // No workspace folders (empty window). The extension can still be activated
+    // implicitly by its typescriptServerPlugins contribution when any JS/TS file
+    // is opened, so we must NOT fall back to process.cwd() here — the extension
+    // host's cwd is arbitrary (often the user's home directory), and downstream
+    // filesystem discovery (findCartridges / detectWorkspaceType) would then
+    // recursively scan it on the shared extension-host thread, freezing every
+    // other extension (W-23618508). Return no working directory so all
+    // discovery is skipped.
+    log.appendLine('[Config] No workspace folders open; skipping filesystem discovery (no working directory)');
+    return '';
   }
 
   const folderNames = folders.map((f) => f.uri.fsPath).join(', ');
@@ -277,7 +285,16 @@ export class B2CExtensionConfig implements vscode.Disposable {
         workingDirectory = await detectWorkingDirectory(this.log);
         this.pinned = false;
       }
-      if (!workingDirectory || workingDirectory === '/' || !(await pathExists(workingDirectory))) {
+      // Never resolve config or run discovery out of a home/root directory or a
+      // path that no longer exists. isUnscannableRoot() also covers ''/'/' — a
+      // home-directory-as-folder layout must not trigger recursive scans that
+      // would stall the extension host (W-23618508).
+      if (isUnscannableRoot(workingDirectory) || !(await pathExists(workingDirectory))) {
+        if (workingDirectory) {
+          this.log.appendLine(
+            `[Config] Working directory ${workingDirectory} is a home/root or missing path; skipping discovery`,
+          );
+        }
         workingDirectory = '';
       }
       this.detectedDirectory = workingDirectory;

--- a/packages/b2c-vs-extension/src/debugger/index.ts
+++ b/packages/b2c-vs-extension/src/debugger/index.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
-import {findCartridges} from '@salesforce/b2c-tooling-sdk/operations/code';
 import {B2CScriptDebugAdapter} from '@salesforce/b2c-tooling-sdk/operations/debug';
 import type {DebugSessionConfig} from '@salesforce/b2c-tooling-sdk/operations/debug';
 import * as vscode from 'vscode';
 import type {B2CExtensionConfig} from '../config-provider.js';
 import {markFeatureUsed} from '../telemetry.js';
+import {findCartridgesSafe} from '../workspace-discovery.js';
 
 const DEBUG_TYPE = 'b2c-script';
 
@@ -43,7 +43,7 @@ class B2CDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {
     }
 
     const workingDirectory = this.configProvider.getWorkingDirectory();
-    const cartridges = findCartridges(workingDirectory);
+    const cartridges = findCartridgesSafe(workingDirectory);
 
     const sessionConfig: DebugSessionConfig = {
       hostname: values.hostname,

--- a/packages/b2c-vs-extension/src/extension.ts
+++ b/packages/b2c-vs-extension/src/extension.ts
@@ -12,7 +12,7 @@ import * as https from 'https';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {B2CExtensionConfig} from './config-provider.js';
-import {workspaceHasDwJson} from './workspace-discovery.js';
+import {workspaceHasDwJson, isUnscannableRoot, WORKSPACE_DISCOVERY_MAX_DEPTH} from './workspace-discovery.js';
 import {CartridgeService} from './cartridges/cartridge-service.js';
 import {registerCap} from './cap/index.js';
 import {registerJobLogViewer} from './job-log-viewer.js';
@@ -84,10 +84,23 @@ async function updateStorefrontNextContext(
   log: vscode.OutputChannel,
 ): Promise<void> {
   const workingDir = configProvider.getWorkingDirectory();
-  log.appendLine(`[Workspace] Running detectWorkspaceType for cwd=${workingDir}`);
   let isStorefrontNext = false;
+  // Only run recursive workspace detection out of a concrete workspace folder.
+  // When there is no working directory (empty window) or it resolves to a
+  // home/root directory, skip it entirely: detectWorkspaceType('') would fall
+  // back to process.cwd() and recursively scan it on the extension-host thread
+  // (W-23618508). isUnscannableRoot('') is true, so this also covers the empty
+  // case.
+  if (isUnscannableRoot(workingDir)) {
+    log.appendLine('[Workspace] No concrete workspace folder; skipping storefront-next detection');
+    await vscode.commands.executeCommand('setContext', 'b2c-dx.isStorefrontNext', false);
+    return;
+  }
+  log.appendLine(`[Workspace] Running detectWorkspaceType for cwd=${workingDir}`);
   try {
-    const result = await detectWorkspaceType(workingDir);
+    // Depth-bound the scan as defense-in-depth so a deep tree can't stall
+    // activation (mirrors the MCP server's DISCOVERY_MAX_DEPTH).
+    const result = await detectWorkspaceType(workingDir, {maxDepth: WORKSPACE_DISCOVERY_MAX_DEPTH});
     log.appendLine(
       `[Workspace] Detection result: projectTypes=[${result.projectTypes.join(', ')}] matchedPatterns=[${result.matchedPatterns.join(', ')}]`,
     );

--- a/packages/b2c-vs-extension/src/jobs/jobs-commands.ts
+++ b/packages/b2c-vs-extension/src/jobs/jobs-commands.ts
@@ -17,7 +17,7 @@ import {
 } from '@salesforce/b2c-tooling-sdk/operations/jobs';
 import {getApiErrorMessage} from '@salesforce/b2c-tooling-sdk';
 import {createScaffoldRegistry, generateFromScaffold} from '@salesforce/b2c-tooling-sdk/scaffold';
-import {findCartridges} from '@salesforce/b2c-tooling-sdk/operations/code';
+import {findCartridgesSafe} from '../workspace-discovery.js';
 import type {B2CInstance} from '@salesforce/b2c-tooling-sdk';
 import JSZip from 'jszip';
 import * as fs from 'node:fs/promises';
@@ -421,7 +421,7 @@ async function promptForJobScaffoldPlan(
     return undefined;
   }
 
-  const cartridges = findCartridges(root.fsPath);
+  const cartridges = findCartridgesSafe(root.fsPath);
   if (cartridges.length === 0) {
     const choice = await vscode.window.showWarningMessage(
       'No cartridges found in this workspace. A custom job step must live in a cartridge. Create one first?',

--- a/packages/b2c-vs-extension/src/jobs/jobs-tree-provider.ts
+++ b/packages/b2c-vs-extension/src/jobs/jobs-tree-provider.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
-import {findCartridges} from '@salesforce/b2c-tooling-sdk/operations/code';
+import {findCartridgesSafe} from '../workspace-discovery.js';
 import {searchJobExecutions, type JobExecution} from '@salesforce/b2c-tooling-sdk/operations/jobs';
 import * as vscode from 'vscode';
 import type {B2CExtensionConfig} from '../config-provider.js';
@@ -657,7 +657,9 @@ export class JobsTreeDataProvider implements vscode.TreeDataProvider<JobsTreeNod
     // that the path-walk heuristic can only approximate. Falls back to the
     // heuristic when no workspace folder is open or nothing is discovered.
     const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    const knownCartridges = workspaceRoot ? findCartridges(workspaceRoot).map((c) => ({name: c.name, src: c.src})) : [];
+    const knownCartridges = workspaceRoot
+      ? findCartridgesSafe(workspaceRoot).map((c) => ({name: c.name, src: c.src}))
+      : [];
 
     const rows: WorkspaceJobTreeItem[] = [];
     const seen = new Set<string>();

--- a/packages/b2c-vs-extension/src/scaffold/scaffold-commands.ts
+++ b/packages/b2c-vs-extension/src/scaffold/scaffold-commands.ts
@@ -21,7 +21,7 @@ import {
   type ScaffoldGenerateResult,
   type SourceResult,
 } from '@salesforce/b2c-tooling-sdk/scaffold';
-import {findCartridges} from '@salesforce/b2c-tooling-sdk/operations/code';
+import {findCartridgesSafe} from '../workspace-discovery.js';
 import type {B2CExtensionConfig} from '../config-provider.js';
 import {registerSafeCommand} from '../safety.js';
 
@@ -95,7 +95,7 @@ async function runScaffoldWizard(
 
   // Filter scaffolds based on context: inside a cartridge → show only cartridge-targeting scaffolds
   const insideCartridge = contextPath
-    ? findCartridges(projectRoot).some((c) => contextPath === c.src || contextPath.startsWith(c.src + path.sep))
+    ? findCartridgesSafe(projectRoot).some((c) => contextPath === c.src || contextPath.startsWith(c.src + path.sep))
     : false;
 
   if (insideCartridge) {

--- a/packages/b2c-vs-extension/src/test/workspace-discovery.test.ts
+++ b/packages/b2c-vs-extension/src/test/workspace-discovery.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {findCartridgesSafe, isUnscannableRoot} from '../workspace-discovery.js';
+
+suite('workspace-discovery guards (W-23618508)', () => {
+  suite('isUnscannableRoot', () => {
+    test('treats empty string as unscannable', () => {
+      assert.strictEqual(isUnscannableRoot(''), true);
+    });
+
+    test('treats the filesystem root as unscannable', () => {
+      assert.strictEqual(isUnscannableRoot(path.parse(process.cwd()).root), true);
+    });
+
+    test('treats the home directory as unscannable', () => {
+      assert.strictEqual(isUnscannableRoot(os.homedir()), true);
+    });
+
+    test('does not flag a normal nested project directory', () => {
+      const nested = path.join(os.homedir(), 'code', 'some-project');
+      assert.strictEqual(isUnscannableRoot(nested), false);
+    });
+  });
+
+  suite('findCartridgesSafe', () => {
+    let tmpRoot: string;
+
+    setup(() => {
+      tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-ws-disc-'));
+    });
+
+    teardown(() => {
+      fs.rmSync(tmpRoot, {recursive: true, force: true});
+    });
+
+    test('returns [] for an empty working directory without scanning cwd', () => {
+      // Must NOT fall back to process.cwd() — that is the freeze the guard prevents.
+      assert.deepStrictEqual(findCartridgesSafe(''), []);
+      assert.deepStrictEqual(findCartridgesSafe(undefined), []);
+    });
+
+    test('returns [] for the home directory (never scans ~)', () => {
+      assert.deepStrictEqual(findCartridgesSafe(os.homedir()), []);
+    });
+
+    test('returns [] for the filesystem root', () => {
+      assert.deepStrictEqual(findCartridgesSafe(path.parse(tmpRoot).root), []);
+    });
+
+    test('discovers cartridges in a concrete workspace folder', () => {
+      const cartridgeDir = path.join(tmpRoot, 'cartridges', 'app_storefront_base');
+      fs.mkdirSync(cartridgeDir, {recursive: true});
+      fs.writeFileSync(path.join(cartridgeDir, '.project'), '<projectDescription/>');
+
+      const found = findCartridgesSafe(tmpRoot);
+      assert.deepStrictEqual(
+        found.map((c) => c.name),
+        ['app_storefront_base'],
+      );
+    });
+
+    test('depth-bounds the scan so a cartridge below the limit is not discovered', () => {
+      // WORKSPACE_DISCOVERY_MAX_DEPTH is 5; place a .project at depth 7 so the
+      // default bound skips it. This is the defense-in-depth behavior that keeps
+      // a huge/deep tree from stalling the extension host.
+      const deep = path.join(tmpRoot, 'a', 'b', 'c', 'd', 'e', 'f', 'deep_cartridge');
+      fs.mkdirSync(deep, {recursive: true});
+      fs.writeFileSync(path.join(deep, '.project'), '<projectDescription/>');
+
+      const found = findCartridgesSafe(tmpRoot);
+      assert.deepStrictEqual(found, []);
+    });
+  });
+});

--- a/packages/b2c-vs-extension/src/walkthrough/onboardingPanel.ts
+++ b/packages/b2c-vs-extension/src/walkthrough/onboardingPanel.ts
@@ -20,8 +20,9 @@ import {
   DetectionSummary,
   StepDetection,
 } from './stepDetection.js';
-import {findCartridges, listCodeVersions, type CodeVersion} from '@salesforce/b2c-tooling-sdk/operations/code';
+import {listCodeVersions, type CodeVersion} from '@salesforce/b2c-tooling-sdk/operations/code';
 import type {B2CExtensionConfig} from '../config-provider.js';
+import {findCartridgesSafe} from '../workspace-discovery.js';
 
 type InboundMessage =
   | {type: 'selectPersona'; personaId: PersonaId}
@@ -586,7 +587,7 @@ export class OnboardingPanel {
     let cartridgeSource: 'scaffolded' | 'only' | 'picker' | 'none' = 'none';
     if (workspaceRoot) {
       try {
-        const cartridges = findCartridges(workspaceRoot);
+        const cartridges = findCartridgesSafe(workspaceRoot);
         if (lastScaffolded && cartridges.some((c) => c.name === lastScaffolded)) {
           resolvedCartridge = lastScaffolded;
           cartridgeSource = 'scaffolded';

--- a/packages/b2c-vs-extension/src/workspace-discovery.ts
+++ b/packages/b2c-vs-extension/src/workspace-discovery.ts
@@ -3,11 +3,83 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
+import {
+  findCartridges,
+  type CartridgeMapping,
+  type FindCartridgesOptions,
+} from '@salesforce/b2c-tooling-sdk/operations/code';
+
+import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
 const DW_JSON_GLOB = '**/dw.json';
 const DISCOVERY_EXCLUDE_GLOB = '**/{node_modules,.git}/**';
+
+/**
+ * Maximum directory depth for recursive workspace scans (cartridge/storefront
+ * detection) triggered during activation. Depth is counted in path segments
+ * relative to the project directory; 5 covers the common layouts — a cartridge
+ * at `cartridges/<name>/.project` (depth 3) and a monorepo cartridge at
+ * `packages/<app>/cartridges/<name>/.project` (depth 5) — without fanning out
+ * across an unrelated deep tree. Mirrors the MCP server's `DISCOVERY_MAX_DEPTH`.
+ */
+export const WORKSPACE_DISCOVERY_MAX_DEPTH = 5;
+
+/**
+ * Returns true when `dir` is a location that should never be recursively
+ * scanned for a B2C project: the user's home directory or a filesystem root.
+ *
+ * The extension is activated implicitly by its `typescriptServerPlugins`
+ * contribution (VS Code loads TS server plugins for every JS/TS file), so it
+ * can wake up in an empty window or a home-directory-as-folder layout where the
+ * resolved working directory is `~` or `/`. Recursively globbing those roots on
+ * the shared extension-host thread would stall every other extension (see
+ * W-23618508), and it would not identify a meaningful workspace anyway. Callers
+ * skip discovery for these directories.
+ *
+ * An empty string (no working directory) is treated as unscannable.
+ */
+export function isUnscannableRoot(dir: string): boolean {
+  if (!dir) return true;
+  const resolved = path.resolve(dir);
+  // Filesystem root: parent equals self (handles `/` and Windows drive roots).
+  if (path.dirname(resolved) === resolved) {
+    return true;
+  }
+  const home = os.homedir();
+  return Boolean(home) && path.resolve(home) === resolved;
+}
+
+/**
+ * Extension-safe wrapper around the SDK's {@link findCartridges}.
+ *
+ * The bare SDK function resolves an empty/undefined directory to
+ * `process.cwd()` and, by default, walks the tree with no depth bound. In the
+ * VS Code extension that is dangerous: the extension is activated implicitly by
+ * its `typescriptServerPlugins` contribution and can wake up with no workspace
+ * folder or a home-directory-as-folder layout, where an unbounded recursive
+ * `**\/.project` glob would run on the shared extension-host thread and stall
+ * every other extension (W-23618508).
+ *
+ * This wrapper enforces two invariants for ALL extension cartridge discovery:
+ *   1. Never scan a home directory, filesystem root, or an empty/undefined
+ *      directory — returns `[]` instead (so we never fall back to cwd).
+ *   2. Always depth-bound the scan ({@link WORKSPACE_DISCOVERY_MAX_DEPTH}
+ *      unless the caller overrides `maxDepth`).
+ *
+ * Use this instead of importing `findCartridges` directly anywhere in the
+ * extension.
+ */
+export function findCartridgesSafe(
+  directory: string | undefined,
+  options: FindCartridgesOptions = {},
+): CartridgeMapping[] {
+  if (isUnscannableRoot(directory ?? '')) {
+    return [];
+  }
+  return findCartridges(directory, {maxDepth: WORKSPACE_DISCOVERY_MAX_DEPTH, ...options});
+}
 
 function pathDepth(relativePath: string): number {
   return relativePath.split(path.sep).length;


### PR DESCRIPTION
## Summary

Fixes **W-23618508**: the B2C Commerce VS Code extension was blocking other extensions when opened in an empty (no-folder) or non-B2C workspace. Clicking a B2C DX activity-bar icon in an empty window would spin forever, and other extensions (e.g. Claude Code) would also show a loading badge with an empty, un-activated panel.

### Root cause
VS Code runs all extensions in a single shared extension-host process, so synchronous CPU work in one extension's activation stalls the event loop and makes every other extension appear stuck "activating" (the spinner + empty panels in the repro).

The extension can be activated in an empty window by several events — clicking a B2C DX view icon (`onView:*`), or opening any JS/TS file (the extension contributes a TypeScript server plugin, which VS Code loads for all JS/TS files). Whatever the trigger, `activate()` → `activateInner()` then ran heavy **synchronous, unbounded** filesystem work:

1. `detectWorkingDirectory()` fell back to `process.cwd()` when there were no workspace folders — the extension host's arbitrary cwd, often the user's **home directory**.
2. Eager activation work then ran unbounded `globSync('**/.project')` walks on the shared extension-host thread (via `registerScriptTypes` → `CartridgeService.getCartridges()` → `findCartridges(cwd)`, and `updateStorefrontNextContext()` → `detectWorkspaceType(cwd)`).

Scanning the whole home tree synchronously freezes the extension host, blocking every other extension.

### Fix (all in `packages/b2c-vs-extension`)
Do no filesystem discovery without a concrete workspace folder, and never let `findCartridges` scan out of home/root:

- **`workspace-discovery.ts`**: added `isUnscannableRoot(dir)` (empty / home dir / filesystem root) and `findCartridgesSafe(dir, opts)` — the single entry point all extension cartridge discovery now uses. It returns `[]` for unscannable roots (never falls back to `process.cwd()`) and depth-bounds every scan (`WORKSPACE_DISCOVERY_MAX_DEPTH = 5`). Mirrors the MCP server's existing `registry.ts` home/root guard.
- **`config-provider.ts`**: `detectWorkingDirectory()` returns `''` (not `process.cwd()`) when there are no workspace folders; `resolveAsync` skips resolution/discovery for home/root/missing dirs.
- **`extension.ts`**: `updateStorefrontNextContext()` skips detection for unscannable roots and depth-bounds the scan otherwise.
- Routed **all** `findCartridges` call sites through `findCartridgesSafe` (cartridge-service, code-sync-manager, deploy-command, debugger, jobs-commands, jobs-tree-provider, scaffold-commands, onboardingPanel) so no path can recursively scan out of home.

## Manual testing

Reproduce the original report:

1. Install the VSIX and open VS Code → **File → New Window** (empty window, no folder).
2. Click any **B2C DX** activity-bar icon (WebDAV Explorer, Sandbox Explorer, etc.).
   - **Before:** the B2C icon shows a spinner that never resolves; clicking another extension's icon (e.g. Claude Code) also shows a spinner with an empty, un-activated panel — the extension host is blocked.
   - **After:** the B2C DX views load immediately (empty/welcome state) and other extensions activate normally with no spinner. **Output → B2C DX** logs `No workspace folders open; skipping filesystem discovery`.
3. (Also) open your **home directory as a folder** and confirm the extension does not hang and does no recursive `.project` scan.
4. (Regression) open a real B2C project (with `dw.json` and cartridges) and confirm cartridge discovery, code sync, debugger, and Script API IntelliSense still work as before.
