### PR TITLE
@W-23634161: warn before installing non-Salesforce Commerce Apps

### DIFF
--- a/.changeset/warn-non-salesforce-cap-install.md
+++ b/.changeset/warn-non-salesforce-cap-install.md
@@ -1,0 +1,6 @@
+---
+'@salesforce/b2c-cli': patch
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+`cap:install` now warns and prompts for confirmation before installing a Commerce App from a non-Salesforce provider. Use `--force` to skip the prompt (e.g. in CI or scripted installs); the prompt is also skipped automatically in `--json` mode.

--- a/packages/b2c-cli/src/commands/cap/install.ts
+++ b/packages/b2c-cli/src/commands/cap/install.ts
@@ -7,11 +7,19 @@ import {Args, Flags} from '@oclif/core';
 import {JobCommand} from '@salesforce/b2c-tooling-sdk/cli';
 import {
   commerceAppInstall,
+  readManifestFromTarget,
   validateCap,
   JobExecutionError,
   type CommerceAppInstallResult,
+  type CommerceAppManifest,
 } from '@salesforce/b2c-tooling-sdk/operations/cap';
+import {confirm} from '@salesforce/b2c-tooling-sdk/ux';
 import {t, withDocs} from '../../i18n/index.js';
+
+const NON_SFDC_WARNING =
+  'You are installing a Non-SFDC Application, as that term may be defined in the MSA between SFDC and Customer. ' +
+  'SFDC does not warrant or support Non-SFDC Applications or other non-SFDC products or services. ' +
+  'By proceeding, you acknowledge these terms.';
 
 export default class CapInstall extends JobCommand<typeof CapInstall> {
   static args = {
@@ -60,11 +68,18 @@ export default class CapInstall extends JobCommand<typeof CapInstall> {
         'Create a pull request against the connected Storefront Next repository when the app includes storefront content',
       default: false,
     }),
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip the non-Salesforce app confirmation prompt',
+      default: false,
+    }),
   };
 
   protected operations = {
     commerceAppInstall,
+    readManifestFromTarget,
     validateCap,
+    confirm,
   };
 
   async run(): Promise<CommerceAppInstallResult> {
@@ -78,10 +93,12 @@ export default class CapInstall extends JobCommand<typeof CapInstall> {
       timeout,
       'skip-validate': skipValidate,
       'create-pr': createPr,
+      force,
     } = this.flags;
     const hostname = this.resolvedConfig.values.hostname!;
 
     // Validate first unless skipped
+    let manifest: CommerceAppManifest | undefined;
     if (!skipValidate) {
       this.log(t('commands.cap.install.validating', 'Validating CAP structure...'));
       const validation = await this.operations.validateCap(path);
@@ -99,15 +116,8 @@ export default class CapInstall extends JobCommand<typeof CapInstall> {
           this.log(`  ⚠ ${warn}`);
         }
       }
+      manifest = validation.manifest;
     }
-
-    this.log(
-      t('commands.cap.install.installing', 'Installing CAP {{path}} to {{hostname}} (site: {{site}})...', {
-        path,
-        hostname,
-        site,
-      }),
-    );
 
     const context = this.createContext('cap:install', {path, site, hostname});
     const beforeResult = await this.runBeforeHooks(context);
@@ -125,6 +135,28 @@ export default class CapInstall extends JobCommand<typeof CapInstall> {
         archiveKept: false,
       } as unknown as CommerceAppInstallResult;
     }
