### PR TITLE
fix(b2c-skills): remove fabricated APIs from b2c skills

### DIFF
--- a/.changeset/fix-b2c-skills-fabricated-apis.md
+++ b/.changeset/fix-b2c-skills-fabricated-apis.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Correct B2C agent skill examples to use supported Script APIs, hook extension points, OCAPI contracts, and schema-valid metadata. Generated implementations no longer rely on nonexistent APIs or invalid request and response shapes.

--- a/skills/b2c/skills/b2c-custom-job-steps/references/CHUNK-ORIENTED.md
+++ b/skills/b2c/skills/b2c-custom-job-steps/references/CHUNK-ORIENTED.md
@@ -65,8 +65,10 @@ exports.beforeStep = function (parameters, stepExecution) {
     var outputPath = parameters.OutputFile || '/export/products.csv';
     var outputFile = new File(File.IMPEX + outputPath);
 
-    // Ensure parent directory exists
-    outputFile.parentFile.mkdirs();
+    // Ensure the directory exists. dw.io.File has no parent accessor, so
+    // derive the directory from the path and create it directly.
+    var dirPath = outputPath.substring(0, outputPath.lastIndexOf('/'));
+    new File(File.IMPEX + dirPath).mkdirs();
 
     writer = new FileWriter(outputFile, 'UTF-8');
     writer.writeLine('ID,Name,Brand,Price,Online');

--- a/skills/b2c/skills/b2c-custom-job-steps/references/TASK-ORIENTED.md
+++ b/skills/b2c/skills/b2c-custom-job-steps/references/TASK-ORIENTED.md
@@ -44,10 +44,10 @@ exports.execute = function (parameters, stepExecution) {
     // Access job information
     var jobId = stepExecution.jobExecution.jobID;
     var stepId = stepExecution.stepID;
-    var startTime = stepExecution.startTime;
+    var stepTypeId = stepExecution.stepTypeID;
 
-    // Access custom exit status if set
-    var exitStatus = stepExecution.exitStatus;
+    // Read a declared step parameter by name
+    var batchSize = stepExecution.getParameterValue('BatchSize');
 };
 ```
 

--- a/skills/b2c/skills/b2c-custom-objects/SKILL.md
+++ b/skills/b2c/skills/b2c-custom-objects/SKILL.md
@@ -161,7 +161,7 @@ Authorization: Bearer {token}
 ### Search Custom Objects
 
 ```http
-POST /s/-/dw/data/v25_6/custom_object_search/{object_type}
+POST /s/-/dw/data/v25_6/custom_objects_search/{object_type}
 Authorization: Bearer {token}
 Content-Type: application/json
 
@@ -169,7 +169,7 @@ Content-Type: application/json
     "query": {
         "bool_query": {
             "must": [
-                { "term_query": { "field": "c_isActive", "value": true } }
+                { "term_query": { "fields": ["c_isActive"], "operator": "is", "values": [true] } }
             ]
         }
     },
@@ -184,9 +184,9 @@ Content-Type: application/json
 
 | Query Type | Description | Example |
 |------------|-------------|---------|
-| `term_query` | Exact match | `{"field": "c_status", "value": "active"}` |
+| `term_query` | Exact match / comparison | `{"fields": ["c_status"], "operator": "is", "values": ["active"]}` |
 | `text_query` | Full-text search | `{"fields": ["c_name"], "search_phrase": "test"}` |
-| `range_query` | Range comparison | `{"field": "c_count", "from": 1, "to": 10}` |
+| `filtered_query` | Query plus a filter — use with `range_filter` for ranges | `{"query": {"match_all_query": {}}, "filter": {"range_filter":{"field": "c_count", "from": 1, "to": 10}}}` |
 | `bool_query` | Combine queries | `{"must": [...], "should": [...], "must_not": [...]}` |
 | `match_all_query` | Match all records | `{}` |
 

--- a/skills/b2c/skills/b2c-custom-objects/references/OCAPI-SEARCH.md
+++ b/skills/b2c/skills/b2c-custom-objects/references/OCAPI-SEARCH.md
@@ -5,7 +5,7 @@ Full reference for searching custom objects via OCAPI Data API.
 ## Search Endpoint
 
 ```http
-POST /s/-/dw/data/v24_1/custom_object_search/{object_type}
+POST /s/-/dw/data/v{version}/custom_objects_search/{object_type}
 Authorization: Bearer {token}
 Content-Type: application/json
 ```
@@ -40,28 +40,30 @@ Content-Type: application/json
 {
     "query": {
         "term_query": {
-            "field": "c_status",
-            "value": "active"
+            "fields": ["c_status"],
+            "operator": "is",
+            "values": ["active"]
         }
     }
 }
 ```
 
-Supports operators:
-- `is` (default): Exact match
+`fields` is a required array, and `operator` is required. `values`, when used, is an array;
+omit it for `is_null` and `is_not_null`. Supported operators:
+- `is`: Exact match
 - `one_of`: Match any value in array
 - `is_null`: Check for null
 - `is_not_null`: Check for non-null
-- `less`, `greater`, `less_or_equal`, `greater_or_equal`: Comparisons
+- `less`, `greater`: Comparisons
 - `not_in`: Exclude values
 - `neq`: Not equal
 
 ```json
 {
     "term_query": {
-        "field": "c_priority",
+        "fields": ["c_priority"],
         "operator": "greater",
-        "value": 5
+        "values": [5]
     }
 }
 ```
@@ -69,7 +71,7 @@ Supports operators:
 ```json
 {
     "term_query": {
-        "field": "c_status",
+        "fields": ["c_status"],
         "operator": "one_of",
         "values": ["active", "pending"]
     }
@@ -89,17 +91,24 @@ Supports operators:
 }
 ```
 
-### Range Query
+### Range Filter
+
+There is no `range_query`. Ranges are expressed as a `range_filter` inside a `filtered_query`:
 
 ```json
 {
     "query": {
-        "range_query": {
-            "field": "c_count",
-            "from": 1,
-            "to": 100,
-            "from_inclusive": true,
-            "to_inclusive": false
+        "filtered_query": {
+            "query": { "match_all_query": {} },
+            "filter": {
+                "range_filter": {
+                    "field": "c_count",
+                    "from": 1,
+                    "to": 100,
+                    "from_inclusive": true,
+                    "to_inclusive": false
+                }
+            }
         }
     }
 }
@@ -114,14 +123,14 @@ Combine multiple queries:
     "query": {
         "bool_query": {
             "must": [
-                { "term_query": { "field": "c_isActive", "value": true } },
-                { "term_query": { "field": "c_type", "value": "premium" } }
+                { "term_query": { "fields": ["c_isActive"], "operator": "is", "values": [true] } },
+                { "term_query": { "fields": ["c_type"], "operator": "is", "values": ["premium"] } }
             ],
             "should": [
-                { "term_query": { "field": "c_priority", "operator": "greater", "value": 5 } }
+                { "term_query": { "fields": ["c_priority"], "operator": "greater", "values": [5] } }
             ],
             "must_not": [
-                { "term_query": { "field": "c_status", "value": "deleted" } }
+                { "term_query": { "fields": ["c_status"], "operator": "is", "values": ["deleted"] } }
             ]
         }
     }
@@ -159,9 +168,10 @@ Combine query with filter (filter doesn't affect scoring):
                 }
             },
             "filter": {
-                "term_query": {
+                "term_filter": {
                     "field": "c_isActive",
-                    "value": true
+                    "operator": "is",
+                    "values": [true]
                 }
             }
         }
@@ -180,8 +190,9 @@ Query nested objects:
             "path": "c_addresses",
             "query": {
                 "term_query": {
-                    "field": "c_addresses.city",
-                    "value": "Boston"
+                    "fields": ["c_addresses.city"],
+                    "operator": "is",
+                    "values": ["Boston"]
                 }
             }
         }