+
+    manifest ??= await this.operations.readManifestFromTarget(path);
+    if (manifest.provider !== 'salesforce') {
+      this.log(`⚠ ${NON_SFDC_WARNING}`);
+      if (!force && !this.jsonEnabled()) {
+        const proceed = await this.operations.confirm(
+          t('commands.cap.install.confirmNonSfdc', 'Proceed with installing this non-Salesforce app?'),
+        );
+        if (!proceed) {
+          this.log(t('commands.cap.install.cancelled', 'Install cancelled'));
+          this.exit(0);
+        }
+      }
+    }
+
+    this.log(
+      t('commands.cap.install.installing', 'Installing CAP {{path}} to {{hostname}} (site: {{site}})...', {
+        path,
+        hostname,
+        site,
+      }),
+    );
 
     try {
       const result = await this.operations.commerceAppInstall(this.instance, path, {

--- a/packages/b2c-cli/test/commands/cap/install.test.ts
+++ b/packages/b2c-cli/test/commands/cap/install.test.ts
@@ -41,18 +41,49 @@ describe('cap install', () => {
     archiveKept: true,
   };
 
+  const salesforceManifest = {id: 'my-app', name: 'My App', version: '1.0.0', domain: 'tax', provider: 'salesforce'};
+  const thirdPartyManifest = {
+    id: 'avalara-tax',
+    name: 'Avalara Tax',
+    version: '0.2.5',
+    domain: 'tax',
+    provider: 'thirdParty',
+  };
+  const noProviderManifest = {id: 'legacy-app', name: 'Legacy App', version: '1.0.0', domain: 'tax'};
+  const customManifest = {
+    id: 'internal-app',
+    name: 'Internal App',
+    version: '1.0.0',
+    domain: 'tax',
+    provider: 'custom',
+  };
+
+  /** Default operations stub set: validation passes, readManifestFromTarget resolves to a Salesforce-provider manifest. */
+  function defaultOperations(overrides: Record<string, unknown> = {}) {
+    return {
+      validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: [], manifest: salesforceManifest}),
+      readManifestFromTarget: sinon.stub().resolves(salesforceManifest),
+      commerceAppInstall: sinon.stub().resolves(installResult),
+      confirm: sinon.stub().resolves(true),
+      ...overrides,
+    };
+  }
+
   it('validates before install and passes flags through to the install operation', async () => {
     // The oclif flag default (false) is applied at runtime; the test harness
     // does not apply defaults, so pass the resolved value explicitly here.
-    const command: any = await createCommand({'site-id': 'RefArch', 'create-pr': false}, {path: './my-cap'});
+    const command: any = await createCommand(
+      {'site-id': 'RefArch', 'create-pr': false, force: false},
+      {path: './my-cap'},
+    );
     const instance = stubCommon(command);
 
     sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
     sinon.stub(command, 'runAfterHooks').resolves(void 0);
 
-    const validateStub = sinon.stub().resolves({valid: true, errors: [], warnings: []});
+    const validateStub = sinon.stub().resolves({valid: true, errors: [], warnings: [], manifest: salesforceManifest});
     const installStub = sinon.stub().resolves(installResult);
-    command.operations = {validateCap: validateStub, commerceAppInstall: installStub};
+    command.operations = defaultOperations({validateCap: validateStub, commerceAppInstall: installStub});
 
     const result = await command.run();
 
@@ -69,17 +100,17 @@ describe('cap install', () => {
   });
 
   it('passes shouldCreatePr=true when --create-pr is set', async () => {
-    const command: any = await createCommand({'site-id': 'RefArch', 'create-pr': true}, {path: './my-cap'});
+    const command: any = await createCommand(
+      {'site-id': 'RefArch', 'create-pr': true, force: false},
+      {path: './my-cap'},
+    );
     stubCommon(command);
 
     sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
     sinon.stub(command, 'runAfterHooks').resolves(void 0);
 
     const installStub = sinon.stub().resolves(installResult);
-    command.operations = {
-      validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: []}),
-      commerceAppInstall: installStub,
-    };
+    command.operations = defaultOperations({commerceAppInstall: installStub});
 
     await command.run();
 
@@ -87,49 +118,58 @@ describe('cap install', () => {
   });
 
   it('maps --clean-archive to keepArchive=false', async () => {
-    const command: any = await createCommand({'site-id': 'RefArch', 'clean-archive': true}, {path: './my-cap'});
+    const command: any = await createCommand(
+      {'site-id': 'RefArch', 'clean-archive': true, force: false},
+      {path: './my-cap'},
+    );
     stubCommon(command);
 
     sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
     sinon.stub(command, 'runAfterHooks').resolves(void 0);
 
     const installStub = sinon.stub().resolves(installResult);
-    command.operations = {
-      validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: []}),
-      commerceAppInstall: installStub,
-    };
+    command.operations = defaultOperations({commerceAppInstall: installStub});
 
     await command.run();
 
     expect(installStub.firstCall.args[2]).to.deep.include({keepArchive: false});
   });
 
-  it('skips validation when --skip-validate is set', async () => {
-    const command: any = await createCommand({'site-id': 'RefArch', 'skip-validate': true}, {path: './my-cap'});
+  it('skips validation when --skip-validate is set, still reading the manifest for the provider check', async () => {
+    const command: any = await createCommand(
+      {'site-id': 'RefArch', 'skip-validate': true, force: false},
+      {path: './my-cap'},
+    );
     stubCommon(command);
 
     sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
     sinon.stub(command, 'runAfterHooks').resolves(void 0);
 
     const validateStub = sinon.stub().resolves({valid: true, errors: [], warnings: []});
+    const readManifestStub = sinon.stub().resolves(salesforceManifest);
     const installStub = sinon.stub().resolves(installResult);
-    command.operations = {validateCap: validateStub, commerceAppInstall: installStub};
+    command.operations = defaultOperations({
+      validateCap: validateStub,
+      readManifestFromTarget: readManifestStub,
+      commerceAppInstall: installStub,
+    });
 
     await command.run();
 
     expect(validateStub.called).to.be.false;
+    expect(readManifestStub.calledOnceWithExactly('./my-cap')).to.be.true;
     expect(installStub.calledOnce).to.be.true;
   });
 
   it('errors and does not install when validation fails', async () => {
-    const command: any = await createCommand({'site-id': 'RefArch'}, {path: './my-cap'});
+    const command: any = await createCommand({'site-id': 'RefArch', force: false}, {path: './my-cap'});
     stubCommon(command);
 
     const installStub = sinon.stub().resolves(installResult);
-    command.operations = {
+    command.operations = defaultOperations({
       validateCap: sinon.stub().resolves({valid: false, errors: ['missing commerce-app.json'], warnings: []}),
       commerceAppInstall: installStub,
-    };
+    });
 
     const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
 
@@ -141,21 +181,214 @@ describe('cap install', () => {
   });
 
   it('returns early without installing when a before hook skips', async () => {
-    const command: any = await createCommand({'site-id': 'RefArch', 'skip-validate': true}, {path: './my-cap'});
+    const command: any = await createCommand(
+      {'site-id': 'RefArch', 'skip-validate': true, force: false},
+      {path: './my-cap'},
+    );
     stubCommon(command);
 
     sinon.stub(command, 'runBeforeHooks').resolves({skip: true, skipReason: 'by plugin'});
     sinon.stub(command, 'runAfterHooks').rejects(new Error('Unexpected after hooks'));
 
+    const readManifestStub = sinon.stub().resolves(salesforceManifest);
     const installStub = sinon.stub().rejects(new Error('Unexpected install'));
-    command.operations = {
-      validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: []}),
+    command.operations = defaultOperations({
+      readManifestFromTarget: readManifestStub,
       commerceAppInstall: installStub,
-    };
+    });
 
     const result: any = await command.run();
 
+    expect(readManifestStub.called).to.be.false;
     expect(installStub.called).to.be.false;
     expect(result.execution.execution_status).to.equal('finished');
+  });
+
+  describe('non-Salesforce provider warning', () => {
+    it('does not warn or prompt when a before hook skips the install, even for a non-Salesforce manifest', async () => {
+      const command: any = await createCommand(
+        {'site-id': 'RefArch', 'skip-validate': true, force: false},
+        {path: './my-cap'},
+      );
+      stubCommon(command);
+      sinon.stub(command, 'jsonEnabled').returns(false);
+
+      sinon.stub(command, 'runBeforeHooks').resolves({skip: true, skipReason: 'by plugin'});
+      sinon.stub(command, 'runAfterHooks').rejects(new Error('Unexpected after hooks'));
+
+      const readManifestStub = sinon.stub().resolves(thirdPartyManifest);
+      const confirmStub = sinon.stub().resolves(true);
+      const installStub = sinon.stub().rejects(new Error('Unexpected install'));
+      command.operations = defaultOperations({
+        readManifestFromTarget: readManifestStub,
+        confirm: confirmStub,
+        commerceAppInstall: installStub,
+      });
+
+      const result: any = await command.run();
+
+      expect(readManifestStub.called).to.be.false;
+      expect(confirmStub.called).to.be.false;
+      expect(command.log.getCalls().some((c: sinon.SinonSpyCall) => String(c.args[0]).includes('Non-SFDC Application')))
+        .to.be.false;
+      expect(installStub.called).to.be.false;
+      expect(result.execution.execution_status).to.equal('finished');
+    });
+
+    it('does not warn or prompt when the manifest provider is salesforce', async () => {
+      const command: any = await createCommand({'site-id': 'RefArch', force: false}, {path: './my-cap'});
+      stubCommon(command);
+
+      sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+      sinon.stub(command, 'runAfterHooks').resolves(void 0);
+
+      const confirmStub = sinon.stub().resolves(true);
+      command.operations = defaultOperations({
+        validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: [], manifest: salesforceManifest}),
+        confirm: confirmStub,
+      });
+
+      await command.run();
+
+      expect(confirmStub.called).to.be.false;
+      expect(command.log.getCalls().some((c: sinon.SinonSpyCall) => String(c.args[0]).includes('Non-SFDC Application')))
+        .to.be.false;
+    });
+
+    it('warns and prompts when the manifest provider is thirdParty, proceeding on confirmation', async () => {
+      const command: any = await createCommand({'site-id': 'RefArch', force: false}, {path: './my-cap'});
+      stubCommon(command);
+      sinon.stub(command, 'jsonEnabled').returns(false);
+
+      sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+      sinon.stub(command, 'runAfterHooks').resolves(void 0);
+
+      const confirmStub = sinon.stub().resolves(true);
+      const installStub = sinon.stub().resolves(installResult);
+      command.operations = defaultOperations({
+        validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: [], manifest: thirdPartyManifest}),
+        confirm: confirmStub,
+        commerceAppInstall: installStub,
+      });
+
+      const result = await command.run();
+
+      expect(command.log.getCalls().some((c: sinon.SinonSpyCall) => String(c.args[0]).includes('Non-SFDC Application')))
+        .to.be.true;
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(installStub.calledOnce).to.be.true;
+      expect(result).to.equal(installResult);
+    });
+
+    it('warns and prompts when the manifest omits the provider field', async () => {
+      const command: any = await createCommand({'site-id': 'RefArch', force: false}, {path: './my-cap'});
+      stubCommon(command);
+      sinon.stub(command, 'jsonEnabled').returns(false);
+
+      sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+      sinon.stub(command, 'runAfterHooks').resolves(void 0);
+
+      const confirmStub = sinon.stub().resolves(true);
+      const installStub = sinon.stub().resolves(installResult);
+      command.operations = defaultOperations({
+        validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: [], manifest: noProviderManifest}),
+        confirm: confirmStub,
+        commerceAppInstall: installStub,
+      });
+
+      const result = await command.run();
+
+      expect(command.log.getCalls().some((c: sinon.SinonSpyCall) => String(c.args[0]).includes('Non-SFDC Application')))
+        .to.be.true;
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(installStub.calledOnce).to.be.true;
+      expect(result).to.equal(installResult);
+    });
+
+    it('warns and prompts when the manifest provider is custom, proceeding on confirmation', async () => {
+      const command: any = await createCommand({'site-id': 'RefArch', force: false}, {path: './my-cap'});
+      stubCommon(command);
+      sinon.stub(command, 'jsonEnabled').returns(false);
+
+      sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+      sinon.stub(command, 'runAfterHooks').resolves(void 0);
+
+      const confirmStub = sinon.stub().resolves(true);
+      const installStub = sinon.stub().resolves(installResult);
+      command.operations = defaultOperations({
+        validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: [], manifest: customManifest}),
+        confirm: confirmStub,
+        commerceAppInstall: installStub,
+      });
+
+      const result = await command.run();
+
+      expect(command.log.getCalls().some((c: sinon.SinonSpyCall) => String(c.args[0]).includes('Non-SFDC Application')))
+        .to.be.true;
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(installStub.calledOnce).to.be.true;
+      expect(result).to.equal(installResult);
+    });
+
+    it('cancels the install when the user declines the non-Salesforce confirmation', async () => {
+      const command: any = await createCommand({'site-id': 'RefArch', force: false}, {path: './my-cap'});
+      stubCommon(command);
+      sinon.stub(command, 'jsonEnabled').returns(false);
+      sinon.stub(command, 'exit').throws(new Error('EEXIT: 0'));
+
+      const installStub = sinon.stub().rejects(new Error('Unexpected install'));
+      command.operations = defaultOperations({
+        validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: [], manifest: thirdPartyManifest}),
+        confirm: sinon.stub().resolves(false),
+        commerceAppInstall: installStub,
+      });
+
+      await expectError(() => command.run());
+
+      expect(installStub.called).to.be.false;
+    });
+
+    it('skips the confirmation prompt when --force is set', async () => {
+      const command: any = await createCommand({'site-id': 'RefArch', force: true}, {path: './my-cap'});
+      stubCommon(command);
+
+      sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+      sinon.stub(command, 'runAfterHooks').resolves(void 0);
+
+      const confirmStub = sinon.stub().resolves(true);
+      const installStub = sinon.stub().resolves(installResult);
+      command.operations = defaultOperations({
+        validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: [], manifest: thirdPartyManifest}),
+        confirm: confirmStub,
+        commerceAppInstall: installStub,
+      });
+
+      await command.run();
+
+      expect(confirmStub.called).to.be.false;
+      expect(installStub.calledOnce).to.be.true;
+    });
+
+    it('skips the confirmation prompt in JSON mode', async () => {
+      const command: any = await createCommand({'site-id': 'RefArch', force: false, json: true}, {path: './my-cap'});
+      stubCommon(command);
+      sinon.stub(command, 'jsonEnabled').returns(true);
+
+      sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+      sinon.stub(command, 'runAfterHooks').resolves(void 0);
+
+      const confirmStub = sinon.stub().resolves(true);
+      const installStub = sinon.stub().resolves(installResult);
+      command.operations = defaultOperations({
+        validateCap: sinon.stub().resolves({valid: true, errors: [], warnings: [], manifest: thirdPartyManifest}),
+        confirm: confirmStub,
+        commerceAppInstall: installStub,
+      });
+
+      await command.run();
+
+      expect(confirmStub.called).to.be.false;
+      expect(installStub.calledOnce).to.be.true;
+    });
   });
 });

--- a/packages/b2c-tooling-sdk/src/operations/cap/index.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cap/index.ts
@@ -48,12 +48,12 @@
  */
 
 export {validateCap} from './validate.js';
-export type {CapValidationResult, CommerceAppManifest} from './validate.js';
+export type {CapValidationResult, CommerceAppManifest, CommerceAppProvider} from './validate.js';
 
 // Re-export JobExecutionError for convenience in CLI commands
 export {JobExecutionError} from '../jobs/run.js';
 
-export {commerceAppInstall, readManifest} from './install.js';
+export {commerceAppInstall, readManifest, readManifestFromTarget} from './install.js';
 export type {CommerceAppInstallOptions, CommerceAppInstallResult} from './install.js';
 
 export {commerceAppUninstall} from './uninstall.js';

--- a/packages/b2c-tooling-sdk/src/operations/cap/install.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cap/install.ts
@@ -220,6 +220,36 @@ export function readManifest(capDir: string): CommerceAppManifest {
   }
 }
 
+/**
+ * Reads the commerce-app.json manifest from a CAP directory or zip file without
+ * uploading or installing anything.
+ *
+ * Useful for inspecting manifest fields (e.g. `provider`) before installing.
+ *
+ * @param target - Path to a CAP directory or .zip file
+ * @returns Parsed manifest object
+ * @throws Error if the target does not exist or is not a directory/.zip file
+ *
+ * @example
+ * ```typescript
+ * const manifest = await readManifestFromTarget('./my-commerce-app-v1.0.0.zip');
+ * console.log(`App: ${manifest.id}@${manifest.version}`);
+ * ```
+ */
+export async function readManifestFromTarget(target: string): Promise<CommerceAppManifest> {
+  if (!fs.existsSync(target)) {
+    throw new Error(`Target not found: ${target}`);
+  }
+  const stat = fs.statSync(target);
+  if (stat.isDirectory()) {
+    return readManifest(target);
+  }
+  if (stat.isFile() && target.endsWith('.zip')) {
+    return readManifestFromZip(target);
+  }
+  throw new Error(`Target must be a directory or .zip file: ${target}`);
+}
+
 async function readManifestFromZip(zipPath: string): Promise<CommerceAppManifest> {
   const data = await fs.promises.readFile(zipPath);
   const zip = await JSZip.loadAsync(data);

--- a/packages/b2c-tooling-sdk/src/operations/cap/validate.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cap/validate.ts
@@ -15,6 +15,14 @@ import * as path from 'node:path';
 import JSZip from 'jszip';
 
 /**
+ * Who authored a Commerce App.
+ * - `salesforce` - first-party Salesforce apps/features.
+ * - `thirdParty` - ISV / non-Salesforce apps.
+ * - `custom` - merchant-provided custom integrations.
+ */
+export type CommerceAppProvider = 'salesforce' | 'thirdParty' | 'custom';
+
+/**
  * Manifest from commerce-app.json.
  */
 export interface CommerceAppManifest {
@@ -25,6 +33,8 @@ export interface CommerceAppManifest {
   description?: string;
   publisher?: {name: string; url?: string; support?: string};
   dependencies?: Record<string, string>;
+  /** Who authored this app. Absent or non-`salesforce` apps are treated as non-Salesforce. */
+  provider?: CommerceAppProvider;
 }
 
 /**

--- a/packages/b2c-tooling-sdk/test/fixtures/commerce-avalara-tax-app-v0.2.5/commerce-app.json
+++ b/packages/b2c-tooling-sdk/test/fixtures/commerce-avalara-tax-app-v0.2.5/commerce-app.json
@@ -4,6 +4,7 @@
   "description": "Automated tax compliance solution by Avalara",
   "domain": "tax",
   "version": "0.2.5",
+  "provider": "thirdParty",
   "publisher": {
     "name": "Avalara",
     "url": "https://developer.avalara.com/",

--- a/packages/b2c-tooling-sdk/test/operations/cap/install.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/cap/install.test.ts
@@ -16,7 +16,7 @@ import JSZip from 'jszip';
 import {WebDavClient} from '../../../src/clients/webdav.js';
 import {createOcapiClient} from '../../../src/clients/ocapi.js';
 import {MockAuthStrategy} from '../../helpers/mock-auth.js';
-import {commerceAppInstall} from '../../../src/operations/cap/install.js';
+import {commerceAppInstall, readManifestFromTarget} from '../../../src/operations/cap/install.js';
 
 const TEST_HOST = 'test.demandware.net';
 const WEBDAV_BASE = `https://${TEST_HOST}/on/demandware.servlet/webdav/Sites`;
@@ -308,6 +308,49 @@ describe('operations/cap/install', () => {
       // Zip target keeps its original filename.
       expect(result.archiveFilename).to.equal('my-app-v1.0.0.zip');
       expect(job.body().app_path).to.equal('webdav/Sites/Impex/commerce-apps/my-app-v1.0.0.zip');
+    });
+  });
+
+  describe('readManifestFromTarget', () => {
+    it('reads the manifest from a CAP directory, including the provider field', async () => {
+      const manifest = await readManifestFromTarget(FIXTURE_CAP);
+      expect(manifest.id).to.equal('avalara-tax');
+      expect(manifest.provider).to.equal('thirdParty');
+    });
+
+    it('reads the manifest from a CAP zip file', async () => {
+      const srcZip = new JSZip();
+      const root = srcZip.folder('my-app-v1.0.0')!;
+      root.file(
+        'commerce-app.json',
+        JSON.stringify({id: 'my-app', name: 'My App', version: '1.0.0', domain: 'tax', provider: 'salesforce'}),
+      );
+      const zipBuffer = await srcZip.generateAsync({type: 'nodebuffer'});
+      const zipPath = path.join(tempDir, 'my-app-v1.0.0.zip');
+      fs.writeFileSync(zipPath, zipBuffer);
+
+      const manifest = await readManifestFromTarget(zipPath);
+      expect(manifest.provider).to.equal('salesforce');
+    });
+
+    it('throws when the target does not exist', async () => {
+      try {
+        await readManifestFromTarget(path.join(tempDir, 'missing'));
+        expect.fail('Should have thrown');
+      } catch (error: any) {
+        expect(error.message).to.include('Target not found');
+      }
+    });
+
+    it('throws when the target is not a directory or zip file', async () => {
+      const filePath = path.join(tempDir, 'not-a-cap.txt');
+      fs.writeFileSync(filePath, 'hello');
+      try {
+        await readManifestFromTarget(filePath);
+        expect.fail('Should have thrown');
+      } catch (error: any) {
+        expect(error.message).to.include('must be a directory or .zip file');
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- `cap:install` now reads the `provider` field from `commerce-app.json` and, when it isn't `'salesforce'` (including manifests that omit the field entirely, e.g. older apps), prints a warning and prompts for y/n confirmation before proceeding.
- Added `--force` to skip the prompt; the prompt is also automatically skipped in `--json` mode.
- Added `CommerceAppProvider` type and `provider` field to `CommerceAppManifest` in the SDK, plus a `readManifestFromTarget` helper (directory or `.zip`) so the CLI can inspect the manifest even when `--skip-validate` is passed.

## Backwards compatibility
This is backwards compatible: no install that succeeded before this change will fail because of it, and no manifest field is required.
- `provider` is optional on `CommerceAppManifest`. Manifests predating this field (`provider` is `undefined`) still parse and install correctly.
- The check is `manifest.provider !== 'salesforce'`, so a missing `provider` is treated the same as an explicit `'thirdParty'`/`'custom'` — it triggers the warning rather than silently skipping it. This is intentional: most existing Commerce Apps predate the `provider` field, and we can't assume "missing" means "Salesforce-authored," so they get the same non-Salesforce confirmation as an app that explicitly declares a third-party provider.
- The prompt itself doesn't block anything permanently — it can be bypassed with `--force`, and is skipped automatically in `--json` mode — so existing scripts/CI pipelines that install CAPs non-interactively continue to work unchanged.

## Test plan
- [x] `pnpm --filter @salesforce/b2c-cli run test:agent` — all passing, including new provider-warning suite (salesforce/thirdParty/no-provider, cancel, `--force`, `--json`)
- [x] `pnpm --filter @salesforce/b2c-tooling-sdk run test:agent` — passing (one pre-existing unrelated `oauth-command` failure present on `main`)
- [x] `pnpm run lint:agent` — clean
- [x] Changeset added (`@salesforce/b2c-cli`, `@salesforce/b2c-tooling-sdk`, patch)