@@ -218,29 +229,24 @@ Query nested objects:
 
 ## Response Structure
 
+This example assumes `MyType` defines a string key attribute named `customObjectId`.
+
 ```json
 {
-    "_v": "24.1",
-    "count": 25,
-    "data": [
-        {
-            "key_property": "key1",
-            "c_name": "Test Object",
-            "c_status": "active",
-            "creation_date": "2024-01-15T10:30:00.000Z"
-        }
-    ],
-    "expand": [],
+    "count": 1,
     "hits": [
         {
-            "data": { },
-            "relevant_attributes": ["c_name"]
+            "key_property": "customObjectId",
+            "key_value_string": "key1",
+            "object_type": "MyType",
+            "c_name": "Test Object",
+            "c_status": "active"
         }
     ],
-    "query": { },
+    "query": { "match_all_query": {} },
     "select": "(**)",
     "start": 0,
-    "total": 150
+    "total": 1
 }
 ```
 
@@ -248,11 +254,11 @@ Query nested objects:
 
 ```bash
 # First page
-curl -X POST ".../custom_object_search/MyType" \
+curl -X POST ".../custom_objects_search/MyType" \
   -d '{"query":{"match_all_query":{}},"start":0,"count":25}'
 
 # Second page
-curl -X POST ".../custom_object_search/MyType" \
+curl -X POST ".../custom_objects_search/MyType" \
   -d '{"query":{"match_all_query":{}},"start":25,"count":25}'
 ```
 
@@ -265,12 +271,13 @@ Find active premium configs modified in the last 7 days:
     "query": {
         "bool_query": {
             "must": [
-                { "term_query": { "field": "c_isActive", "value": true } },
-                { "term_query": { "field": "c_tier", "value": "premium" } },
+                { "term_query": { "fields": ["c_isActive"], "operator": "is", "values": [true] } },
+                { "term_query": { "fields": ["c_tier"], "operator": "is", "values": ["premium"] } },
                 {
-                    "range_query": {
-                        "field": "last_modified",
-                        "from": "2024-01-08T00:00:00.000Z"
+                    "term_query": {
+                        "fields": ["last_modified"],
+                        "operator": "greater",
+                        "values": ["2024-01-08T00:00:00.000Z"]
                     }
                 }
             ]

--- a/skills/b2c/skills/b2c-hooks/references/SYSTEM-HOOKS.md
+++ b/skills/b2c/skills/b2c-hooks/references/SYSTEM-HOOKS.md
@@ -26,51 +26,69 @@ Calculate hooks control basket and order calculation logic.
 }
 ```
 
-### Implementation
+### SFRA Implementation
+
+SFRA registers all three extension points to
+`app_storefront_base/cartridge/scripts/hooks/cart/calculate.js`. Do not call `TaxMgr.applyTax()` from
+inside `calculateTax` — `applyTax` belongs in `dw.order.calculate` and dispatches to
+`dw.order.calculateTax` itself.
 
 ```javascript
 // calculate.js
 var Status = require('dw/system/Status');
-var HookMgr = require('dw/system/HookMgr');
 var ShippingMgr = require('dw/order/ShippingMgr');
 var TaxMgr = require('dw/order/TaxMgr');
+var collections = require('*/cartridge/scripts/util/collections');
 
-exports.calculate = function(lineItemCtnr) {
-    // 1. Calculate product prices
-    calculateProductPrices(lineItemCtnr);
-
-    // 2. Calculate shipping
-    HookMgr.callHook('dw.order.calculateShipping', 'calculateShipping', lineItemCtnr);
-
-    // 3. Calculate promotions
-    calculatePromotions(lineItemCtnr);
-
-    // 4. Calculate tax
-    HookMgr.callHook('dw.order.calculateTax', 'calculateTax', lineItemCtnr);
-
-    // 5. Calculate totals
-    lineItemCtnr.updateTotals();
-
+exports.calculateShipping = function(basket) {
+    ShippingMgr.applyShippingCost(basket);
     return new Status(Status.OK);
 };
 
-exports.calculateShipping = function(lineItemCtnr) {
-    var shipments = lineItemCtnr.shipments.iterator();
-    while (shipments.hasNext()) {
-        var shipment = shipments.next();
-        var method = shipment.shippingMethod;
-        if (method) {
-            var cost = ShippingMgr.getShippingCost(method, shipment);
-            shipment.setShippingLineItem(method);
-            shipment.shippingLineItem.setPriceValue(cost.amount.value);
+exports.calculateTax = function(basket) {
+    var basketCalculationHelpers = require('*/cartridge/scripts/helpers/basketCalculationHelpers');
+    var taxes = basketCalculationHelpers.calculateTaxes(basket);
+    var taxesMap = {};
+
+    taxes.taxes.forEach(function (item) {
+        taxesMap[item.uuid] = { value: item.value, amount: item.amount };
+    });
+
+    var lineItems = basket.getAllLineItems();
+
+    collections.forEach(lineItems, function (lineItem) {
+        var tax = taxesMap[lineItem.UUID];
+
+        if (tax) {
+            if (tax.amount) {
+                lineItem.updateTaxAmount(tax.value);
+            } else {
+                lineItem.updateTax(tax.value);
+            }
+        } else if (lineItem.taxClassID === TaxMgr.customRateTaxClassID) {
+            lineItem.updateTax(lineItem.taxRate);
+        } else {
+            lineItem.updateTax(null);
+        }
+    });
+
+    // Order-level price adjustments, including order-level shipping price adjustments
+    if (!basket.getPriceAdjustments().empty || !basket.getShippingPriceAdjustments().empty) {
+        if (collections.first(basket.getPriceAdjustments(), function (priceAdjustment) {
+            return taxesMap[priceAdjustment.UUID] === null;
+        }) || collections.first(basket.getShippingPriceAdjustments(), function (shippingPriceAdjustment) {
+            return taxesMap[shippingPriceAdjustment.UUID] === null;
+        })) {
+            basket.updateOrderLevelPriceAdjustmentTax();
         }
     }
-    return new Status(Status.OK);
-};
 
-exports.calculateTax = function(lineItemCtnr) {
-    // Use built-in tax calculation or external service
-    TaxMgr.applyDefaultTaxes(lineItemCtnr);
+    if (taxes.custom) {
+        Object.keys(taxes.custom).forEach(function (key) {
+            basket.custom[key] = taxes.custom[key];
+        });
+    }
+
     return new Status(Status.OK);
 };
 ```
@@ -278,27 +296,50 @@ Registration:
 
 ## Checkout Hooks
 
-| Extension Point | Function | Purpose |
-|-----------------|----------|---------|
-| `dw.order.hooks.validateOrder` | `validateOrder(basket)` | Validate before order creation |
+| Extension Point                    | Function                                    | Purpose                                |
+| ---------------------------------- | ------------------------------------------- | -------------------------------------- |
+| `dw.order.populateCustomerDetails` | `populateCustomerDetails(basket, customer)` | Populate customer data onto the basket |
+
+> **Note**: `dw.order.hooks` is the _package_ holding the hook interfaces — it is never part of the
+> extension point name. There is no `dw.order.hooks.validateOrder` system hook; order validation for
+> OCAPI/SCAPI order requests is `dw.ocapi.shop.order.validateOrder`, documented in
+> [OCAPI/SCAPI Hooks](./OCAPI-SCAPI-HOOKS.md).
 
 ## Return Hooks
 
-| Extension Point | Function | Purpose |
-|-----------------|----------|---------|
-| `dw.order.hooks.returnChangeStatus` | `changeStatus(return, returnWO)` | Handle return status changes |
+> **Inactive by default.** Return and shipping order hooks are order post-processing APIs and
+> **throw an exception if accessed**. Activation requires approval from Product Management.
+
+| Extension Point                      | Function                                                   | Purpose                      |
+| ------------------------------------ | ---------------------------------------------------------- | ---------------------------- |
+| `dw.order.return.createReturn`       | `createReturn(returnWO: ReturnWO)`                         | Create the return record     |
+| `dw.order.return.addReturnItem`      | `addReturnItem(retrn: Return, returnItemWO: ReturnItemWO)` | Add an item to a return      |
+| `dw.order.return.changeStatus`       | `changeStatus(retrn: Return, returnWO: ReturnWO)`          | Handle return status changes |
+| `dw.order.return.afterStatusChange`  | `afterStatusChange(retrn: Return)`                         | React after a status change  |
+| `dw.order.return.notifyStatusChange` | `notifyStatusChange(retrn: Return)`                        | Notify on status change      |
 
 ## Shipping Order Hooks
 
-| Extension Point | Function | Purpose |
-|-----------------|----------|---------|
-| `dw.order.hooks.shippingOrderChangeStatus` | `changeStatus(shippingOrder, shippingOrderWO)` | Handle shipping order status |
+> **Inactive by default.** Same order post-processing restriction as [Return Hooks](#return-hooks).
+
+| Extension Point                                      | Function                                                                       | Purpose                              |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------ |
+| `dw.order.shippingorder.prepareCreateShippingOrders` | `prepareCreateShippingOrders(order: Order)`                                    | Prepare shipping order creation      |
+| `dw.order.shippingorder.createShippingOrders`        | `createShippingOrders(order: Order)`                                           | Create shipping orders for an order  |
+| `dw.order.shippingorder.resolveShippingOrder`        | `resolveShippingOrder(shippingOrderWO: ShippingOrderWO)`                       | Resolve the target shipping order    |
+| `dw.order.shippingorder.changeStatus`                | `changeStatus(shippingOrder: ShippingOrder, shippingOrderWO: ShippingOrderWO)` | Handle shipping order status changes |
+| `dw.order.shippingorder.afterStatusChange`           | `afterStatusChange(shippingOrder: ShippingOrder)`                              | React after a status change          |
+| `dw.order.shippingorder.notifyStatusChange`          | `notifyStatusChange(shippingOrder: ShippingOrder)`                             | Notify on status change              |
+| `dw.order.shippingorder.updateShippingOrderItem`     | `updateShippingOrderItem(shippingOrder: ShippingOrder, itemWO: ShippingOrderItemWO)` | Update a shipping order item    |
+| `dw.order.shippingorder.setShippingOrderShipped`     | `setShippingOrderShipped(shippingOrderWO: ShippingOrderWO)`                    | Mark a shipping order shipped        |
+| `dw.order.shippingorder.setShippingOrderCancelled`   | `setShippingOrderCancelled(shippingOrderWO: ShippingOrderWO)`                  | Mark a shipping order cancelled      |
+| `dw.order.shippingorder.setShippingOrderWarehouse`   | `setShippingOrderWarehouse(shippingOrderWO: ShippingOrderWO)`                  | Set the warehouse                    |
 
 ## Basket Merge Hooks
 
-| Extension Point | Function | Purpose |
-|-----------------|----------|---------|
-| `dw.order.hooks.basketMerge` | `merge(sourceBasket, targetBasket)` | Custom basket merge logic |
+| Extension Point        | Function                             | Purpose                   |
+| ---------------------- | ------------------------------------ | ------------------------- |
+| `dw.order.mergeBasket` | `mergeBasket(source, currentBasket)` | Custom basket merge logic |
 
 ## Request Hooks
 

--- a/skills/b2c/skills/b2c-localization/references/PATTERNS.md
+++ b/skills/b2c/skills/b2c-localization/references/PATTERNS.md
@@ -287,13 +287,21 @@ function sendWelcomeEmail(customer, locale) {
     mail.send();
 }
 
-// Helper for getting strings in specific locale
+// Helper for getting strings in a specific locale.
+// There is no API for reading a bundle in an arbitrary locale directly —
+// switch the request locale around the lookup and restore it afterwards.
 function getLocalizedString(key, bundle, locale) {
-    // This requires reading property files directly for non-current locale
-    // Or storing translations in a custom object
-    var ResourceBundle = require('dw/web/ResourceBundle');
-    var rb = ResourceBundle.getBundle(bundle, locale);
-    return rb.getString(key);
+    var previous = request.locale;
+    // Returns false if the locale is not allowed for the current site.
+    if (!request.setLocale(locale)) {
+        return Resource.msg(key, bundle, null);
+    }
+
+    try {
+        return Resource.msg(key, bundle, null);
+    } finally {
+        request.setLocale(previous);
+    }
 }
 ```
 

--- a/skills/b2c/skills/b2c-metadata/SKILL.md
+++ b/skills/b2c/skills/b2c-metadata/SKILL.md
@@ -367,17 +367,16 @@ var maxItems = Site.current.getCustomPreferenceValue('maxItemsPerPage');
     <description xml:lang="x-default">Description for BM tooltip</description>
     <type>string</type>
     <localizable-flag>false</localizable-flag>
-    <mandatory-flag>false</mandatory-flag>
-    <externally-managed-flag>false</externally-managed-flag>
-    <visible-flag>true</visible-flag>
     <site-specific-flag>false</site-specific-flag>
-    <order-required-flag>false</order-required-flag>
+    <mandatory-flag>false</mandatory-flag>
     <searchable-flag>false</searchable-flag>
+    <visible-flag>true</visible-flag>
+    <externally-managed-flag>false</externally-managed-flag>
+    <order-required-flag>false</order-required-flag>
     <min-length>0</min-length>
-    <max-length>256</max-length>
+    <field-length>256</field-length>
+    <unit xml:lang="x-default">kg</unit>
     <default-value>default</default-value>
-    <select-mode>none</select-mode>
-    <unit>kg</unit>
 </attribute-definition>
 ```
 

--- a/skills/b2c/skills/b2c-metadata/references/XML-EXAMPLES.md
+++ b/skills/b2c/skills/b2c-metadata/references/XML-EXAMPLES.md
@@ -52,7 +52,7 @@ b2c docs schema --list
                 <mandatory-flag>false</mandatory-flag>
                 <externally-managed-flag>true</externally-managed-flag>
                 <min-length>0</min-length>
-                <max-length>50</max-length>
+                <field-length>50</field-length>
             </attribute-definition>
 
             <!-- Enum attribute -->
@@ -201,7 +201,7 @@ b2c docs schema --list
             <display-name xml:lang="x-default">Email Address</display-name>
             <type>string</type>
             <min-length>5</min-length>
-            <max-length>256</max-length>
+            <field-length>256</field-length>
         </key-definition>
 
         <attribute-definitions>
@@ -238,7 +238,7 @@ b2c docs schema --list
                         <value>new-arrivals</value>
                     </value-definition>
                     <value-definition>
-                        <display xml:lang="x-default">Tips & Tricks</display>
+                        <display xml:lang="x-default">Tips &amp; Tricks</display>
                         <value>tips</value>
                     </value-definition>
                 </value-definitions>
@@ -340,8 +340,8 @@ Preferences can be set per instance type or for all instances:
             <custom-attribute attribute-id="weight">2.5</custom-attribute>
             <custom-attribute attribute-id="certifications">energy-star</custom-attribute>
             <custom-attribute attribute-id="certifications">ul-listed</custom-attribute>
-            <custom-attribute attribute-id="localDescription" xml:lang="en_US">US Description</custom-attribute>
-            <custom-attribute attribute-id="localDescription" xml:lang="fr_FR">Description en Français</custom-attribute>
+            <custom-attribute attribute-id="localDescription" xml:lang="en-US">US Description</custom-attribute>
+            <custom-attribute attribute-id="localDescription" xml:lang="fr-FR">Description en Français</custom-attribute>
         </custom-attributes>
     </product>
 </catalog>

--- a/skills/b2c/skills/b2c-page-designer/SKILL.md
+++ b/skills/b2c/skills/b2c-page-designer/SKILL.md
@@ -93,38 +93,38 @@ Page Designer files are in the cartridge's `experience` directory:
 
 var Template = require('dw/util/Template');
 var HashMap = require('dw/util/HashMap');
+var PageRenderHelper = require('*/cartridge/experience/utilities/PageRenderHelper.js');
 
 module.exports.render = function (context) {
     var model = new HashMap();
     var page = context.page;
 
-    model.put('page', page);
+    model.page = page;
+    model.regions = PageRenderHelper.getRegionModelRegistry(page);
 
     return new Template('experience/pages/homepage').render(model).text;
 };
 ```
 
-### Page Template (templates/experience/pages/homepage.isml)
+### Page Template (templates/default/experience/pages/homepage.isml)
 
-> Illustrative SFRA pattern using custom PageRenderHelper utility; confirm current region rendering API with `docs_read dw.experience.PageMgr` (use PageMgr.renderRegion() for canonical approach).
+> This follows SFRA's region-model pattern: the page script builds `pdict.regions` with
+> `PageRenderHelper.getRegionModelRegistry(page)`, and each `RegionModel.render()` call delegates to
+> the platform's `PageMgr.renderRegion()` with SFRA's render settings.
 
 ```html
 <isdecorate template="common/layout/page">
-    <isscript>
-        var PageRenderHelper = require('*/cartridge/experience/utilities/PageRenderHelper');
-    </isscript>
-
     <div class="homepage">
         <div class="hero-region">
-            <isprint value="${PageRenderHelper.renderRegion(pdict.page.getRegion('hero'))}" encoding="off"/>
+            <isprint value="${pdict.regions.hero.render()}" encoding="off"/>
         </div>
 
         <div class="content-region">
-            <isprint value="${PageRenderHelper.renderRegion(pdict.page.getRegion('content'))}" encoding="off"/>
+            <isprint value="${pdict.regions.content.render()}" encoding="off"/>
         </div>
 
         <div class="footer-region">
-            <isprint value="${PageRenderHelper.renderRegion(pdict.page.getRegion('footer'))}" encoding="off"/>
+            <isprint value="${pdict.regions.footer.render()}" encoding="off"/>
         </div>
     </div>
 </isdecorate>

--- a/skills/b2c/skills/b2c-page-designer/references/META-DEFINITIONS.md
+++ b/skills/b2c/skills/b2c-page-designer/references/META-DEFINITIONS.md
@@ -260,7 +260,10 @@ Component with nested regions:
 
 **Script for container:**
 
-> Illustrative SFRA pattern using custom PageRenderHelper utility; confirm current region rendering API with `docs_read dw.experience.PageMgr` (use PageMgr.renderRegion() for canonical approach).
+> This follows SFRA's container-component pattern: build the region registry with
+> `PageRenderHelper.getRegionModelRegistry(component)`, pass it to the template as `regions`, and
+> call `RegionModel.render()` in ISML. The region model preserves SFRA's region and component render
+> settings before delegating to `PageMgr.renderRegion()`.
 
 ```javascript
 'use strict';
@@ -273,15 +276,23 @@ module.exports.render = function (context) {
     var model = new HashMap();
     var component = context.component;
 
-    model.put('leftWidth', context.content.leftWidth || '50%');
-    model.put('gap', context.content.gap || 'medium');
-
-    // Render nested regions
-    model.put('leftRegion', PageRenderHelper.renderRegion(component.getRegion('left')));
-    model.put('rightRegion', PageRenderHelper.renderRegion(component.getRegion('right')));
+    model.regions = PageRenderHelper.getRegionModelRegistry(component);
 
     return new Template('experience/components/twocolumn').render(model).text;
 };
+```
+
+**Template for container:**
+
+```html
+<div class="two-column">
+    <div class="left-column">
+        <isprint value="${pdict.regions.left.render()}" encoding="off"/>
+    </div>
+    <div class="right-column">
+        <isprint value="${pdict.regions.right.render()}" encoding="off"/>
+    </div>
+</div>
 ```
 
 ## Page Script Context

--- a/skills/b2c/skills/b2c-querying-data/SKILL.md
+++ b/skills/b2c/skills/b2c-querying-data/SKILL.md
@@ -86,9 +86,7 @@ psm.search();
 
 // Get available refinement values for the current result set
 var refinements = psm.getRefinements();
-var colorValues = refinements.getNextLevelRefinementValues(
-    refinements.getRefinementDefinitionByName('color')
-);
+var colorValues = refinements.getAllRefinementValues('color');
 ```
 
 ### ProductSearchModel API Summary

--- a/skills/b2c/skills/b2c-querying-data/references/PERFORMANCE-APIS.md
+++ b/skills/b2c/skills/b2c-querying-data/references/PERFORMANCE-APIS.md
@@ -26,7 +26,8 @@ Complete reference for index-friendly vs database-intensive APIs in B2C Commerce
 | `ProductSearchModel.setCategoryID(id)` | Replaces `Category.getProducts()` |
 | `ProductSearchModel.setOrderableProductsOnly(true)` | Replaces `Category.getOnlineProducts()` + availability check |
 | `ProductSearchModel.getRefinements()` | Index-backed refinement values |
-| `ProductSearchRefinements.getNextLevelRefinementValues()` | Replaces `Category.getOnlineSubCategories()` for nav |
+| `ProductSearchRefinements.getNextLevelCategoryRefinementValues(category)` | Replaces `Category.getOnlineSubCategories()` for nav |
+| `ProductSearchRefinements.getAllRefinementValues(attributeName)` | Refinement values for one attribute |
 | `ProductSearchModel.getProductSearchHits()` | Efficient result iteration |
 | `ProductSearchHit.getMinPrice()` / `getMaxPrice()` | Replaces `Product.getPriceModel()` in search |
 | `ProductSearchHit.getRepresentedProductIDs()` | Replaces `Product.getVariants()` in search |

--- a/skills/b2c/skills/b2c-webservices/references/SOAP-SERVICES.md
+++ b/skills/b2c/skills/b2c-webservices/references/SOAP-SERVICES.md
@@ -125,6 +125,7 @@ Use `WSUtil` for WS-Security headers:
 
 ```javascript
 var WSUtil = require('dw/ws/WSUtil');
+var HashMap = require('dw/util/HashMap');
 
 var secureService = LocalServiceRegistry.createService('my.secure.soap', {
     initServiceClient: function (svc) {
@@ -133,15 +134,20 @@ var secureService = LocalServiceRegistry.createService('my.secure.soap', {
 
     createRequest: function (svc, params) {
         var stub = svc.serviceClient;
-
-        // Add WS-Security UsernameToken
         var credential = svc.configuration.credential;
-        WSUtil.setWSSecurityUsernameToken(
-            stub,
-            credential.user,
-            credential.password,
-            null  // nonce (optional)
-        );
+
+        // Add a WS-Security UsernameToken via the WS-Security config map.
+        // The password is passed through the secrets map, keyed by user name.
+        var requestConfig = new HashMap();
+        requestConfig.put(WSUtil.WS_ACTION, WSUtil.WS_USERNAME_TOKEN);
+        requestConfig.put(WSUtil.WS_USER, credential.user);
+        requestConfig.put(WSUtil.WS_PASSWORD_TYPE, WSUtil.WS_PW_TEXT);
+
+        var secrets = new HashMap();
+        secrets.put(credential.user, credential.password);
+        requestConfig.put(WSUtil.WS_SECRETS_MAP, secrets);
+
+        WSUtil.setWSSecurityConfig(stub, requestConfig, null);
 
         var request = new webreferences2.SecureServiceWSDL.SecureRequest();
         request.setData(params.data);
@@ -165,16 +171,27 @@ var secureService = LocalServiceRegistry.createService('my.secure.soap', {
 
 ### WSUtil Methods
 
-| Method | Description |
-|--------|-------------|
-| `setWSSecurityUsernameToken(stub, user, pass, nonce)` | Add UsernameToken header |
-| `setProperty(stub, property, value)` | Set SOAP property |
-| `addSOAPHeader(stub, namespace, name, value)` | Add custom SOAP header |
+| Method                                                           | Description                                          |
+| ---------------------------------------------------------------- | ---------------------------------------------------- |
+| `setWSSecurityConfig(port, requestConfigMap, responseConfigMap)` | Configure WS-Security for request and response       |
+| `setUserNamePassword(user, password, port)`                      | HTTP Basic authentication (weaker than WS-Security)  |
+| `setProperty(key, value, port)`                                  | Set a SOAP property                                  |
+| `getProperty(key, port)`                                         | Read a SOAP property                                 |
+| `addSOAPHeader(port, xml, mustUnderstand, actor)`                | Add a custom SOAP header (2nd arg is the header XML) |
+| `clearSOAPHeaders(port)`                                         | Remove previously added headers                      |
+| `setRequestTimeout(ms, port)` / `setConnectionTimeout(ms, port)` | Timeouts                                             |
+| `setHTTPRequestHeader(port, key, value)`                         | Set an HTTP-level request header                     |
+
+Key WS-Security config constants: `WS_ACTION`, `WS_USERNAME_TOKEN`, `WS_TIMESTAMP`, `WS_SIGNATURE`,
+`WS_ENCRYPT`, `WS_NO_SECURITY`, `WS_USER`, `WS_PASSWORD_TYPE` (`WS_PW_TEXT` / `WS_PW_DIGEST`), and
+`WS_SECRETS_MAP`. There is no `setWSSecurityUsernameToken()` and no nonce generator — a UsernameToken
+is configured through the map shown above.
 
 ### WS-Security with Timestamps
 
 ```javascript
 var WSUtil = require('dw/ws/WSUtil');
+var HashMap = require('dw/util/HashMap');
 
 var timestampService = LocalServiceRegistry.createService('my.timestamp.soap', {
     initServiceClient: function (svc) {
@@ -186,15 +203,18 @@ var timestampService = LocalServiceRegistry.createService('my.timestamp.soap', {
         var credential = svc.configuration.credential;
 
         // Username token with timestamp
-        WSUtil.setWSSecurityUsernameToken(
-            stub,
-            credential.user,
-            credential.password,
-            WSUtil.generateNonce()
-        );
+        // Request both a Timestamp and a UsernameToken. WS_ACTION takes a
+        // space-separated list of actions.
+        var requestConfig = new HashMap();
+        requestConfig.put(WSUtil.WS_ACTION, WSUtil.WS_TIMESTAMP + ' ' + WSUtil.WS_USERNAME_TOKEN);
+        requestConfig.put(WSUtil.WS_USER, credential.user);
+        requestConfig.put(WSUtil.WS_PASSWORD_TYPE, WSUtil.WS_PW_DIGEST);
 
-        // Set timestamp properties
-        WSUtil.setProperty(stub, WSUtil.WS_ACTION, 'Timestamp UsernameToken');
+        var secrets = new HashMap();
+        secrets.put(credential.user, credential.password);
+        requestConfig.put(WSUtil.WS_SECRETS_MAP, secrets);
+
+        WSUtil.setWSSecurityConfig(stub, requestConfig, null);
 
         var request = new webreferences2.TimestampServiceWSDL.Request();
         request.setData(params.data);
@@ -219,6 +239,7 @@ var timestampService = LocalServiceRegistry.createService('my.timestamp.soap', {
 
 ```javascript
 var WSUtil = require('dw/ws/WSUtil');
+var StringUtils = require('dw/util/StringUtils');
 
 var headerService = LocalServiceRegistry.createService('my.header.soap', {
     initServiceClient: function (svc) {
@@ -228,12 +249,18 @@ var headerService = LocalServiceRegistry.createService('my.header.soap', {
     createRequest: function (svc, params) {
         var stub = svc.serviceClient;
 
-        // Add custom SOAP header
+        // Add custom SOAP header. The second argument is the complete header
+        // XML — namespaces are declared inline, not passed separately. Escape
+        // dynamic values so they cannot break or inject markup into the header.
         WSUtil.addSOAPHeader(
             stub,
-            'http://example.com/ns',
-            'CustomHeader',
-            '<customValue>' + params.headerValue + '</customValue>'
+            '<ns:CustomHeader xmlns:ns="http://example.com/ns">' +
+                '<ns:customValue>' +
+                StringUtils.stringToXml(String(params.headerValue)) +
+                '</ns:customValue>' +
+                '</ns:CustomHeader>',
+            false, // mustUnderstand
+            null // actor
         );
 
         var request = new webreferences2.HeaderServiceWSDL.Request();
@@ -529,12 +556,9 @@ var WSUtil = require('dw/ws/WSUtil');
 
 var mtomService = LocalServiceRegistry.createService('my.mtom.soap', {
     initServiceClient: function (svc) {
-        var stub = webreferences2.MTOMServiceWSDL.getDefaultService();
-
-        // Enable MTOM
-        WSUtil.setProperty(stub, WSUtil.WS_MTOM_ENABLED, true);
-
-        return stub;
+        // MTOM is enabled by the WSDL/web-reference binding, not by a WSUtil
+        // property — there is no MTOM constant on WSUtil.
+        return webreferences2.MTOMServiceWSDL.getDefaultService();
     },
 
     createRequest: function (svc, params) {


### PR DESCRIPTION
## Summary

Fixes #600.

Replaces fabricated Script APIs, hook extension points, OCAPI request/response shapes, and metadata XML in the `skills/b2c` skills with their verified equivalents. Examples are corrected in place rather than deleted, so the skills keep the same coverage — an agent following them now emits code that runs.

| Skill | Correction |
| --- | --- |
| `b2c-custom-objects` | `custom_object_search` → `custom_objects_search`; `term_query` takes `fields[]`/`operator`/`values[]`; `range_query` → `range_filter` inside `filtered_query`; filters use `term_filter`; response shape corrected to `hits[]` with `key_property`/`key_value_string`/`object_type` |
| `b2c-hooks` | Removed the `dw.order.hooks.*` extension point names (that's the interface package, never part of the name); real names for return, shipping order, and basket merge hooks, with their `*WO` parameter types; `calculate.js` replaced with SFRA's actual implementation; added the order post-processing caveat — return/shipping order hooks are inactive by default and throw unless approved by Product Management |
| `b2c-webservices` | `setWSSecurityUsernameToken()`, `generateNonce()`, and `WS_MTOM_ENABLED` don't exist; WS-Security now goes through `setWSSecurityConfig()` with a `WS_ACTION`/`WS_USER`/`WS_PASSWORD_TYPE`/`WS_SECRETS_MAP` map; corrected `addSOAPHeader` and `setProperty` signatures |
| `b2c-custom-job-steps` | Dropped `File.parentFile`, `JobStepExecution.startTime`, and `.exitStatus` |
| `b2c-localization` | Removed the fabricated `dw/web/ResourceBundle` module; non-current-locale lookup goes through `request.setLocale()` |
| `b2c-querying-data` | `getNextLevelRefinementValues()` → `getNextLevelCategoryRefinementValues(category)` / `getAllRefinementValues(name)` |
| `b2c-metadata` | `<max-length>` → `<field-length>`; dropped invalid `<select-mode>`; `<unit>` given its required `xml:lang`; elements reordered to satisfy the XSD sequence; escaped a bare `&`; `xml:lang="en_US"` → `en-US` |
| `b2c-page-designer` | `PageRenderHelper.renderRegion()` → `getRegionModelRegistry()` + `RegionModel.render()`, matching SFRA; corrected the template's `default/` locale path segment |

## Testing

No automated test covers skill content, so each change was verified against a source of truth rather than a test run:

- `b2c docs read` / `b2c docs search` for Script API, OCAPI, and hook documentation
- vendored Script API typings in `packages/b2c-script-types/types/dw/**` (upstream 26.7.0)
- a `storefront-reference-architecture` clone (SFRA 7.1.1) for the SFRA-side patterns — the `calculate.js` snippet matches SFRA line-for-line, and the Page Designer pattern matches SFRA's `PageRenderHelper`
- `xmllint` against `packages/b2c-tooling-sdk/data/xsd/*.xsd` for the metadata XML

Every fenced code block in the touched files was re-validated after editing: JavaScript through `node --check`, JSON through a parser.

Where the typings were the only source, the claim was cross-checked against the docs — the typings drop overloads, so absence there alone isn't proof, and they occasionally carry members the docs pages omit.

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm test`) — 5104 passing, `pnpm run lint:agent` clean
- [x] Code is formatted (`pnpm run format`) — this PR's files are clean. `format:check` does report `packages/b2c-vs-extension/src/cip-analytics/cip-styles.css`, but that's pre-existing on `main` and untouched here.
