### PR TITLE
Refresh docs corpora to 26.8 and track source provenance

### DIFF
--- a/.changeset/corpus-update-26-8.md
+++ b/.changeset/corpus-update-26-8.md
@@ -1,0 +1,16 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+Refresh the bundled documentation corpora to the 26.8 release so `b2c docs
+search`/`docs read` and the MCP `docs_*` tools surface the latest content:
+
+- Script API reference and XSD schemas updated to DWAPP 26.8 (adds the
+  `dw.commerceapps` package, connection-health hooks, and `ShippingHooks`).
+- Developer Center guides refreshed (adds newly published guides such as SCAPI
+  CDN caching, guest order access codes, and several Storefront Next topics).
+
+Each corpus index now records where it came from so maintainers can spot the
+delta before a refresh: git-sourced prose corpora store the upstream commit
+(`source` block) and DWAPP-sourced corpora store the platform release
+(`platformDocVersion`, e.g. "DWAPP 26.8").

--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -282,6 +282,60 @@ skips any `.md` file not linked from a guide table-of-contents YAML (e.g.
 drafts) are not published by the docs site, so indexing them would yield dead
 404 URLs.
 
+### Salesforce Help corpus (`help-admin` / `help-merchant`)
+
+A second prose corpus covers help.salesforce.com Business Manager administration
+and merchandising content, sourced from a local clone of the
+`content-commerce-cloud` DITA repo (defaults to `~/code/content-commerce-cloud`,
+override with `CONTENT_COMMERCE_CLOUD_REPO`). Unlike the guides, Help content is
+JS-rendered with no fetchable source, so the DITA is converted to Markdown and
+packed into the committed `docs/help-content.tar.gz` (extracted into the docs
+site at build time), with the lightweight index at
+`packages/b2c-tooling-sdk/data/help/index.json`:
+
+```bash
+CONTENT_COMMERCE_CLOUD_REPO=/path/to/content-commerce-cloud \
+  pnpm --filter @salesforce/b2c-tooling-sdk run generate:help-corpus
+```
+
+### Source provenance (delta tracking)
+
+Both prose indexes record the upstream git commit they were generated from in a
+`source` block at the top of `index.json`:
+
+```json
+"source": { "sha": "<full-sha>", "committedAt": "<ISO date>", "ref": "<branch>" }
+```
+
+Only these opaque values are stored — deliberately **no repository URL** — so no
+internal host name or maintainer credential lands in the published package
+(captured by `scripts/source-provenance.ts`).
+
+Corpora sourced from the **DWAPP archive** (Script API, XSD schemas, job steps)
+are not git-backed, so instead of `source` they record the platform release:
+`data/script-api/index.json` and `data/xsd/index.json` carry a
+`platformDocVersion` (e.g. `"DWAPP 26.8"`), and `data/job-steps/job-steps.json`
+records the same under `provenance.platformDocVersion`. The version is parsed
+from the archive by `refresh:docs-data` and forwarded to
+`generate:docs-index <version>`; running that generator manually with no arg
+preserves whatever version is already committed (it never silently drops it).
+
+Use the recorded SHA to see exactly what changed upstream before a refresh. In
+the relevant local clone:
+
+```bash
+# What guide content changed since the committed guides index was generated?
+git -C ~/code/commerce-cloud-docs log --oneline <sha>..HEAD -- content/en-us
+
+# What Help content changed since the committed help index was generated?
+git -C ~/code/content-commerce-cloud log --oneline <sha>..HEAD -- content/ht/en-us
+```
+
+An empty log means the corpus is already current with that clone; otherwise the
+listed commits are the delta a regeneration will pick up. Always re-run
+`enrich:docs` (missing-only) after a guides refresh so new pages get
+summaries/keywords, then re-run `generate:guides-index` to merge them.
+
 ### Verifying links (local only)
 
 After regenerating, verify every URL in the index resolves:

--- a/packages/b2c-tooling-sdk/data/guides/enrichment.json
+++ b/packages/b2c-tooling-sdk/data/guides/enrichment.json
@@ -4194,6 +4194,21 @@
       "custom data"
     ]
   },
+  "b2c-commerce/creatingcustombusinessobjectsinstance": {
+    "summary": "Create and manage custom object instances in Business Manager with site-specific or organization-wide storage options.",
+    "keywords": [
+      "custom object instance",
+      "Business Manager",
+      "custom object editor",
+      "create custom object",
+      "site-specific storage",
+      "organization-wide storage",
+      "custom object management",
+      "merchant tools",
+      "custom object attributes",
+      "custom object configuration"
+    ]
+  },
   "b2c-commerce/creatingcustombusinessobjectswithdemandwarebusinessmanager": {
     "summary": "Create custom business object definitions in Business Manager to store organization-wide data with custom attributes and attribute groupings.",
     "keywords": [
@@ -4325,6 +4340,89 @@
       "ecommerce platform structure",
       "Salesforce Commerce Cloud",
       "instance configuration"
+    ]
+  },
+  "b2c-commerce/hybrid-auth-environment-matrix": {
+    "summary": "Set up Hybrid Auth routing across B2C Commerce environments (PIG, ODS, localhost) for Storefront Next and PWA Kit architectures.",
+    "keywords": [
+      "Hybrid Auth",
+      "routing",
+      "PIG",
+      "ODS",
+      "Storefront Next",
+      "PWA Kit",
+      "Composable Storefront",
+      "environment setup",
+      "eCDN",
+      "localhost",
+      "hybrid implementation",
+      "traffic routing"
+    ]
+  },
+  "b2c-commerce/hybrid-auth-manual-setup": {
+    "summary": "Set up hybrid authentication manually for PWA Kit, SFRA, SiteGenesis, or headless storefronts by configuring MRT, SLAS, and eCDN.",
+    "keywords": [
+      "hybrid auth setup",
+      "manual hybrid authentication",
+      "PWA Kit",
+      "SFRA",
+      "SiteGenesis",
+      "Managed Runtime MRT",
+      "SLAS",
+      "headless storefront",
+      "session bridging",
+      "eCDN",
+      "Composable Storefront",
+      "hybrid storefront configuration"
+    ]
+  },
+  "b2c-commerce/hybrid-auth-quick-start": {
+    "summary": "Quickly set up a Storefront Next hybrid storefront with automated provisioning of MRT environment and eCDN through Business Manager.",
+    "keywords": [
+      "Storefront Next setup",
+      "automated setup",
+      "hybrid storefront",
+      "Managed Runtime",
+      "MRT environment",
+      "eCDN",
+      "hybrid auth",
+      "Business Manager provisioning",
+      "Storefront Next configuration",
+      "quick setup",
+      "hybrid authentication"
+    ]
+  },
+  "b2c-commerce/hybrid-auth-select-storefront": {
+    "summary": "Choose and set up your storefront architecture (Storefront Next, PWA Kit, or SFRA/SiteGenesis) with appropriate hybrid authentication configuration.",
+    "keywords": [
+      "storefront selection",
+      "storefront architecture",
+      "PWA Kit setup",
+      "Storefront Next",
+      "SFRA SiteGenesis",
+      "hybrid implementation",
+      "hybrid auth",
+      "composable storefront",
+      "storefront configuration",
+      "headless commerce",
+      "implementation guide"
+    ]
+  },
+  "b2c-commerce/hybrid-auth-troubleshooting": {
+    "summary": "Diagnose and resolve common Hybrid Auth implementation issues including token drift, routing mismatches, and SLAS configuration problems.",
+    "keywords": [
+      "Hybrid Auth troubleshooting",
+      "SLAS client ID",
+      "session bridge",
+      "eCDN routing",
+      "token drift",
+      "SCAPI short code",
+      "Hybrid Auth not applying",
+      "session-bridge authentication",
+      "hybrid routing matrix",
+      "localhost hybrid proxy",
+      "ODS sandbox",
+      "auth loops"
     ]
   },
   "b2c-commerce/integratingwithapplications": {
@@ -5816,6 +5914,23 @@
       "origin server caching"
     ]
   },
+  "commerce-api/cdn-caching": {
+    "summary": "Implement CDN caching for non-personalized SCAPI GET responses to reduce latency and improve headless storefront performance using the personalized=none parameter.",
+    "keywords": [
+      "SCAPI CDN caching",
+      "personalized=none",
+      "CDN edge cache",
+      "content delivery network",
+      "web-tier caching",
+      "non-personalized responses",
+      "latency reduction",
+      "headless storefront",
+      "cache hit",
+      "TTL",
+      "SCAPI performance",
+      "commerce API caching"
+    ]
+  },
   "commerce-api/cdn-pci-4-compliance": {
     "summary": "Monitor and secure client-side scripts on your storefront using eCDN PCI 4.0 compliance tools powered by Cloudflare Page Shield.",
     "keywords": [
@@ -6341,6 +6456,23 @@
       "cross-cutting concerns"
     ]
   },
+  "commerce-api/guest-order-access-code": {
+    "summary": "Enable guest shoppers to securely access and manage their orders after losing session via email-based one-time password (OTP) access codes.",
+    "keywords": [
+      "guest order access",
+      "OTP",
+      "one-time password",
+      "access code",
+      "order lookup",
+      "Shopper Orders API",
+      "guest checkout",
+      "order self-service",
+      "email hook",
+      "order management",
+      "guest authentication",
+      "session recovery"
+    ]
+  },
   "commerce-api/hook-method-details": {
     "summary": "Reference documentation for available SCAPI authentication hooks with method signatures, parameters, and return types for the Shopper API login endpoint.",
     "keywords": [
@@ -6372,6 +6504,23 @@
       "commerce-sdk-react",
       "package.json update",
       "storefront authentication"
+    ]
+  },
+  "commerce-api/hybrid-auth-shared-setup": {
+    "summary": "Configure shared Hybrid Auth setup across all storefront architectures including SLAS client, session bridging, and platform dependencies.",
+    "keywords": [
+      "hybrid auth setup",
+      "SLAS client configuration",
+      "session bridging",
+      "commerce API authentication",
+      "third-party IDP",
+      "social login",
+      "business manager",
+      "Storefront Next",
+      "PWA Kit",
+      "SFRA",
+      "shopper APIs",
+      "hybrid authentication"
     ]
   },
   "commerce-api/hybrid-authentication": {
@@ -7754,6 +7903,22 @@
       "multi-channel storefront"
     ]
   },
+  "pwa-kit-managed-runtime/hybrid-routing-matrix": {
+    "summary": "Configure routing between PWA Kit and SFRA/SiteGenesis using eCDN rules and app/routes.jsx filtering for hybrid storefronts.",
+    "keywords": [
+      "hybrid storefront routing",
+      "PWA Kit routing matrix",
+      "eCDN routing rules",
+      "app/routes.jsx",
+      "Composable Storefront",
+      "SFRA SiteGenesis",
+      "Managed Runtime MRT",
+      "Cloudflare rule expression",
+      "hybrid proxy local development",
+      "phased headless rollout",
+      "React Router navigation"
+    ]
+  },
   "pwa-kit-managed-runtime/hybrid-upgrade-v2.x": {
     "summary": "Upgrade PWA Kit 2.x hybrid storefronts to implement hybrid stability improvements and update Plugin SLAS to version 7.4.0.",
     "keywords": [
@@ -8318,6 +8483,23 @@
       "hybrid stability upgrade",
       "composable storefront hybrid",
       "headless rollout"
+    ]
+  },
+  "pwa-kit-managed-runtime/protect-storefront": {
+    "summary": "Enable Protected Storefronts in Business Manager to restrict storefront access during development to only authorized organization users via basic authentication.",
+    "keywords": [
+      "protected storefront",
+      "limit access",
+      "development environment",
+      "basic auth",
+      "site status",
+      "shared password",
+      "restrict access",
+      "storefront under development",
+      "Business Manager",
+      "access control",
+      "authentication",
+      "online protected"
     ]
   },
   "pwa-kit-managed-runtime/proxying-requests": {
@@ -9534,6 +9716,23 @@
       "locale detection"
     ]
   },
+  "sfnext/sfnext-load-more": {
+    "summary": "Configure load-more pagination on product listing pages to keep shoppers browsing without page reloads or scroll loss.",
+    "keywords": [
+      "load more pagination",
+      "product listing pages",
+      "pagination configuration",
+      "uiConfig.pages.category.pagination",
+      "load more button",
+      "numbered pagination",
+      "traditional pagination",
+      "infinite scroll",
+      "category page pagination",
+      "sfnext pagination",
+      "progress indicator",
+      "ui config"
+    ]
+  },
   "sfnext/sfnext-logging": {
     "summary": "Configure and use Storefront Next's built-in structured JSON logger with correlation IDs for server-side and client-side logging across your application.",
     "keywords": [
@@ -9754,6 +9953,21 @@
       "environment launch"
     ]
   },
+  "sfnext/sfnext-mrt-node-version": {
+    "summary": "Manage Node.js versions for Storefront Next Managed Runtime environments, understanding support lifecycles and upgrade requirements.",
+    "keywords": [
+      "Node.js version support",
+      "Node version upgrade",
+      "Managed Runtime Node",
+      "Storefront Next Node",
+      "Node.js deprecation",
+      "Node.js end of life",
+      "Runtime environment Node",
+      "Node version lifecycle",
+      "Node.js deployment",
+      "Runtime Admin notifications"
+    ]
+  },
   "sfnext/sfnext-mrt-overview": {
     "summary": "Managed Runtime provides cloud infrastructure to deploy, host, and monitor Storefront Next apps with serverless Node.js hosting, WAF protection, and environment management.",
     "keywords": [
@@ -9769,6 +9983,21 @@
       "Storefront Next hosting",
       "React Router 7",
       "TLS security"
+    ]
+  },
+  "sfnext/sfnext-mrt-release-notes": {
+    "summary": "Track Managed Runtime feature updates, changes, and new capabilities across releases.",
+    "keywords": [
+      "Managed Runtime release notes",
+      "MRT releases",
+      "sfnext updates",
+      "SSR bundle size limit",
+      "release changelog",
+      "feature updates",
+      "MRT changelog",
+      "version history",
+      "Managed Runtime changes",
+      "deployment updates"
     ]
   },
   "sfnext/sfnext-mrt-routing-bm": {
@@ -9836,6 +10065,22 @@
       "B2C Commerce checkout configuration",
       "sfnext checkout setup",
       "verify email address"
+    ]
+  },
+  "sfnext/sfnext-order-mgmt": {
+    "summary": "Connect Storefront Next with Salesforce Order Management to display and sync orders, enabling shoppers to track shipments and manage returns from the storefront.",
+    "keywords": [
+      "Storefront Next Order Management integration",
+      "SOM integration",
+      "order history page",
+      "order tracking",
+      "order synchronization",
+      "B2C Commerce Order Management",
+      "order status",
+      "return management",
+      "self-service order management",
+      "order detail page",
+      "connect B2C Commerce SOM"
     ]
   },
   "sfnext/sfnext-page-designer": {
@@ -9933,6 +10178,23 @@
       "Storefront Next",
       "config.server.ts",
       "shopper authentication"
+    ]
+  },
+  "sfnext/sfnext-pd-deploy-cartridge": {
+    "summary": "Deploy the Storefront Next cartridge to upload Page Designer metadata and components to your B2C Commerce instance after setup or modifications.",
+    "keywords": [
+      "deploy Storefront Next cartridge",
+      "Page Designer metadata",
+      "Page Designer components",
+      "dw.json configuration",
+      "B2C DX CLI deploy",
+      "cartridge deployment",
+      "Page Designer pages",
+      "Storefront Next setup",
+      "Business Manager deployment",
+      "upload Page Designer",
+      "code version deployment",
+      "sfnext cartridge"
     ]
   },
   "sfnext/sfnext-perf-section": {
@@ -10485,6 +10747,38 @@
       "local development",
       "B2C Commerce retail storefront",
       "get started sfnext"
+    ]
+  },
+  "sfnext/sfnext-release-notes": {
+    "summary": "Track new features and changes in Storefront Next monthly releases with links to detailed GitHub release information.",
+    "keywords": [
+      "Storefront Next release notes",
+      "sfnext releases",
+      "Storefront Next features",
+      "monthly releases",
+      "version updates",
+      "changelog",
+      "GitHub releases",
+      "Storefront Next v1.0.0",
+      "template updates",
+      "B2C Commerce releases"
+    ]
+  },
+  "sfnext/sfnext-salesforce-payments": {
+    "summary": "Set up Salesforce Payments for Storefront Next by configuring payment gateways, defining types, and updating configuration URLs.",
+    "keywords": [
+      "Salesforce Payments",
+      "Storefront Next",
+      "payment gateway configuration",
+      "Adyen",
+      "Stripe",
+      "PayPal",
+      "checkout",
+      "B2C Commerce payments",
+      "config.server.ts",
+      "payment methods",
+      "sdkUrl",
+      "metadataUrl"
     ]
   },
   "sfnext/sfnext-security-headers": {

--- a/packages/b2c-tooling-sdk/data/guides/index.json
+++ b/packages/b2c-tooling-sdk/data/guides/index.json
@@ -1,6 +1,11 @@
 {
   "version": "2.0.0",
-  "generatedAt": "2026-07-17T15:02:44.783Z",
+  "generatedAt": "2026-08-03T18:22:28.428Z",
+  "source": {
+    "sha": "2e8f2f4e0b521c1aa3dc8e97e0c1db05b2f9975a",
+    "committedAt": "2026-07-31T14:49:45-07:00",
+    "ref": "main"
+  },
   "entries": [
     {
       "id": "b2c-commerce/agentic-mcp-shopper-tools-quick-start",
@@ -4309,7 +4314,7 @@
       "category": "b2c-commerce",
       "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/building-your-app.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/building-your-app.md",
-      "headings": "Getting Started with Claude Code • Backend-Only Apps • Extension Points • Example: non-blocking error (returning `Status.ERROR`) • Example: blocking error (throwing an exception) • Implementation best practices • Optional: delivering Storefront Next components • UI-Only and Fullstack Apps • Building your Storefront Next extension • target-config.json • How UITarget replacement works at build time • Extension routes • Extension localization • Extension installation • Injecting External SDK Scripts • How script injection works in Storefront Next • Choosing the right mechanism • Example: Global SDK via contextProvider • Example: Checkout-scoped SDK via components • Handling SPA re-initialization • Script placement decision guide • Storefront Action Hooks • Available action hooks • Declaring and writing action hooks • Listing available extension points • Building the back-end • Extension Points • Custom SCAPI • Backend Development Notes • Example Apps in the Registry • Anti-patterns to avoid",
+      "headings": "Getting Started with Claude Code • Backend-Only Apps • Extension Points • Example: non-blocking error (returning `Status.ERROR`) • Example: blocking error (throwing an exception) • Implementation best practices • Optional: delivering Storefront Next components • Connection Health Check • Registering the hook • Implementing the hook • Status codes • Status details • Localizing health check messages • Best practices • Apps without a health check • UI-Only and Fullstack Apps • Building your Storefront Next extension • target-config.json • How UITarget replacement works at build time • Extension routes • Extension localization • Extension installation • Injecting External SDK Scripts • How script injection works in Storefront Next • Choosing the right mechanism • Example: Global SDK via contextProvider • Example: Checkout-scoped SDK via components • Handling SPA re-initialization • Script placement decision guide • Storefront Action Hooks • Available action hooks • Declaring and writing action hooks • Listing available extension points • Building the back-end • Extension Points • Custom SCAPI • Backend Development Notes • Example Apps in the Registry • Anti-patterns to avoid",
       "summary": "Build a Commerce App by choosing an architecture (UI-only, Backend-only, or Fullstack) and using Claude Code skills to scaffold and generate app structure with extension points.",
       "keywords": [
         "build commerce app",
@@ -4585,6 +4590,21 @@
       "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/hybrid-auth-environment-matrix.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/hybrid-auth-environment-matrix.md",
       "headings": "Setup Guide by Architecture and Environment • Configuration by Environment • Route Ownership • Canonical Routing Rules • Notes",
+      "summary": "Set up Hybrid Auth routing across B2C Commerce environments (PIG, ODS, localhost) for Storefront Next and PWA Kit architectures.",
+      "keywords": [
+        "Hybrid Auth",
+        "routing",
+        "PIG",
+        "ODS",
+        "Storefront Next",
+        "PWA Kit",
+        "Composable Storefront",
+        "environment setup",
+        "eCDN",
+        "localhost",
+        "hybrid implementation",
+        "traffic routing"
+      ],
       "relatedEntries": [
         "commerce-api/hybrid-authentication"
       ]
@@ -4596,6 +4616,21 @@
       "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/hybrid-auth-manual-setup.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/hybrid-auth-manual-setup.md",
       "headings": "Are You Starting Fresh or Coming from an Existing Setup? • Fresh Setup • Existing Setup • Set Up by Instance Type • PIG (Primary Instance Group) • ODS (On-Demand Sandbox) • Localhost (Local Development) • SFRA/SiteGenesis Proper + Hybrid Auth (Session Extension and SLAS Setup) • Scope • High-Level Steps • Validate the Setup • Migration Recommendation • Headless Storefronts + SFRA/SiteGenesis • When to Use This Path • Supported Scenario • Before You Begin • Step-by-Step Setup • Step 1: Authenticate Shoppers with SLAS • Step 2: Respect SLAS Set-Cookie Responses • Step 3: Send the `sfdc_dwsid` Header on SCAPI Calls • Step 4: Configure Route Ownership Between Headless and SFRA • Step 5: (Optional) Basket Merge and Shopper Context • Step 6: Validate Cross-Runtime Navigation • Next Steps",
+      "summary": "Set up hybrid authentication manually for PWA Kit, SFRA, SiteGenesis, or headless storefronts by configuring MRT, SLAS, and eCDN.",
+      "keywords": [
+        "hybrid auth setup",
+        "manual hybrid authentication",
+        "PWA Kit",
+        "SFRA",
+        "SiteGenesis",
+        "Managed Runtime MRT",
+        "SLAS",
+        "headless storefront",
+        "session bridging",
+        "eCDN",
+        "Composable Storefront",
+        "hybrid storefront configuration"
+      ],
       "relatedEntries": [
         "commerce-api/hybrid-authentication"
       ]
@@ -4607,6 +4642,20 @@
       "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/hybrid-auth-quick-start.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/hybrid-auth-quick-start.md",
       "headings": "Before You Begin • Set Up by Instance Type • PIG (Primary Instance Group) • ODS (On-Demand Sandbox) • Localhost (Local Development) • Next Steps",
+      "summary": "Quickly set up a Storefront Next hybrid storefront with automated provisioning of MRT environment and eCDN through Business Manager.",
+      "keywords": [
+        "Storefront Next setup",
+        "automated setup",
+        "hybrid storefront",
+        "Managed Runtime",
+        "MRT environment",
+        "eCDN",
+        "hybrid auth",
+        "Business Manager provisioning",
+        "Storefront Next configuration",
+        "quick setup",
+        "hybrid authentication"
+      ],
       "relatedEntries": [
         "commerce-api/hybrid-authentication"
       ]
@@ -4617,6 +4666,20 @@
       "category": "b2c-commerce",
       "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/hybrid-auth-select-storefront.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/hybrid-auth-select-storefront.md",
+      "summary": "Choose and set up your storefront architecture (Storefront Next, PWA Kit, or SFRA/SiteGenesis) with appropriate hybrid authentication configuration.",
+      "keywords": [
+        "storefront selection",
+        "storefront architecture",
+        "PWA Kit setup",
+        "Storefront Next",
+        "SFRA SiteGenesis",
+        "hybrid implementation",
+        "hybrid auth",
+        "composable storefront",
+        "storefront configuration",
+        "headless commerce",
+        "implementation guide"
+      ],
       "relatedEntries": [
         "commerce-api/hybrid-authentication"
       ]
@@ -4628,6 +4691,21 @@
       "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/hybrid-auth-troubleshooting.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/hybrid-auth-troubleshooting.md",
       "headings": "Hybrid Auth Not Applying • Token or Session Drift Across Runtimes • eCDN Routing Mismatch • Localhost and Sandbox Differences • Missing SCAPI Short Code on On-Demand Sandboxes (ODS)",
+      "summary": "Diagnose and resolve common Hybrid Auth implementation issues including token drift, routing mismatches, and SLAS configuration problems.",
+      "keywords": [
+        "Hybrid Auth troubleshooting",
+        "SLAS client ID",
+        "session bridge",
+        "eCDN routing",
+        "token drift",
+        "SCAPI short code",
+        "Hybrid Auth not applying",
+        "session-bridge authentication",
+        "hybrid routing matrix",
+        "localhost hybrid proxy",
+        "ODS sandbox",
+        "auth loops"
+      ],
       "relatedEntries": [
         "commerce-api/hybrid-authentication"
       ]
@@ -6433,7 +6511,7 @@
       "category": "b2c-commerce",
       "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/reference.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/reference.md",
-      "headings": "commerce-app.json Schema • adminComponents.json Schema • Component Object Fields • `storefrontComponentVisibility` Attributes • Example • CI Validation • App-shipped string localization • Stable keys: `taskKey` and `componentKey` • `app-configuration/translations/<locale>.json` • Fallback chain • Locale rollout • Supported locales • CI validation • APIs • Install/Uninstall Jobs (OCAPI Data API) • Required OCAPI Permissions • Install Job Parameters • Uninstall Job Parameters • Job Execution Response • CommerceFeatureState Data Model • FeatureType Values • Multi-Site Behavior • Feature Toggles • Tax Domain Toggles • Install and Uninstall Flow Details • Install Flow • Uninstall Flow • App Registry Manifest • Manifest Entry Fields • Entry Types • Hub Display • Manifest and Catalog Cache TTL • Known Limitations • Storefront compatibility • Extension points • Installation and upgrades • Multi-site • Storefront Next extensions • External Documentation Links • Glossary",
+      "headings": "commerce-app.json Schema • adminComponents.json Schema • Component Object Fields • `storefrontComponentVisibility` Attributes • Example • CI Validation • App-shipped string localization • Stable keys: `taskKey` and `componentKey` • `app-configuration/translations/<locale>.json` • Fallback chain • Locale rollout • Supported locales • CI validation • adminComponents.json Schema • Component Object Fields • `storefrontComponentVisibility` Attributes • Example • CI Validation • App-shipped string localization • Stable keys: `taskKey` and `componentKey` • `app-configuration/translations/<locale>.json` • Fallback chain • Locale rollout • Supported locales • CI validation • APIs • Install/Uninstall Jobs (OCAPI Data API) • Required OCAPI Permissions • Install Job Parameters • Uninstall Job Parameters • Job Execution Response • CommerceFeatureState Data Model • FeatureType Values • Multi-Site Behavior • Feature Toggles • Tax Domain Toggles • Install and Uninstall Flow Details • Install Flow • Uninstall Flow • App Registry Manifest • Manifest Entry Fields • Entry Types • Hub Display • Manifest and Catalog Cache TTL • Manifest and Catalog Cache TTL • Known Limitations • Storefront compatibility • Extension points • Installation and upgrades • Multi-site • Storefront Next extensions • Connection Health Check • Extension Point • Status Interpretation • Status Detail Keys • Localization • Timeout Behavior • Availability • External Documentation Links • Glossary",
       "summary": "Define Commerce App package identity, metadata, and publisher details using the required commerce-app.json schema file.",
       "keywords": [
         "commerce-app.json",
@@ -6924,6 +7002,32 @@
       ]
     },
     {
+      "id": "commerce-api/cdn-caching",
+      "title": "SCAPI CDN Caching",
+      "category": "commerce-api",
+      "url": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/cdn-caching.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/cdn-caching.md",
+      "headings": "How It Works • Enablement • Time-to-Live • Invalidation • Cache Tags • The personalized=none Query Parameter • Applicable APIs • The cf-cache-status Response Header • Example: How a Request Travels Through Both Cache Tiers • Troubleshooting • Custom APIs",
+      "summary": "Implement CDN caching for non-personalized SCAPI GET responses to reduce latency and improve headless storefront performance using the personalized=none parameter.",
+      "keywords": [
+        "SCAPI CDN caching",
+        "personalized=none",
+        "CDN edge cache",
+        "content delivery network",
+        "web-tier caching",
+        "non-personalized responses",
+        "latency reduction",
+        "headless storefront",
+        "cache hit",
+        "TTL",
+        "SCAPI performance",
+        "commerce API caching"
+      ],
+      "relatedEntries": [
+        "commerce-api/performance"
+      ]
+    },
+    {
       "id": "commerce-api/cdn-pci-4-compliance",
       "title": "eCDN PCI 4.0 Compliance Tools",
       "category": "commerce-api",
@@ -7096,7 +7200,7 @@
       "category": "commerce-api",
       "url": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/cdn-zones-custom-rules.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/cdn-zones-custom-rules.md",
-      "headings": "Validation Overview • Rule Expression • Rule Actions • Rule Order • Position • Create a Custom Rule • Sample Success Response - 201 HttpStatus Code • Get All Custom Rules • Sample Success Response - 200 HttpStatus Code • Get a Custom Rule • Sample Success Response - 200 HttpStatus Code • Update a Custom Rule • Sample Success Response - 200 HttpStatus Code • Update the Order of All Custom Rules • Sample Success Response - 200 HttpStatus Code • Delete a Custom Rule • Sample Success Response - 204 HttpStatus Code (No Content) • Transition From Firewall Rules to Custom Rules • Manage Block All Rule Information • Create an Allowlist Using Custom Rules • Create a Blocklist Using Custom Rules • Custom Rules FAQ",
+      "headings": "Validation Overview • Rule Expression • Rule Actions • Rule Order • Position • Create a Custom Rule • Sample Success Response - 201 HttpStatus Code • Get All Custom Rules • Sample Success Response - 200 HttpStatus Code • Get a Custom Rule • Sample Success Response - 200 HttpStatus Code • Update a Custom Rule • Sample Success Response - 200 HttpStatus Code • Update the Order of All Custom Rules • Sample Success Response - 200 HttpStatus Code • Delete a Custom Rule • Sample Success Response - 204 HttpStatus Code (No Content) • Custom Rules FAQ",
       "summary": "Create and manage eCDN custom firewall rules to control incoming traffic using expressions, request parameters, and rule actions like block or js_challenge.",
       "keywords": [
         "eCDN custom rules",
@@ -7370,6 +7474,7 @@
       "category": "commerce-api",
       "url": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/custom-api-caching.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/custom-api-caching.md",
+      "headings": "CDN Caching",
       "summary": "Enable and configure response caching for Custom API endpoints using setExpires() and setVaryBy() methods to improve performance.",
       "keywords": [
         "caching custom API",
@@ -7578,7 +7683,7 @@
       "category": "commerce-api",
       "url": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/develop.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/develop.md",
-      "headings": "Prerequisites • Next Steps",
+      "headings": "API Categories Overview • Start Here: Common Task Paths • Building a Storefront • Automating Backend Operations • Building with Storefront Next • Building with PWA Kit • Prerequisites • Next Steps",
       "summary": "Build applications using B2C Commerce APIs with resources for Shopper and Admin APIs, including prerequisites and best practices.",
       "keywords": [
         "B2C Commerce API",
@@ -7760,6 +7865,32 @@
       ]
     },
     {
+      "id": "commerce-api/guest-order-access-code",
+      "title": "Guest Order Access with an Access Code (OTP)",
+      "category": "commerce-api",
+      "url": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/guest-order-access-code.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/guest-order-access-code.md",
+      "headings": "What the Platform Does vs. What You Do • Capabilities With and Without OMS • Reach Orders No Longer in B2C Commerce • Flow Overview • Lookup Only (No OMS) • Full Self-Service (with Integrated OMS) • Implement the Delivery Hook • Register the Extension Point • Implement the Script • Hook Parameters • Return Values • Deliver Through a Non-Email Channel • Call the Shopper Orders Endpoints • Request an Access Code • Look Up the Order • Without Integrated OMS • With Integrated OMS (`expand=oms`) • Cancel an Order (Requires Integrated OMS) • Return Items (Requires Integrated OMS) • Access Code Rules • Limitations • Best Practices • See Also",
+      "summary": "Enable guest shoppers to securely access and manage their orders after losing session via email-based one-time password (OTP) access codes.",
+      "keywords": [
+        "guest order access",
+        "OTP",
+        "one-time password",
+        "access code",
+        "order lookup",
+        "Shopper Orders API",
+        "guest checkout",
+        "order self-service",
+        "email hook",
+        "order management",
+        "guest authentication",
+        "session recovery"
+      ],
+      "relatedEntries": [
+        "commerce-api/use-shopper-api"
+      ]
+    },
+    {
       "id": "commerce-api/hook-method-details",
       "title": "Hook Method Details",
       "category": "commerce-api",
@@ -7817,6 +7948,21 @@
       "url": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/hybrid-auth-shared-setup.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/hybrid-auth-shared-setup.md",
       "headings": "Step 1: Set Up a SLAS Client • Step 2: Enable Session Bridging • Step 3: (Optional) Configure Third-Party IDP and Social Login • Step 4: Configure Business Manager • Step 5: Remove Plugin SLAS (If Migrating) • Step 6: Remove OCAPI Permissions (If Migrating from Plugin SLAS) • Step 7: (Optional) Set Shopper Context • Step 8: (Optional) Enable or Disable Do-Not-Track Synchronization • DNT Cookie Expiration • Next Steps",
+      "summary": "Configure shared Hybrid Auth setup across all storefront architectures including SLAS client, session bridging, and platform dependencies.",
+      "keywords": [
+        "hybrid auth setup",
+        "SLAS client configuration",
+        "session bridging",
+        "commerce API authentication",
+        "third-party IDP",
+        "social login",
+        "business manager",
+        "Storefront Next",
+        "PWA Kit",
+        "SFRA",
+        "shopper APIs",
+        "hybrid authentication"
+      ],
       "relatedEntries": [
         "commerce-api/hybrid-authentication"
       ]
@@ -8006,7 +8152,8 @@
       ],
       "relatedEntries": [
         "commerce-api/scapi-get-started",
-        "commerce-api/server-side-web-tier-caching"
+        "commerce-api/server-side-web-tier-caching",
+        "commerce-api/cdn-caching"
       ]
     },
     {
@@ -8710,7 +8857,7 @@
       "category": "commerce-api",
       "url": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-passwordless-login-overview.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-passwordless-login-overview.md",
-      "headings": "Passwordless Login Feature Support",
+      "headings": "Choosing a Passwordless Method • Decision Guidance • Passwordless Login Feature Support",
       "summary": "Implement secure passwordless authentication for shoppers using OTPs, SMS, or passkeys via SLAS.",
       "keywords": [
         "passwordless login",
@@ -9210,6 +9357,7 @@
       "category": "commerce-api",
       "url": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/troubleshoot.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/troubleshoot.md",
+      "headings": "Quick Triage: Find Your Solution • Troubleshooting Resources • Step-by-Step Troubleshooting Process • 1. Identify the Request • 2. Check the Response • 3. Review Logs • 4. Monitor Performance • 5. Verify Configuration • 6. Test and Validate",
       "summary": "Debug and resolve B2C Commerce API issues using error codes, response analysis, rate limits, timeouts, and performance monitoring tools.",
       "keywords": [
         "API troubleshooting",
@@ -9292,7 +9440,7 @@
       "category": "commerce-api",
       "url": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/use-admin-api.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/use-admin-api.md",
-      "headings": "Next Steps",
+      "headings": "Admin API Overview • Authentication Prerequisites • Common Automation Scenarios • Scenario 1: Automated Inventory Synchronization • Scenario 2: CDN Configuration Management • Scenario 3: Product Catalog Updates • Scenario 4: Customer Data Integration • Scenario 5: Multi-Site Configuration Deployment • Additional Resources • Next Steps",
       "summary": "Configure and manage SCAPI Admin APIs for CDN zones, inventory, WAF rules, certificates, and authentication settings.",
       "keywords": [
         "SCAPI Admin API",
@@ -9343,7 +9491,7 @@
       "category": "commerce-api",
       "url": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/use-shopper-api.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/commerce-api/guide/use-shopper-api.md",
-      "headings": "Next Steps",
+      "headings": "Common Use Case Mappings • Building a Product Listing Page (PLP) • Building a Product Detail Page (PDP) • Building a Checkout Flow • Implementing Personalization • Additional Resources • Next Steps",
       "summary": "Access Shopper APIs for authentication, context management, and SEO to build B2C Commerce storefronts.",
       "keywords": [
         "Shopper APIs",
@@ -9364,6 +9512,7 @@
         "commerce-api/slas",
         "commerce-api/shopper-context-api",
         "commerce-api/work-with-baskets-orders",
+        "commerce-api/guest-order-access-code",
         "commerce-api/promotion-details",
         "commerce-api/mcp-shopper-tools",
         "commerce-api/url-resolution"
@@ -9540,6 +9689,7 @@
         "pwa-kit-managed-runtime/address-autocomplete",
         "pwa-kit-managed-runtime/one-click-checkout",
         "pwa-kit-managed-runtime/tracking-consent",
+        "pwa-kit-managed-runtime/protect-storefront",
         "pwa-kit-managed-runtime/maximizing-your-cache-hit-ratio",
         "pwa-kit-managed-runtime/create-a-sitemap"
       ]
@@ -10021,6 +10171,20 @@
       "url": "https://developer.salesforce.com/docs/commerce/pwa-kit-managed-runtime/guide/hybrid-routing-matrix.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/pwa-kit-managed-runtime/guide/hybrid-routing-matrix.md",
       "headings": "Use the Right Rule Syntax by Setup Type • Architectural Foundations • Matrix Configurations • Matrix-01: Modern Core (Home, PDP, PLP on PWA Kit) • Matrix-02: Modern Checkout (Cart and Checkout on PWA Kit) • Matrix-03: Modern Entry Only (Home on PWA Kit) • Matrix-04: Legacy Entry Only (Home on SFRA) • Matrix-05: Catalog-Only Migration (PLP/PDP on PWA Kit) • Matrix-06: Account and Auth Only (Identity Flows on PWA Kit) • Global Framework Requirements",
+      "summary": "Configure routing between PWA Kit and SFRA/SiteGenesis using eCDN rules and app/routes.jsx filtering for hybrid storefronts.",
+      "keywords": [
+        "hybrid storefront routing",
+        "PWA Kit routing matrix",
+        "eCDN routing rules",
+        "app/routes.jsx",
+        "Composable Storefront",
+        "SFRA SiteGenesis",
+        "Managed Runtime MRT",
+        "Cloudflare rule expression",
+        "hybrid proxy local development",
+        "phased headless rollout",
+        "React Router navigation"
+      ],
       "relatedEntries": [
         "pwa-kit-managed-runtime/hybrid-implementation"
       ]
@@ -10915,6 +11079,32 @@
         "pwa-kit-managed-runtime/phased-headless-rollouts",
         "pwa-kit-managed-runtime/hybrid-upgrade-v3.x",
         "pwa-kit-managed-runtime/hybrid-upgrade-v2.x"
+      ]
+    },
+    {
+      "id": "pwa-kit-managed-runtime/protect-storefront",
+      "title": "Limit Access to a Storefront Under Development",
+      "category": "pwa-kit-managed-runtime",
+      "url": "https://developer.salesforce.com/docs/commerce/pwa-kit-managed-runtime/guide/protect-storefront.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/pwa-kit-managed-runtime/guide/protect-storefront.md",
+      "headings": "Enable a Protected Storefront • Limitations",
+      "summary": "Enable Protected Storefronts in Business Manager to restrict storefront access during development to only authorized organization users via basic authentication.",
+      "keywords": [
+        "protected storefront",
+        "limit access",
+        "development environment",
+        "basic auth",
+        "site status",
+        "shared password",
+        "restrict access",
+        "storefront under development",
+        "Business Manager",
+        "access control",
+        "authentication",
+        "online protected"
+      ],
+      "relatedEntries": [
+        "pwa-kit-managed-runtime/build-customize"
       ]
     },
     {
@@ -12354,13 +12544,16 @@
         "sfnext/sfnext-mcp-server",
         "sfnext/sfnext-mrt-data-store",
         "sfnext/sfnext-customize",
+        "sfnext/sfnext-pd-deploy-cartridge",
         "sfnext/sfnext-push-mrt-auto",
         "sfnext/sfnext-modern-exp",
         "sfnext/sfnext-instore-pickup",
+        "sfnext/sfnext-order-mgmt",
         "sfnext/sfnext-shopping-agent",
         "sfnext/sfnext-page-designer",
-        "sfnext/sfnext-address-autocomplete",
         "sfnext/sfnext-one-click-checkout",
+        "sfnext/sfnext-address-autocomplete",
+        "sfnext/sfnext-salesforce-payments",
         "sfnext/sfnext-passwordless-login",
         "sfnext/sfnext-email-verification",
         "sfnext/sfnext-social-login",
@@ -12639,6 +12832,7 @@
       "relatedEntries": [
         "sfnext/sfnext-get-started",
         "sfnext/sfnext-release-notes",
+        "sfnext/sfnext-mrt-release-notes",
         "sfnext/sfnext-architecture",
         "sfnext/sfnext-browser-comp",
         "sfnext/sfnext-quick-start-choice",
@@ -12828,6 +13022,32 @@
       ]
     },
     {
+      "id": "sfnext/sfnext-load-more",
+      "title": "Keep Shoppers Browsing with Load More Pagination",
+      "category": "sfnext",
+      "url": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-load-more.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-load-more.md",
+      "headings": "Configure Pagination",
+      "summary": "Configure load-more pagination on product listing pages to keep shoppers browsing without page reloads or scroll loss.",
+      "keywords": [
+        "load more pagination",
+        "product listing pages",
+        "pagination configuration",
+        "uiConfig.pages.category.pagination",
+        "load more button",
+        "numbered pagination",
+        "traditional pagination",
+        "infinite scroll",
+        "category page pagination",
+        "sfnext pagination",
+        "progress indicator",
+        "ui config"
+      ],
+      "relatedEntries": [
+        "sfnext/sfnext-modern-exp"
+      ]
+    },
+    {
       "id": "sfnext/sfnext-logging",
       "title": "Logging in Storefront Next",
       "category": "sfnext",
@@ -12954,7 +13174,8 @@
       ],
       "relatedEntries": [
         "sfnext/sfnext-customize-sf",
-        "sfnext/sfnext-prototyped-cmp"
+        "sfnext/sfnext-prototyped-cmp",
+        "sfnext/sfnext-load-more"
       ]
     },
     {
@@ -13145,7 +13366,7 @@
       "category": "sfnext",
       "url": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-launch-storefront.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-launch-storefront.md",
-      "headings": "Before You Begin • Launching an Environment • 1. Import the Storefront to the Staging or Production Instance • 2. Perform the Cutover • Default Domain • Vanity Domain or New Zone • Set the MRT Access Control Header • Send the Access Control Header from eCDN to the MRT Origin • 3. Monitor the Site",
+      "headings": "Before You Begin • Launching an Environment • 1. Import the Storefront to the Staging or Production Instance • 2. Update the SLAS Client Redirect URI • 3. Perform the Cutover • Default Domain • Vanity Domain or New Zone • Send the Access Control Header from eCDN to the MRT Origin • 4. Finalize the Environment • 5. Monitor the Site",
       "summary": "Deploy and publish your Storefront Next to a public web address with proper DNS and Managed Runtime configuration.",
       "keywords": [
         "launch storefront",
@@ -13160,6 +13381,30 @@
         "go live",
         "publish storefront",
         "environment launch"
+      ],
+      "relatedEntries": [
+        "sfnext/sfnext-mrt-section"
+      ]
+    },
+    {
+      "id": "sfnext/sfnext-mrt-node-version",
+      "title": "Node Version Support",
+      "category": "sfnext",
+      "url": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-node-version.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-node-version.md",
+      "headings": "Supported Node Versions • Opt Out of Email Notifications",
+      "summary": "Manage Node.js versions for Storefront Next Managed Runtime environments, understanding support lifecycles and upgrade requirements.",
+      "keywords": [
+        "Node.js version support",
+        "Node version upgrade",
+        "Managed Runtime Node",
+        "Storefront Next Node",
+        "Node.js deprecation",
+        "Node.js end of life",
+        "Runtime environment Node",
+        "Node version lifecycle",
+        "Node.js deployment",
+        "Runtime Admin notifications"
       ],
       "relatedEntries": [
         "sfnext/sfnext-mrt-section"
@@ -13189,6 +13434,30 @@
       ],
       "relatedEntries": [
         "sfnext/sfnext-mrt-section"
+      ]
+    },
+    {
+      "id": "sfnext/sfnext-mrt-release-notes",
+      "title": "Managed Runtime Release Notes",
+      "category": "sfnext",
+      "url": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-release-notes.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-release-notes.md",
+      "headings": "<Date> - vx.y.z • <Release note title> • 7/28/2026 • SSR Bundle Size Limit Lowered to 247 MB",
+      "summary": "Track Managed Runtime feature updates, changes, and new capabilities across releases.",
+      "keywords": [
+        "Managed Runtime release notes",
+        "MRT releases",
+        "sfnext updates",
+        "SSR bundle size limit",
+        "release changelog",
+        "feature updates",
+        "MRT changelog",
+        "version history",
+        "Managed Runtime changes",
+        "deployment updates"
+      ],
+      "relatedEntries": [
+        "sfnext/sfnext-get-started-section"
       ]
     },
     {
@@ -13241,6 +13510,7 @@
         "sfnext/sfnext-get-started",
         "sfnext/sfnext-mrt-overview",
         "sfnext/sfnext-mrt-administration",
+        "sfnext/sfnext-mrt-node-version",
         "sfnext/sfnext-mrt-api",
         "sfnext/sfnext-mrt-environment-vars",
         "sfnext/sfnext-mrt-env-vars-api",
@@ -13301,12 +13571,37 @@
       ]
     },
     {
+      "id": "sfnext/sfnext-order-mgmt",
+      "title": "Integrate Storefront Next with Salesforce Order Management",
+      "category": "sfnext",
+      "url": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-order-mgmt.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-order-mgmt.md",
+      "headings": "Prerequisite: Connect Your B2C Commerce Instance and the Order Management Organization • Step 1: Connect a B2C Commerce Instance to the SOM organization • Step 2: Verify the Connection by Placing an Order • Storefront Next-SOM Integration Considerations • Getting Orders from SOM • Placing Orders in SOM • Managing Orders in SOM • Prerequisites • Accessing the Order Detail Page • Tracking Order Shipments • Canceling an Order • Returning Eligible Items • Order Refunds • Status Badge",
+      "summary": "Connect Storefront Next with Salesforce Order Management to display and sync orders, enabling shoppers to track shipments and manage returns from the storefront.",
+      "keywords": [
+        "Storefront Next Order Management integration",
+        "SOM integration",
+        "order history page",
+        "order tracking",
+        "order synchronization",
+        "B2C Commerce Order Management",
+        "order status",
+        "return management",
+        "self-service order management",
+        "order detail page",
+        "connect B2C Commerce SOM"
+      ],
+      "relatedEntries": [
+        "sfnext/sfnext-customize-sf"
+      ]
+    },
+    {
       "id": "sfnext/sfnext-page-designer",
       "title": "Page Designer Integration with Storefront Next",
       "category": "sfnext",
       "url": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-page-designer.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-page-designer.md",
-      "headings": "How It Works for Developers • Core Architecture • Prerequisites • Implement Page Designer Components • Component Structure • Metadata Decorators • Basic Component Example • Attribute Types • Component Patterns: Fallbacks and Loaders • Fallback Components • Data Loaders • Components with Regions • Region Definition Options • Implement Page Designer Pages • Page Structure • Page Metadata Options • Supported Aspect Types • Region Usage in Pages • Generate Cartridges • Automatic Generation on Build • Manual Generation • Generated Output Structure • Generated Metadata Format • Key Notes • Deploy Cartridges • Prerequisites • Deploy the Cartridge with the `push` Command • Manual Cartridge Deployment • Deployment Process • Business Manager Setup • Prerequisites • Using Page Designer • Page Assignment • Live Preview • Shopper Context Preview • Known Limitations • Local Development • Setup Steps • Troubleshooting • Merchant Storefront Next Customization • Content Slot Migration from SFRA",
+      "headings": "How It Works for Developers • Core Architecture • Implement Page Designer Components • Component Structure • Metadata Decorators • Basic Component Example • Attribute Types • Component Patterns: Fallbacks and Loaders • Fallback Components • Data Loaders • Components with Regions • Region Definition Options • Implement Page Designer Pages • Page Structure • Page Metadata Options • Supported Aspect Types • Region Usage in Pages • Generate Cartridges • Automatic Generation on Build • Manual Generation • Generated Output Structure • Generated Metadata Format • Key Notes • Deploy Cartridges • Prerequisites • Deploy the Cartridge with the `push` Command • Manual Cartridge Deployment • Deployment Process • Business Manager Setup • Prerequisites • Using Page Designer • Page Assignment • Live Preview • Shopper Context Preview • Known Limitations • Local Development • Setup Steps • Troubleshooting • Merchant Storefront Next Customization • Content Slot Migration from SFRA",
       "summary": "Build reusable React components for Page Designer in Storefront Next to enable merchants to create personalized pages without developer intervention.",
       "keywords": [
         "Page Designer",
@@ -13449,6 +13744,32 @@
         "Storefront Next",
         "config.server.ts",
         "shopper authentication"
+      ],
+      "relatedEntries": [
+        "sfnext/sfnext-customize-sf"
+      ]
+    },
+    {
+      "id": "sfnext/sfnext-pd-deploy-cartridge",
+      "title": "Deploy the Storefront Next Cartridge for Page Designer",
+      "category": "sfnext",
+      "url": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-pd-deploy-cartridge.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-pd-deploy-cartridge.md",
+      "headings": "Prerequisites: • Automatic Cartridge Sync with the VS Code Extension",
+      "summary": "Deploy the Storefront Next cartridge to upload Page Designer metadata and components to your B2C Commerce instance after setup or modifications.",
+      "keywords": [
+        "deploy Storefront Next cartridge",
+        "Page Designer metadata",
+        "Page Designer components",
+        "dw.json configuration",
+        "B2C DX CLI deploy",
+        "cartridge deployment",
+        "Page Designer pages",
+        "Storefront Next setup",
+        "Business Manager deployment",
+        "upload Page Designer",
+        "code version deployment",
+        "sfnext cartridge"
       ],
       "relatedEntries": [
         "sfnext/sfnext-customize-sf"
@@ -14202,7 +14523,7 @@
       "category": "sfnext",
       "url": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-quick-start-create-bm.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-quick-start-create-bm.md",
-      "headings": "Prerequisites • Constraints • Steps",
+      "headings": "Prerequisites • Constraints • Steps • Next Steps",
       "summary": "Create a Storefront Next in Business Manager and generate its code locally using Salesforce CLI.",
       "keywords": [
         "Storefront Next",
@@ -14228,7 +14549,7 @@
       "category": "sfnext",
       "url": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-quick-start-create-bm-github.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-quick-start-create-bm-github.md",
-      "headings": "Prerequisites • Constraints • Steps",
+      "headings": "Prerequisites • Constraints • Steps • Next Steps",
       "summary": "Set up a Storefront Next instance in Business Manager by connecting a GitHub repository to create storefront code and dependent API and Managed Runtime resources.",
       "keywords": [
         "Storefront Next",
@@ -14280,9 +14601,48 @@
       "category": "sfnext",
       "url": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-release-notes.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-release-notes.md",
-      "headings": "<Date> - vx.y.z • <Date> - B2C Commerce 26.x • <Release note title> • July 9, 2026 - v1.1.0 • Maintain Shopper Sessions Across Subdomains in Storefront Next • Secure Your Storefront and Stabilize APIs by Upgrading to React Router 7.18",
+      "headings": "<Date> - vx.y.z • <Date> - B2C Commerce 26.x • <Release note title> • August 4, 2026 - Storefront Next 1.2.0 • Integrate Storefront Next with Salesforce Order Management • Keep Shoppers Browsing with Load More Pagination • July 21, 2026 - B2C Commerce 26.8 • Speed Up Storefront Next Development with the Beauty Street Template • July 9, 2026 - Storefront Next 1.1.0 • Process Payments Natively in Storefront Next with Salesforce Payments • Maintain Shopper Sessions Across Subdomains in Storefront Next • Secure Your Storefront and Stabilize APIs by Upgrading to React Router 7.18",
+      "summary": "Track new features and changes in Storefront Next monthly releases with links to detailed GitHub release information.",
+      "keywords": [
+        "Storefront Next release notes",
+        "sfnext releases",
+        "Storefront Next features",
+        "monthly releases",
+        "version updates",
+        "changelog",
+        "GitHub releases",
+        "Storefront Next v1.0.0",
+        "template updates",
+        "B2C Commerce releases"
+      ],
       "relatedEntries": [
         "sfnext/sfnext-get-started-section"
+      ]
+    },
+    {
+      "id": "sfnext/sfnext-salesforce-payments",
+      "title": "Configure Salesforce Payments for Storefront Next",
+      "category": "sfnext",
+      "url": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-salesforce-payments.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-salesforce-payments.md",
+      "headings": "Set Up Salesforce Payments for Storefront Next • Prerequisites • Steps",
+      "summary": "Set up Salesforce Payments for Storefront Next by configuring payment gateways, defining types, and updating configuration URLs.",
+      "keywords": [
+        "Salesforce Payments",
+        "Storefront Next",
+        "payment gateway configuration",
+        "Adyen",
+        "Stripe",
+        "PayPal",
+        "checkout",
+        "B2C Commerce payments",
+        "config.server.ts",
+        "payment methods",
+        "sdkUrl",
+        "metadataUrl"
+      ],
+      "relatedEntries": [
+        "sfnext/sfnext-customize-sf"
       ]
     },
     {

--- a/packages/b2c-tooling-sdk/data/help/index.json
+++ b/packages/b2c-tooling-sdk/data/help/index.json
@@ -1,6 +1,11 @@
 {
   "version": "2.0.0",
-  "generatedAt": "2026-07-17T15:31:19.255Z",
+  "generatedAt": "2026-08-03T18:06:26.853Z",
+  "source": {
+    "sha": "073f7f276321e25b00034d3a9a467690024ad9b8",
+    "committedAt": "2026-07-02T11:30:54-06:00",
+    "ref": "dev"
+  },
   "entries": [
     {
       "id": "help-admin/b2c__replication_best_practices",

--- a/packages/b2c-tooling-sdk/data/job-steps/index.json
+++ b/packages/b2c-tooling-sdk/data/job-steps/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-02T00:13:16.337Z",
+  "generatedAt": "2026-08-03T18:22:27.295Z",
   "entries": [
     {
       "id": "CatalogDeltaExport",

--- a/packages/b2c-tooling-sdk/data/job-steps/job-steps.json
+++ b/packages/b2c-tooling-sdk/data/job-steps/job-steps.json
@@ -3,7 +3,7 @@
   "provenance": {
     "description": "Catalog of standard (system) B2C Commerce job step type IDs available in Business Manager job flows and jobs.xml site-import flows.",
     "derivation": "Generated from the public B2C Commerce Job Step API documentation (the jobstepapi section of the Script API documentation archive obtained via `b2c docs download`). Each step lists its purpose, execution scope, and input parameters (required, description, allowed values, default) as published in that documentation.",
-    "platformDocVersion": "DWAPP 26.7",
+    "platformDocVersion": "DWAPP 26.8",
     "regenerate": "pnpm --filter @salesforce/b2c-tooling-sdk run refresh:docs-data (or, standalone: build:job-steps-dataset -- <jobstep-html-dir> [version]; then generate:job-steps-docs)"
   },
   "steps": [

--- a/packages/b2c-tooling-sdk/data/script-api/dw.catalog.ProductSearchModel.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.catalog.ProductSearchModel.md
@@ -43,6 +43,7 @@ search refinement. It also provides utility methods to generate a search URL.
 | [categoryID](#categoryid): [String](TopLevel.String.md) | Returns the category id that was specified in the search query. |
 | [categorySearch](#categorysearch): [Boolean](TopLevel.Boolean.md) `(read-only)` | The method returns true, if this is a pure search for a category. |
 | [deepestCommonCategory](#deepestcommoncategory): [Category](dw.catalog.Category.md) `(read-only)` | Returns the deepest common category of all products in the search result. |
+| [effectiveSearchMode](#effectivesearchmode): [String](TopLevel.String.md) `(read-only)` | Returns the effective search mode that was used for the last search execution. |
 | [effectiveSortingRule](#effectivesortingrule): [SortingRule](dw.catalog.SortingRule.md) `(read-only)` | Returns the sorting rule used to order the products in the results of this query,  or `null` if no search has been executed yet. |
 | [inventoryIDs](#inventoryids): [List](dw.util.List.md) `(read-only)` | <p>  Returns a list of inventory IDs that were specified in the search query or an empty list if no inventory ID set. |
 | [orderableProductsOnly](#orderableproductsonly): [Boolean](TopLevel.Boolean.md) | Get the flag indicating whether unorderable products should be excluded  when the next call to getProducts() is made. |
@@ -64,6 +65,7 @@ search refinement. It also provides utility methods to generate a search URL.
 | [refinedCategorySearch](#refinedcategorysearch): [Boolean](TopLevel.Boolean.md) `(read-only)` | Identifies if this is a category search and is refined with further  criteria, like a brand refinement or an attribute refinement. |
 | [refinementCategory](#refinementcategory): [Category](dw.catalog.Category.md) | Returns the category used to determine possible refinements for the search. |
 | [refinements](#refinements): [ProductSearchRefinements](dw.catalog.ProductSearchRefinements.md) `(read-only)` | Returns the ProductSearchRefinements associated with this search and filtered by session currency. |
+| [searchMode](#searchmode): [String](TopLevel.String.md) | Returns the search mode that was requested for the next search execution via [setSearchMode(String)](dw.catalog.ProductSearchModel.md#setsearchmodestring), or  {@code null} if no mode was explicitly requested. |
 | [searchPhraseSuggestions](#searchphrasesuggestions): [SearchPhraseSuggestions](dw.suggest.SearchPhraseSuggestions.md) `(read-only)` | Returns search phrase suggestions for the current search phrase. |
 | [searchableImageUploadURL](#searchableimageuploadurl): [String](TopLevel.String.md) `(read-only)` | This method returns the URL of the endpoint where the merchants should upload their image for visual search. |
 | [sortingRule](#sortingrule): [SortingRule](dw.catalog.SortingRule.md) | Returns the sorting rule explicitly set on this model to be used  to order the products in the results of this query, or `null`  if no rule has been explicitly set. |
@@ -88,6 +90,7 @@ search refinement. It also provides utility methods to generate a search URL.
 | [getCategory](dw.catalog.ProductSearchModel.md#getcategory)() | Returns the category object for the category id specified in the query. |
 | [getCategoryID](dw.catalog.ProductSearchModel.md#getcategoryid)() | Returns the category id that was specified in the search query. |
 | [getDeepestCommonCategory](dw.catalog.ProductSearchModel.md#getdeepestcommoncategory)() | Returns the deepest common category of all products in the search result. |
+| [getEffectiveSearchMode](dw.catalog.ProductSearchModel.md#geteffectivesearchmode)() | Returns the effective search mode that was used for the last search execution. |
 | [getEffectiveSortingRule](dw.catalog.ProductSearchModel.md#geteffectivesortingrule)() | Returns the sorting rule used to order the products in the results of this query,  or `null` if no search has been executed yet. |
 | [getInventoryIDs](dw.catalog.ProductSearchModel.md#getinventoryids)() | <p>  Returns a list of inventory IDs that were specified in the search query or an empty list if no inventory ID set. |
 | [getOrderableProductsOnly](dw.catalog.ProductSearchModel.md#getorderableproductsonly)() | Get the flag indicating whether unorderable products should be excluded  when the next call to getProducts() is made. |
@@ -105,6 +108,7 @@ search refinement. It also provides utility methods to generate a search URL.
 | [getPromotionProductType](dw.catalog.ProductSearchModel.md#getpromotionproducttype)() | Returns the promotion product type specified in the search query. |
 | [getRefinementCategory](dw.catalog.ProductSearchModel.md#getrefinementcategory)() | Returns the category used to determine possible refinements for the search. |
 | [getRefinements](dw.catalog.ProductSearchModel.md#getrefinements)() | Returns the ProductSearchRefinements associated with this search and filtered by session currency. |
+| [getSearchMode](dw.catalog.ProductSearchModel.md#getsearchmode)() | Returns the search mode that was requested for the next search execution via [setSearchMode(String)](dw.catalog.ProductSearchModel.md#setsearchmodestring), or  {@code null} if no mode was explicitly requested. |
 | [getSearchPhraseSuggestions](dw.catalog.ProductSearchModel.md#getsearchphrasesuggestions)() | Returns search phrase suggestions for the current search phrase. |
 | [getSearchableImageUploadURL](dw.catalog.ProductSearchModel.md#getsearchableimageuploadurl)() | This method returns the URL of the endpoint where the merchants should upload their image for visual search. |
 | [getSortingRule](dw.catalog.ProductSearchModel.md#getsortingrule)() | Returns the sorting rule explicitly set on this model to be used  to order the products in the results of this query, or `null`  if no rule has been explicitly set. |
@@ -136,6 +140,7 @@ search refinement. It also provides utility methods to generate a search URL.
 | [setPromotionProductType](dw.catalog.ProductSearchModel.md#setpromotionproducttypestring)([String](TopLevel.String.md)) | Specifies the promotion product type used for the search query. |
 | [setRecursiveCategorySearch](dw.catalog.ProductSearchModel.md#setrecursivecategorysearchboolean)([Boolean](TopLevel.Boolean.md)) | Set a flag to indicate if the search in category should be recursive. |
 | [setRefinementCategory](dw.catalog.ProductSearchModel.md#setrefinementcategorycategory)([Category](dw.catalog.Category.md)) | Sets an explicit category to be used when determining refinements. |
+| [setSearchMode](dw.catalog.ProductSearchModel.md#setsearchmodestring)([String](TopLevel.String.md)) | Sets the search mode for the next search execution. |
 | [setSearchableImageID](dw.catalog.ProductSearchModel.md#setsearchableimageidstring)([String](TopLevel.String.md)) | An image ID can be retrieved by uploading an image with a multipart/form-data POST  request to 'https://api.cquotient.com/v3/image/search/upload/{siteID}'. |
 | ~~[setSortingCondition](dw.catalog.ProductSearchModel.md#setsortingconditionstring-number)([String](TopLevel.String.md), [Number](TopLevel.Number.md))~~ | Sets or removes a sorting condition for the specified attribute. |
 | [setSortingOption](dw.catalog.ProductSearchModel.md#setsortingoptionsortingoption)([SortingOption](dw.catalog.SortingOption.md)) | Sets the sorting option to be used to order the products in the results of this query. |
@@ -376,6 +381,16 @@ search refinement. It also provides utility methods to generate a search URL.
 
 ---
 
+### effectiveSearchMode
+- effectiveSearchMode: [String](TopLevel.String.md) `(read-only)`
+  - : Returns the effective search mode that was used for the last search execution. This reflects the actual matching
+      approach that ran, which may differ from the requested mode if a fallback occurred. Returns {@code null} before
+      [search()](dw.catalog.ProductSearchModel.md#search) has been called.
+
+
+
+---
+
 ### effectiveSortingRule
 - effectiveSortingRule: [SortingRule](dw.catalog.SortingRule.md) `(read-only)`
   - : Returns the sorting rule used to order the products in the results of this query,
@@ -584,6 +599,18 @@ This method should not be used because loading Products for each result of a pro
 
 ---
 
+### searchMode
+- searchMode: [String](TopLevel.String.md)
+  - : Returns the search mode that was requested for the next search execution via [setSearchMode(String)](dw.catalog.ProductSearchModel.md#setsearchmodestring), or
+      {@code null} if no mode was explicitly requested. This reflects the caller's requested preference, not the mode
+      that actually ran — the requested mode is non-authoritative and {@code "semantic"} may still be demoted to
+      {@code "lexical"} by the search router. Use [getEffectiveSearchMode()](dw.catalog.ProductSearchModel.md#geteffectivesearchmode) to obtain the mode that was
+      actually used after [search()](dw.catalog.ProductSearchModel.md#search).
+
+
+
+---
+
 ### searchPhraseSuggestions
 - searchPhraseSuggestions: [SearchPhraseSuggestions](dw.suggest.SearchPhraseSuggestions.md) `(read-only)`
   - : Returns search phrase suggestions for the current search phrase.
@@ -735,6 +762,21 @@ Please use [getSearchPhraseSuggestions()](dw.catalog.ProductSearchModel.md#getse
 
     **Returns:**
     - the deepest common category of all products in the search result of this search model or root for an empty search result.
+
+
+---
+
+### getEffectiveSearchMode()
+- getEffectiveSearchMode(): [String](TopLevel.String.md)
+  - : Returns the effective search mode that was used for the last search execution. This reflects the actual matching
+      approach that ran, which may differ from the requested mode if a fallback occurred. Returns {@code null} before
+      [search()](dw.catalog.ProductSearchModel.md#search) has been called.
+
+
+    **Returns:**
+    - {@code "semantic"} if the query ran against the external search provider, {@code "lexical"} if it ran
+              against the native search, or {@code null} if no search has been executed yet
+
 
 
 ---
@@ -986,6 +1028,21 @@ This method should not be used because loading Products for each result of a pro
 
     **Returns:**
     - the ProductSearchRefinements associated with this search.
+
+
+---
+
+### getSearchMode()
+- getSearchMode(): [String](TopLevel.String.md)
+  - : Returns the search mode that was requested for the next search execution via [setSearchMode(String)](dw.catalog.ProductSearchModel.md#setsearchmodestring), or
+      {@code null} if no mode was explicitly requested. This reflects the caller's requested preference, not the mode
+      that actually ran — the requested mode is non-authoritative and {@code "semantic"} may still be demoted to
+      {@code "lexical"} by the search router. Use [getEffectiveSearchMode()](dw.catalog.ProductSearchModel.md#geteffectivesearchmode) to obtain the mode that was
+      actually used after [search()](dw.catalog.ProductSearchModel.md#search).
+
+
+    **Returns:**
+    - {@code "semantic"} or {@code "lexical"} if a mode was requested, or {@code null} if no mode was requested
 
 
 ---
@@ -1393,6 +1450,22 @@ Please use [setProductIDs(List)](dw.catalog.ProductSearchModel.md#setproductidsl
 
     **Throws:**
     - IllegalArgumentException - if the refinement category does not reside in the storefront catalog
+
+
+---
+
+### setSearchMode(String)
+- setSearchMode(mode: [String](TopLevel.String.md)): void
+  - : Sets the search mode for the next search execution. The mode influences the routing decision made by the search
+      router, but is non-authoritative — {@code "semantic"} still runs the full routing cascade and may be demoted to
+      {@code "lexical"} based on availability and query characteristics.
+
+
+    **Parameters:**
+    - mode - the search mode to request, either {@code "semantic"} or {@code "lexical"}
+
+    **Throws:**
+    - IllegalArgumentException - if the mode is not one of the allowed values
 
 
 ---

--- a/packages/b2c-tooling-sdk/data/script-api/dw.commerceapps.ConnectionHealthStatusCodes.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.commerceapps.ConnectionHealthStatusCodes.md
@@ -1,0 +1,79 @@
+<!-- prettier-ignore-start -->
+# Class ConnectionHealthStatusCodes
+
+- [TopLevel.Object](TopLevel.Object.md)
+  - [dw.commerceapps.ConnectionHealthStatusCodes](dw.commerceapps.ConnectionHealthStatusCodes.md)
+
+Status codes and detail keys returned by the
+[ConnectionHealthCheckHooks.checkConnectionHealth()](dw.commerceapps.hooks.ConnectionHealthCheckHooks.md#checkconnectionhealth) hook. The BM connection-health
+endpoint translates the returned [Status](dw.system.Status.md) into a health payload using these values.
+
+
+**See Also:**
+- [ConnectionHealthCheckHooks](dw.commerceapps.hooks.ConnectionHealthCheckHooks.md)
+
+
+## Constant Summary
+
+| Constant | Description |
+| --- | --- |
+| [DETAIL_MESSAGE](#detail_message): [String](TopLevel.String.md) = "message" | [Status](dw.system.Status.md) detail key for the human-readable status message. |
+| [DETAIL_REMEDIATION](#detail_remediation): [String](TopLevel.String.md) = "remediation" | [Status](dw.system.Status.md) detail key for the merchant-facing remediation hint. |
+| [STATUS_CODE_DEGRADED](#status_code_degraded): [String](TopLevel.String.md) = "DEGRADED" | Status code that indicates a degraded connection (partial functionality available). |
+| [STATUS_CODE_UNHEALTHY](#status_code_unhealthy): [String](TopLevel.String.md) = "UNHEALTHY" | Status code that indicates the connection is unhealthy. |
+
+## Constructor Summary
+
+| Constructor | Description |
+| --- | --- |
+| [ConnectionHealthStatusCodes](#connectionhealthstatuscodes)() |  |
+
+## Method Summary
+
+### Methods inherited from class Object
+
+[assign](TopLevel.Object.md#assignobject-object), [create](TopLevel.Object.md#createobject), [create](TopLevel.Object.md#createobject-object), [defineProperties](TopLevel.Object.md#definepropertiesobject-object), [defineProperty](TopLevel.Object.md#definepropertyobject-object-object), [entries](TopLevel.Object.md#entriesobject), [freeze](TopLevel.Object.md#freezeobject), [fromEntries](TopLevel.Object.md#fromentriesiterable), [getOwnPropertyDescriptor](TopLevel.Object.md#getownpropertydescriptorobject-object), [getOwnPropertyNames](TopLevel.Object.md#getownpropertynamesobject), [getOwnPropertySymbols](TopLevel.Object.md#getownpropertysymbolsobject), [getPrototypeOf](TopLevel.Object.md#getprototypeofobject), [hasOwnProperty](TopLevel.Object.md#hasownpropertystring), [is](TopLevel.Object.md#isobject-object), [isExtensible](TopLevel.Object.md#isextensibleobject), [isFrozen](TopLevel.Object.md#isfrozenobject), [isPrototypeOf](TopLevel.Object.md#isprototypeofobject), [isSealed](TopLevel.Object.md#issealedobject), [keys](TopLevel.Object.md#keysobject), [preventExtensions](TopLevel.Object.md#preventextensionsobject), [propertyIsEnumerable](TopLevel.Object.md#propertyisenumerablestring), [seal](TopLevel.Object.md#sealobject), [setPrototypeOf](TopLevel.Object.md#setprototypeofobject-object), [toLocaleString](TopLevel.Object.md#tolocalestring), [toString](TopLevel.Object.md#tostring), [valueOf](TopLevel.Object.md#valueof), [values](TopLevel.Object.md#valuesobject)
+## Constant Details
+
+### DETAIL_MESSAGE
+
+- DETAIL_MESSAGE: [String](TopLevel.String.md) = "message"
+  - : [Status](dw.system.Status.md) detail key for the human-readable status message.
+
+
+---
+
+### DETAIL_REMEDIATION
+
+- DETAIL_REMEDIATION: [String](TopLevel.String.md) = "remediation"
+  - : [Status](dw.system.Status.md) detail key for the merchant-facing remediation hint.
+
+
+---
+
+### STATUS_CODE_DEGRADED
+
+- STATUS_CODE_DEGRADED: [String](TopLevel.String.md) = "DEGRADED"
+  - : Status code that indicates a degraded connection (partial functionality available).
+
+
+---
+
+### STATUS_CODE_UNHEALTHY
+
+- STATUS_CODE_UNHEALTHY: [String](TopLevel.String.md) = "UNHEALTHY"
+  - : Status code that indicates the connection is unhealthy.
+
+
+---
+
+## Constructor Details
+
+### ConnectionHealthStatusCodes()
+- ConnectionHealthStatusCodes()
+  - : 
+
+
+---
+
+<!-- prettier-ignore-end -->

--- a/packages/b2c-tooling-sdk/data/script-api/dw.commerceapps.hooks.ConnectionHealthCheckHooks.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.commerceapps.hooks.ConnectionHealthCheckHooks.md
@@ -1,0 +1,118 @@
+<!-- prettier-ignore-start -->
+# Class ConnectionHealthCheckHooks
+
+- [TopLevel.Object](TopLevel.Object.md)
+  - [dw.commerceapps.hooks.ConnectionHealthCheckHooks](dw.commerceapps.hooks.ConnectionHealthCheckHooks.md)
+
+This interface represents the optional connection health check extension point for Commerce App providers. It lets a
+Commerce App report whether its external service is reachable and operating correctly so Business Manager can surface
+health on the app's installation details. Implementing this hook is not required &mdash; apps that do not depend on
+an external connection may omit it entirely. When omitted, Business Manager does not display health status on the
+app's tile.
+
+
+A function must be defined inside a JavaScript source and must be exported. The script with the exported hook
+function must be located inside a site cartridge. Inside the site cartridge a 'package.json' file with a 'hooks'
+entry must exist.
+
+
+```
+"hooks": "./hooks.json"
+```
+
+
+The hooks entry links to a json file, relative to the 'package.json' file. This file lists all registered hooks
+inside the hooks property:
+
+
+```
+"hooks": [
+     {"name": "sfcc.app.tax.checkConnectionHealth", "script": "./checkConnectionHealth.js"}
+]
+```
+
+
+A hook entry has a 'name' and a 'script' property.
+
+- The 'name' contains the extension point, the hook name.
+- The 'script' contains the script relative to the hooks file, with the exported hook function.
+
+
+
+The hook is registered **per app domain** using the {@code sfcc.app.<domain>.checkConnectionHealth}
+convention &mdash; for example, {@code sfcc.app.tax.checkConnectionHealth} for a tax app.
+
+
+**IMPORTANT:** This hook should only be implemented and registered by Commerce Apps (applications
+installed via the Commerce App framework with a CAP file). It is not intended for custom merchant cartridges or
+storefront implementations.
+
+
+
+## Constructor Summary
+
+This class does not have a constructor, so you cannot create it directly.
+## Method Summary
+
+| Method | Description |
+| --- | --- |
+| [checkConnectionHealth](dw.commerceapps.hooks.ConnectionHealthCheckHooks.md#checkconnectionhealth)() | Reports the current health of the Commerce App's connection to its external service. |
+
+### Methods inherited from class Object
+
+[assign](TopLevel.Object.md#assignobject-object), [create](TopLevel.Object.md#createobject), [create](TopLevel.Object.md#createobject-object), [defineProperties](TopLevel.Object.md#definepropertiesobject-object), [defineProperty](TopLevel.Object.md#definepropertyobject-object-object), [entries](TopLevel.Object.md#entriesobject), [freeze](TopLevel.Object.md#freezeobject), [fromEntries](TopLevel.Object.md#fromentriesiterable), [getOwnPropertyDescriptor](TopLevel.Object.md#getownpropertydescriptorobject-object), [getOwnPropertyNames](TopLevel.Object.md#getownpropertynamesobject), [getOwnPropertySymbols](TopLevel.Object.md#getownpropertysymbolsobject), [getPrototypeOf](TopLevel.Object.md#getprototypeofobject), [hasOwnProperty](TopLevel.Object.md#hasownpropertystring), [is](TopLevel.Object.md#isobject-object), [isExtensible](TopLevel.Object.md#isextensibleobject), [isFrozen](TopLevel.Object.md#isfrozenobject), [isPrototypeOf](TopLevel.Object.md#isprototypeofobject), [isSealed](TopLevel.Object.md#issealedobject), [keys](TopLevel.Object.md#keysobject), [preventExtensions](TopLevel.Object.md#preventextensionsobject), [propertyIsEnumerable](TopLevel.Object.md#propertyisenumerablestring), [seal](TopLevel.Object.md#sealobject), [setPrototypeOf](TopLevel.Object.md#setprototypeofobject-object), [toLocaleString](TopLevel.Object.md#tolocalestring), [toString](TopLevel.Object.md#tostring), [valueOf](TopLevel.Object.md#valueof), [values](TopLevel.Object.md#valuesobject)
+## Method Details
+
+### checkConnectionHealth()
+- checkConnectionHealth(): [Status](dw.system.Status.md)
+  - : Reports the current health of the Commerce App's connection to its external service. The platform applies a CPU
+      timeout, so implementations should be lightweight and time-bounded.
+      
+      
+      The Business Manager connection-health endpoint that invokes this hook reports {@code unknown} when the hook
+      times out, throws, or returns {@code null}. {@code dw.system.HookMgr#callHook} itself rethrows any exception
+      raised by the hook script &mdash; the {@code unknown} translation is applied by the BM endpoint dispatcher, not
+      by {@code HookMgr}.
+      
+      
+      The BM endpoint interprets the returned [Status](dw.system.Status.md) as follows: {@code Status.OK} &rarr; healthy;
+      {@code Status.ERROR} with code [DEGRADED](dw.commerceapps.ConnectionHealthStatusCodes.md#status_code_degraded)
+      &rarr; degraded; {@code Status.ERROR} with code
+      [UNHEALTHY](dw.commerceapps.ConnectionHealthStatusCodes.md#status_code_unhealthy) (or any other ERROR code)
+      &rarr; unhealthy. A {@code null} return is treated as {@code unknown}.
+      
+      
+      Use [Status.addDetail(String, Object)](dw.system.Status.md#adddetailstring-object) with keys
+      [ConnectionHealthStatusCodes.DETAIL_MESSAGE](dw.commerceapps.ConnectionHealthStatusCodes.md#detail_message) and
+      [ConnectionHealthStatusCodes.DETAIL_REMEDIATION](dw.commerceapps.ConnectionHealthStatusCodes.md#detail_remediation) to provide structured information for the
+      BM UI. [DETAIL\_REMEDIATION](dw.commerceapps.ConnectionHealthStatusCodes.md#detail_remediation) should describe
+      actionable steps the merchant can take when the connection is degraded or unhealthy.
+      
+      
+      Both detail values are surfaced verbatim in Business Manager. To localize them for the BM admin's language, look
+      up the strings via {@code dw.web.Resource} from the cartridge's resource bundles (e.g. files under
+      {@code cartridge/templates/resources/}) instead of hard-coding English. The BM endpoint dispatcher invokes the
+      hook in the BM session locale, so {@code Resource.msg(...)} resolves against the admin's language.
+      
+      
+      ```
+      var Resource = require('dw/web/Resource');
+      var Status = require('dw/system/Status');
+      
+      exports.checkConnectionHealth = function () {
+          var status = new Status(Status.ERROR, 'DEGRADED');
+          status.addDetail('message', Resource.msg('healthcheck.degraded.message', 'taxapp', null));
+          status.addDetail('remediation',
+              Resource.msgf('healthcheck.degraded.remediation', 'taxapp', null, providerName));
+          return status;
+      };
+      ```
+
+
+    **Returns:**
+    - the connection health status. A {@code null} return is treated as {@code unknown} by the BM endpoint.
+
+
+---
+
+<!-- prettier-ignore-end -->

--- a/packages/b2c-tooling-sdk/data/script-api/dw.commerceapps.hooks.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.commerceapps.hooks.md
@@ -1,0 +1,6 @@
+# Package dw.commerceapps.hooks
+
+## Classes
+| Class | Description |
+| --- | --- |
+| [ConnectionHealthCheckHooks](dw.commerceapps.hooks.ConnectionHealthCheckHooks.md) | This interface represents the optional connection health check extension point for Commerce App providers. |

--- a/packages/b2c-tooling-sdk/data/script-api/dw.commerceapps.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.commerceapps.md
@@ -1,0 +1,6 @@
+# Package dw.commerceapps
+
+## Classes
+| Class | Description |
+| --- | --- |
+| [ConnectionHealthStatusCodes](dw.commerceapps.ConnectionHealthStatusCodes.md) | Status codes and detail keys returned by the  [ConnectionHealthCheckHooks.checkConnectionHealth()](dw.commerceapps.hooks.ConnectionHealthCheckHooks.md#checkconnectionhealth) hook. |

--- a/packages/b2c-tooling-sdk/data/script-api/dw.order.ShippingMgr.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.order.ShippingMgr.md
@@ -21,6 +21,7 @@ This class does not have a constructor, so you cannot create it directly.
 
 | Method | Description |
 | --- | --- |
+| static [applyShipping](dw.order.ShippingMgr.md#applyshippingbasket)([Basket](dw.order.Basket.md)) | Applies shipping to the given [Basket](dw.order.Basket.md) using the platform's shipping hook dispatch logic. |
 | static [applyShippingCost](dw.order.ShippingMgr.md#applyshippingcostlineitemctnr)([LineItemCtnr](dw.order.LineItemCtnr.md)) | Applies product and shipment-level shipping cost to the specified line  item container. |
 | static [getAllShippingMethods](dw.order.ShippingMgr.md#getallshippingmethods)() | Returns the active shipping methods of the current site applicable to the session currency and current customer group. |
 | static [getDefaultShippingMethod](dw.order.ShippingMgr.md#getdefaultshippingmethod)() | Returns the default shipping method of the current site applicable to the session currency. |
@@ -52,6 +53,63 @@ This class does not have a constructor, so you cannot create it directly.
 ---
 
 ## Method Details
+
+### applyShipping(Basket)
+- static applyShipping(basket: [Basket](dw.order.Basket.md)): void
+  - : Applies shipping to the given [Basket](dw.order.Basket.md) using the platform's shipping hook dispatch logic.
+      
+      
+      This method is intended for use in custom {@code dw.order.calculate} hook implementations (e.g., in SFRA or
+      SiteGenesis) that override the default basket calculation. Calling this method instead of directly invoking
+      {@code dw.order.calculateShipping} ensures that Commerce App shipping providers registered via
+      {@code sfcc.app.shipping.calculate} are invoked when available, with automatic fallback to the legacy
+      {@code dw.order.calculateShipping} hook or the platform default shipping calculation.
+      
+      
+      
+      
+      **WARNING:** Do NOT call this method from within a {@code dw.order.calculateShipping} hook
+      implementation, as this will cause infinite recursion. This method is designed to be called from
+      {@code dw.order.calculate} hooks only.
+      
+      
+      
+      
+      The dispatch precedence is:
+      
+      1. {@code sfcc.app.shipping.calculate}— if a Commerce App shipping provider is installed.
+      2. {@code dw.order.calculateShipping}— if registered by the storefront.
+      3. Platform default shipping calculation — using product and shipment shipping cost tables.
+      
+      
+      
+      
+      
+      **Typical usage in a custom {@code dw.order.calculate} hook:**
+      
+      
+      
+      
+      ```
+      var ShippingMgr = require('dw/order/ShippingMgr');
+      
+      exports.calculate = function (basket) {
+          // ... product prices, promotions ...
+          ShippingMgr.applyShipping(basket);
+          // ... tax ...
+          basket.updateTotals();
+      };
+      ```
+
+
+    **Parameters:**
+    - basket - the basket for which shipping should be calculated.
+
+    **Throws:**
+    - NullArgumentException - if {@code basket} is {@code null}.
+
+
+---
 
 ### applyShippingCost(LineItemCtnr)
 - static applyShippingCost(lineItemCtnr: [LineItemCtnr](dw.order.LineItemCtnr.md)): void

--- a/packages/b2c-tooling-sdk/data/script-api/dw.order.TaxMgr.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.order.TaxMgr.md
@@ -136,7 +136,7 @@ This class does not have a constructor, so you cannot create it directly.
       
       ```
          var TaxMgr = require('dw/order/TaxMgr');
-         
+      
          calculateTaxes: function () {
             Basket basket = BasketMgr.getCurrentBasket();
             if ( basket.isExternallyTaxed() )

--- a/packages/b2c-tooling-sdk/data/script-api/dw.order.hooks.ShippingHooks.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.order.hooks.ShippingHooks.md
@@ -1,0 +1,256 @@
+<!-- prettier-ignore-start -->
+# Class ShippingHooks
+
+- [TopLevel.Object](TopLevel.Object.md)
+  - [dw.order.hooks.ShippingHooks](dw.order.hooks.ShippingHooks.md)
+
+This interface represents shipping extension points for Commerce App shipping providers.
+
+
+These hooks provide integration points for external shipping rate / delivery-estimate services installed via the
+Commerce App framework.
+
+
+**IMPORTANT:** These hooks should **only** be implemented and registered by Commerce Apps
+(applications installed via the Commerce App framework with a CAP file). They are not intended for custom merchant
+cartridges or storefront implementations. Merchants who want custom shipping calculation logic should use the legacy
+`dw.order.calculateShipping` extension point instead.
+
+
+Hook Registration A function must be defined inside a JavaScript source and must be exported. The script
+with the exported hook function must be located inside a site cartridge. Inside the site cartridge a
+`package.json` file with a 'hooks' entry must exist:
+
+
+```
+"hooks": "./hooks.json"
+```
+
+
+
+The hooks entry links to a JSON file, relative to the `package.json` file. This file lists all registered
+hooks inside the hooks property:
+
+
+
+
+```
+"hooks": [
+   {"name": "sfcc.app.shipping.quote", "script": "./quote.js"},
+   {"name": "sfcc.app.shipping.calculate", "script": "./calculate.js"}
+]
+```
+
+
+
+A hook entry has a `name` and a `script` property:
+
+
+
+- The `name`contains the extension point name (the hook name).
+- The `script`contains the script path relative to the hooks file, with the exported hook  function.
+
+
+
+**Function Naming Convention:** The exported JavaScript function name must match the last segment of the
+extension point name, for example, `quote` or `calculate`.
+
+
+Hook Lifecycle Each hook fires at a specific surface and lifecycle stage:
+
+- **quote**(checkout): Fires on every invocation of  `GET /baskets/{basket_id}/shipments/{shipment_id}/shipping_methods`. Lets the Commerce App override native  shipping prices and add delivery information for the methods it can quote.
+- **calculate**(basket calculation): Fires during basket calculation on every basket operation that  recomputes shipping. Applies provider-supplied shipping rates to the selected `ShippingLineItem`and may  persist provider metadata on the shipment.
+
+Hook Precedence
+
+- When `sfcc.app.shipping.calculate`is registered and the `ShippingAppHooksEnabled`toggle  is on, it takes precedence over the legacy `dw.order.calculateShipping`hook.
+- If the Commerce App hook is not registered (or the toggle is off), the platform falls back to  `dw.order.calculateShipping`(if registered).
+- If neither hook is available, the platform uses the native default  (`ShippingMgr.applyShippingCost`).
+
+
+
+## Constant Summary
+
+| Constant | Description |
+| --- | --- |
+| [SHIPPING_DOMAIN](#shipping_domain): [String](TopLevel.String.md) = "shipping" | The shipping app domain segment used to compose extension-point names under the shared  `sfcc.app` prefix. |
+| [extensionPointCalculate](#extensionpointcalculate): [String](TopLevel.String.md) = "sfcc.app.shipping.calculate" | The extension point name sfcc.app.shipping.calculate. |
+| [extensionPointQuote](#extensionpointquote): [String](TopLevel.String.md) = "sfcc.app.shipping.quote" | The extension point name sfcc.app.shipping.quote. |
+
+## Constructor Summary
+
+This class does not have a constructor, so you cannot create it directly.
+## Method Summary
+
+| Method | Description |
+| --- | --- |
+| [calculate](dw.order.hooks.ShippingHooks.md#calculatelineitemctnr)([LineItemCtnr](dw.order.LineItemCtnr.md)) | The function is called by extension point [extensionPointCalculate](dw.order.hooks.ShippingHooks.md#extensionpointcalculate) during basket calculation. |
+| [quote](dw.order.hooks.ShippingHooks.md#quoteshipment-shippingmethodresultwo)([Shipment](dw.order.Shipment.md), ShippingMethodResultWO) | The function is called by extension point [extensionPointQuote](dw.order.hooks.ShippingHooks.md#extensionpointquote) on every invocation of  `GET /baskets/{basket_id}/shipments/{shipment_id}/shipping_methods`. |
+
+### Methods inherited from class Object
+
+[assign](TopLevel.Object.md#assignobject-object), [create](TopLevel.Object.md#createobject), [create](TopLevel.Object.md#createobject-object), [defineProperties](TopLevel.Object.md#definepropertiesobject-object), [defineProperty](TopLevel.Object.md#definepropertyobject-object-object), [entries](TopLevel.Object.md#entriesobject), [freeze](TopLevel.Object.md#freezeobject), [fromEntries](TopLevel.Object.md#fromentriesiterable), [getOwnPropertyDescriptor](TopLevel.Object.md#getownpropertydescriptorobject-object), [getOwnPropertyNames](TopLevel.Object.md#getownpropertynamesobject), [getOwnPropertySymbols](TopLevel.Object.md#getownpropertysymbolsobject), [getPrototypeOf](TopLevel.Object.md#getprototypeofobject), [hasOwnProperty](TopLevel.Object.md#hasownpropertystring), [is](TopLevel.Object.md#isobject-object), [isExtensible](TopLevel.Object.md#isextensibleobject), [isFrozen](TopLevel.Object.md#isfrozenobject), [isPrototypeOf](TopLevel.Object.md#isprototypeofobject), [isSealed](TopLevel.Object.md#issealedobject), [keys](TopLevel.Object.md#keysobject), [preventExtensions](TopLevel.Object.md#preventextensionsobject), [propertyIsEnumerable](TopLevel.Object.md#propertyisenumerablestring), [seal](TopLevel.Object.md#sealobject), [setPrototypeOf](TopLevel.Object.md#setprototypeofobject-object), [toLocaleString](TopLevel.Object.md#tolocalestring), [toString](TopLevel.Object.md#tostring), [valueOf](TopLevel.Object.md#valueof), [values](TopLevel.Object.md#valuesobject)
+## Constant Details
+
+### SHIPPING_DOMAIN
+
+- SHIPPING_DOMAIN: [String](TopLevel.String.md) = "shipping"
+  - : The shipping app domain segment used to compose extension-point names under the shared
+      `sfcc.app` prefix.
+
+
+
+---
+
+### extensionPointCalculate
+
+- extensionPointCalculate: [String](TopLevel.String.md) = "sfcc.app.shipping.calculate"
+  - : The extension point name sfcc.app.shipping.calculate.
+
+
+---
+
+### extensionPointQuote
+
+- extensionPointQuote: [String](TopLevel.String.md) = "sfcc.app.shipping.quote"
+  - : The extension point name sfcc.app.shipping.quote.
+
+
+---
+
+## Method Details
+
+### calculate(LineItemCtnr)
+- calculate(lineItemCtnr: [LineItemCtnr](dw.order.LineItemCtnr.md)): [Status](dw.system.Status.md)
+  - : The function is called by extension point [extensionPointCalculate](dw.order.hooks.ShippingHooks.md#extensionpointcalculate) during basket calculation. It
+      applies provider-supplied shipping rates to the selected `ShippingLineItem` and may persist
+      provider metadata (for example, a rate id, carrier code, or delivery window) on the shipment via supported
+      `custom.*` attributes. This hook fires on every basket operation that recomputes shipping, not only
+      before order creation.
+      
+      
+      The hook owns: native fallback (calling `ShippingMgr.applyShippingCost(lineItemCtnr)` if it wants to
+      preserve product-level shipping, surcharges, cleanup, and tax-class setup), provider lookup / rate-cache reuse,
+      selected-rate application onto the standard shipment shipping line item, and provider metadata persistence
+      (custom attributes on the shipment, custom objects, etc.).
+      
+      
+      
+      
+      **Note:** If the master `dw.order.calculate` hook (not the per-step
+      `dw.order.calculateShipping`) is overridden, the entire basket calculation is replaced and the
+      platform's automatic shipping hook selection is bypassed. You must manually invoke this hook from within your
+      custom `dw.order.calculate` implementation if you want to use Commerce App shipping providers.
+      
+      
+      
+      
+      **Error Handling:** Both returning a `Status.ERROR` and throwing an exception will
+      prevent the basket calculation from completing successfully. The platform logs the error and halts the current
+      basket operation. Since order creation requires a successful basket calculation, this also prevents orders from
+      being created with incorrect shipping amounts.
+      
+      
+      
+      
+      **Sample Implementation:**
+      
+      
+      
+      
+      ```
+      function calculate(lineItemCtnr) {
+          var ShippingMgr = require('dw/order/ShippingMgr');
+          var Status = require('dw/system/Status');
+          var Transaction = require('dw/system/Transaction');
+      
+          // 1. Run native shipping defaults (product-level surcharges, tax classes)
+          ShippingMgr.applyShippingCost(lineItemCtnr);
+      
+          // 2. Look up the provider rate that was selected on the shipment
+          var shipment = lineItemCtnr.getDefaultShipment();
+          var rateId = shipment.custom.providerRateId;
+          if (!rateId) {
+              return new Status(Status.OK);
+          }
+      
+          // 3. Apply the provider rate to the shipping line item
+          Transaction.wrap(function () {
+              var sli = shipment.getStandardShippingLineItem();
+              sli.setPriceValue(lookupRate(rateId).price);
+          });
+      
+          return new Status(Status.OK);
+      }
+      
+      exports.calculate = calculate;
+      ```
+
+
+    **Parameters:**
+    - lineItemCtnr - the line item container (basket) for which shipping should be calculated.
+
+    **Returns:**
+    - `Status.OK` or `null` for success; `Status.ERROR` to block the basket
+              calculation with details about the failure. Throwing an exception will also block the basket
+              calculation.
+
+
+
+---
+
+### quote(Shipment, ShippingMethodResultWO)
+- quote(shipment: [Shipment](dw.order.Shipment.md), result: ShippingMethodResultWO): [Status](dw.system.Status.md)
+  - : The function is called by extension point [extensionPointQuote](dw.order.hooks.ShippingHooks.md#extensionpointquote) on every invocation of
+      `GET /baskets/{basket_id}/shipments/{shipment_id}/shipping_methods`. ECOM pre-populates a
+      `ShippingMethodResultWO` with the applicable shipping methods, each carrying its native price. The
+      hook implementation may override prices and delivery information on any methods it can quote. Methods the hook
+      does not touch keep their native price.
+      
+      
+      **Error Handling:** To signal a failure, return `new Status(Status.ERROR)`. The platform
+      logs that an error status was returned for this hook and the `GET shipping-methods` request fails.
+      Uncaught exceptions thrown from the hook are also treated as failures.
+      
+      
+      
+      
+      **SCAPI Behavior:** When `ScapiHookExecutionEnabled` is disabled, SCAPI requests bypass
+      this hook and use native shipping pricing.
+      
+      
+      
+      
+      **Sample Implementation:**
+      
+      
+      
+      
+      ```
+      function quote(shipment, result) {
+          var Status = require('dw/system/Status');
+      
+          var methods = result.applicableShippingMethods;
+          for (var i = 0; i < methods.length; i++) {
+              var method = methods[i];
+              // ... call provider for this method, set price ...
+              method.setPrice(providerPrice);
+          }
+          return new Status(Status.OK);
+      }
+      
+      exports.quote = quote;
+      ```
+
+
+    **Parameters:**
+    - shipment - the shipment for which shipping methods are being displayed.
+    - result - the pre-populated result with native prices on each method. Mutated in place by the hook.
+
+    **Returns:**
+    - `Status.OK` or `null` for success; `Status.ERROR` to block the request.
+
+
+---
+
+<!-- prettier-ignore-end -->

--- a/packages/b2c-tooling-sdk/data/script-api/dw.order.hooks.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.order.hooks.md
@@ -9,5 +9,6 @@
 | [OrderHooks](dw.order.hooks.OrderHooks.md) | This interface represents all script hooks that can be registered to customize the order logic. |
 | [PaymentHooks](dw.order.hooks.PaymentHooks.md) | This interface represents all script hooks that can be registered to  customize the order center payment functionality. |
 | [ReturnHooks](dw.order.hooks.ReturnHooks.md) | This interface represents all script hooks that can be registered to  customizing the order center return resource. |
+| [ShippingHooks](dw.order.hooks.ShippingHooks.md) | This interface represents shipping extension points for Commerce App shipping providers. |
 | [ShippingOrderHooks](dw.order.hooks.ShippingOrderHooks.md) | This interface represents all script hooks that can be registered around  shipping order lifecycle. |
 | [TaxHooks](dw.order.hooks.TaxHooks.md) | This interface represents tax extension points for Commerce App tax providers. |

--- a/packages/b2c-tooling-sdk/data/script-api/dw.suggest.SuggestModel.md
+++ b/packages/b2c-tooling-sdk/data/script-api/dw.suggest.SuggestModel.md
@@ -53,10 +53,12 @@ regardless of the value of "Search Autocorrections" search preference.
 | [categorySuggestions](#categorysuggestions): [CategorySuggestions](dw.suggest.CategorySuggestions.md) `(read-only)` | Returns a [CategorySuggestions](dw.suggest.CategorySuggestions.md) container for the current search phrase. |
 | [contentSuggestions](#contentsuggestions): [ContentSuggestions](dw.suggest.ContentSuggestions.md) `(read-only)` | Returns a [ContentSuggestions](dw.suggest.ContentSuggestions.md) container for the current search phrase. |
 | [customSuggestions](#customsuggestions): [CustomSuggestions](dw.suggest.CustomSuggestions.md) `(read-only)` | Returns a [CustomSuggestions](dw.suggest.CustomSuggestions.md) container for the current search phrase. |
+| [effectiveSearchMode](#effectivesearchmode): [String](TopLevel.String.md) `(read-only)` | Returns the effective search mode that was used for the last suggestion execution. |
 | [filteredByFolder](#filteredbyfolder): [Boolean](TopLevel.Boolean.md) | The method returns true, if the search suggestions are filtered by the folder. |
 | [popularSearchPhrases](#popularsearchphrases): [Iterator](dw.util.Iterator.md) `(read-only)` | Use this method to obtain a list of search phrases  that currently are very popular among all users across the Site. |
 | [productSuggestions](#productsuggestions): [ProductSuggestions](dw.suggest.ProductSuggestions.md) `(read-only)` | Returns a [ProductSuggestions](dw.suggest.ProductSuggestions.md) container for the current search phrase. |
 | [recentSearchPhrases](#recentsearchphrases): [Iterator](dw.util.Iterator.md) `(read-only)` | Use this method to obtain a list of personalized search phrases  that the current user entered recently. |
+| [searchMode](#searchmode): [String](TopLevel.String.md) | Returns the search mode that was requested for the next suggestion execution via [setSearchMode(String)](dw.suggest.SuggestModel.md#setsearchmodestring),  or {@code null} if no mode was explicitly requested. |
 
 ## Constructor Summary
 
@@ -73,15 +75,18 @@ regardless of the value of "Search Autocorrections" search preference.
 | [getCategorySuggestions](dw.suggest.SuggestModel.md#getcategorysuggestions)() | Returns a [CategorySuggestions](dw.suggest.CategorySuggestions.md) container for the current search phrase. |
 | [getContentSuggestions](dw.suggest.SuggestModel.md#getcontentsuggestions)() | Returns a [ContentSuggestions](dw.suggest.ContentSuggestions.md) container for the current search phrase. |
 | [getCustomSuggestions](dw.suggest.SuggestModel.md#getcustomsuggestions)() | Returns a [CustomSuggestions](dw.suggest.CustomSuggestions.md) container for the current search phrase. |
+| [getEffectiveSearchMode](dw.suggest.SuggestModel.md#geteffectivesearchmode)() | Returns the effective search mode that was used for the last suggestion execution. |
 | [getPopularSearchPhrases](dw.suggest.SuggestModel.md#getpopularsearchphrases)() | Use this method to obtain a list of search phrases  that currently are very popular among all users across the Site. |
 | [getProductSuggestions](dw.suggest.SuggestModel.md#getproductsuggestions)() | Returns a [ProductSuggestions](dw.suggest.ProductSuggestions.md) container for the current search phrase. |
 | [getRecentSearchPhrases](dw.suggest.SuggestModel.md#getrecentsearchphrases)() | Use this method to obtain a list of personalized search phrases  that the current user entered recently. |
+| [getSearchMode](dw.suggest.SuggestModel.md#getsearchmode)() | Returns the search mode that was requested for the next suggestion execution via [setSearchMode(String)](dw.suggest.SuggestModel.md#setsearchmodestring),  or {@code null} if no mode was explicitly requested. |
 | [isFilteredByFolder](dw.suggest.SuggestModel.md#isfilteredbyfolder)() | The method returns true, if the search suggestions are filtered by the folder. |
 | [removeRefinementValues](dw.suggest.SuggestModel.md#removerefinementvaluesstring-string)([String](TopLevel.String.md), [String](TopLevel.String.md)) | Removes a refinement. |
 | [setCategoryID](dw.suggest.SuggestModel.md#setcategoryidstring)([String](TopLevel.String.md)) | Apply a category ID to filter product, brand and category suggestions. |
 | [setFilteredByFolder](dw.suggest.SuggestModel.md#setfilteredbyfolderboolean)([Boolean](TopLevel.Boolean.md)) | Set a flag to indicate if the search suggestions filter for elements that do not belong to a folder. |
 | [setMaxSuggestions](dw.suggest.SuggestModel.md#setmaxsuggestionsnumber)([Number](TopLevel.Number.md)) | Use this method to setup the maximum number of returned suggested  items. |
 | [setRefinementValues](dw.suggest.SuggestModel.md#setrefinementvaluesstring-string)([String](TopLevel.String.md), [String](TopLevel.String.md)) | Sets product suggestion refinement values for an attribute. |
+| [setSearchMode](dw.suggest.SuggestModel.md#setsearchmodestring)([String](TopLevel.String.md)) | Sets the search mode for the next suggestion execution. |
 | [setSearchPhrase](dw.suggest.SuggestModel.md#setsearchphrasestring)([String](TopLevel.String.md)) | Sets the user input search phrase. |
 
 ### Methods inherited from class Object
@@ -156,6 +161,16 @@ regardless of the value of "Search Autocorrections" search preference.
 
 ---
 
+### effectiveSearchMode
+- effectiveSearchMode: [String](TopLevel.String.md) `(read-only)`
+  - : Returns the effective search mode that was used for the last suggestion execution. This reflects the actual
+      matching approach that ran, which may differ from the requested mode if a fallback occurred. Returns {@code null}
+      if no suggestions have been executed yet.
+
+
+
+---
+
 ### filteredByFolder
 - filteredByFolder: [Boolean](TopLevel.Boolean.md)
   - : The method returns true, if the search suggestions are filtered by the folder. If this returns true it is not
@@ -197,6 +212,18 @@ regardless of the value of "Search Autocorrections" search preference.
       that the current user entered recently.
       
       The user is being identified by the CQuotient tracking cookie.
+
+
+
+---
+
+### searchMode
+- searchMode: [String](TopLevel.String.md)
+  - : Returns the search mode that was requested for the next suggestion execution via [setSearchMode(String)](dw.suggest.SuggestModel.md#setsearchmodestring),
+      or {@code null} if no mode was explicitly requested. This reflects the caller's requested preference, not the
+      mode that actually ran — the requested mode is non-authoritative and {@code "semantic"} may still be demoted to
+      {@code "lexical"} by the search router. Use [getEffectiveSearchMode()](dw.suggest.SuggestModel.md#geteffectivesearchmode) to obtain the mode that was
+      actually used.
 
 
 
@@ -305,6 +332,21 @@ regardless of the value of "Search Autocorrections" search preference.
 
 ---
 
+### getEffectiveSearchMode()
+- getEffectiveSearchMode(): [String](TopLevel.String.md)
+  - : Returns the effective search mode that was used for the last suggestion execution. This reflects the actual
+      matching approach that ran, which may differ from the requested mode if a fallback occurred. Returns {@code null}
+      if no suggestions have been executed yet.
+
+
+    **Returns:**
+    - {@code "semantic"} if the query ran against the external search provider, {@code "lexical"} if it ran
+              against the native search, or {@code null} if no suggestions have been executed yet
+
+
+
+---
+
 ### getPopularSearchPhrases()
 - getPopularSearchPhrases(): [Iterator](dw.util.Iterator.md)
   - : Use this method to obtain a list of search phrases
@@ -349,6 +391,21 @@ regardless of the value of "Search Autocorrections" search preference.
 
     **Returns:**
     - a list of recent search phrases of the current user
+
+
+---
+
+### getSearchMode()
+- getSearchMode(): [String](TopLevel.String.md)
+  - : Returns the search mode that was requested for the next suggestion execution via [setSearchMode(String)](dw.suggest.SuggestModel.md#setsearchmodestring),
+      or {@code null} if no mode was explicitly requested. This reflects the caller's requested preference, not the
+      mode that actually ran — the requested mode is non-authoritative and {@code "semantic"} may still be demoted to
+      {@code "lexical"} by the search router. Use [getEffectiveSearchMode()](dw.suggest.SuggestModel.md#geteffectivesearchmode) to obtain the mode that was
+      actually used.
+
+
+    **Returns:**
+    - {@code "semantic"} or {@code "lexical"} if a mode was requested, or {@code null} if no mode was requested
 
 
 ---
@@ -439,6 +496,22 @@ regardless of the value of "Search Autocorrections" search preference.
     **Parameters:**
     - attributeID - The ID of the refinement attribute.
     - values - the refinement values to set (delimited by '|') or null to             remove all values
+
+
+---
+
+### setSearchMode(String)
+- setSearchMode(mode: [String](TopLevel.String.md)): void
+  - : Sets the search mode for the next suggestion execution. The mode influences the routing decision made by the
+      search router, but is non-authoritative — {@code "semantic"} still runs the full routing cascade and may be
+      demoted to {@code "lexical"} based on availability and query characteristics.
+
+
+    **Parameters:**
+    - mode - the search mode to request, either {@code "semantic"} or {@code "lexical"}
+
+    **Throws:**
+    - IllegalArgumentException - if the mode is not one of the allowed values
 
 
 ---

--- a/packages/b2c-tooling-sdk/data/script-api/index.json
+++ b/packages/b2c-tooling-sdk/data/script-api/index.json
@@ -1,6 +1,7 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-09T21:59:05.025Z",
+  "generatedAt": "2026-08-03T18:24:52.134Z",
+  "platformDocVersion": "DWAPP 26.8",
   "entries": [
     {
       "id": "dw.alert",
@@ -545,7 +546,7 @@
       "category": "script-api",
       "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.catalog.ProductSearchModel.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.catalog.ProductSearchModel.md",
-      "headings": "Constant Summary • Property Summary • Constructor Summary • Method Summary • Methods inherited from class SearchModel • Methods inherited from class Object • Constant Details • CATEGORYID_PARAMETER • INVENTORY_LIST_IDS_PARAMETER • MAXIMUM_INVENTORY_LIST_IDS • MAXIMUM_PRODUCT_IDS • MAXIMUM_STORE_INVENTORY_FILTER_VALUES • PRICE_MAX_PARAMETER • PRICE_MIN_PARAMETER • PRODUCTID_PARAMETER • PROMOTIONID_PARAMETER • PROMOTION_PRODUCT_TYPE_ALL • PROMOTION_PRODUCT_TYPE_BONUS • PROMOTION_PRODUCT_TYPE_DISCOUNTED • PROMOTION_PRODUCT_TYPE_PARAMETER • PROMOTION_PRODUCT_TYPE_QUALIFYING • REFINE_NAME_PARAMETER_PREFIX • REFINE_VALUE_PARAMETER_PREFIX • SORTING_OPTION_PARAMETER • SORTING_RULE_PARAMETER • SORT_BY_PARAMETER_PREFIX • SORT_DIRECTION_PARAMETER_PREFIX • Property Details • category • categoryID • categorySearch • deepestCommonCategory • effectiveSortingRule • inventoryIDs • orderableProductsOnly • pageMetaTags • personalizedSort • priceMax • priceMin • productID • productIDs • productSearchHits • products • promotionID • promotionIDs • promotionProductType • recursiveCategorySearch • refinedByCategory • refinedByPrice • refinedByPromotion • refinedCategorySearch • refinementCategory • refinements • searchPhraseSuggestions • searchableImageUploadURL • sortingRule • storeInventoryFilter • suggestedSearchPhrase • suggestedSearchPhrases • trackingEmptySearchesEnabled • visualSearch • Constructor Details • ProductSearchModel() • Method Details • addHitTypeRefinement(String...) • excludeHitType(String...) • getCategory() • getCategoryID() • getDeepestCommonCategory() • getEffectiveSortingRule() • getInventoryIDs() • getOrderableProductsOnly() • getPageMetaTag(String) • getPageMetaTags() • getPriceMax() • getPriceMin() • getProductID() • getProductIDs() • getProductSearchHit(Product) • getProductSearchHits() • getProducts() • getPromotionID() • getPromotionIDs() • getPromotionProductType() • getRefinementCategory() • getRefinements() • getSearchPhraseSuggestions() • getSearchableImageUploadURL() • getSortingRule() • getStoreInventoryFilter() • getSuggestedSearchPhrase() • getSuggestedSearchPhrases() • isCategorySearch() • isPersonalizedSort() • isRecursiveCategorySearch() • isRefinedByCategory() • isRefinedByPrice() • isRefinedByPriceRange(Number, Number) • isRefinedByPromotion() • isRefinedByPromotion(String) • isRefinedCategorySearch() • isTrackingEmptySearchesEnabled() • isVisualSearch() • search() • setCategoryID(String) • setEnableTrackingEmptySearches(Boolean) • setInventoryListIDs(List) • setOrderableProductsOnly(Boolean) • setPriceMax(Number) • setPriceMin(Number) • setProductID(String) • setProductIDs(List) • setPromotionID(String) • setPromotionIDs(List) • setPromotionProductType(String) • setRecursiveCategorySearch(Boolean) • setRefinementCategory(Category) • setSearchableImageID(String) • setSortingCondition(String, Number) • setSortingOption(SortingOption) • setSortingRule(SortingRule) • setStoreInventoryFilter(StoreInventoryFilter) • urlForCategory(URL, String) • urlForCategory(String, String) • urlForProduct(URL, String, String) • urlForProduct(String, String, String) • urlForRefine(URL, String, String) • urlForRefine(String, String, String) • urlRefineCategory(URL, String) • urlRefineCategory(String, String) • urlRefinePrice(URL, Number, Number) • urlRefinePrice(String, Number, Number) • urlRefinePromotion(URL, String) • urlRefinePromotion(String, String) • urlRelaxCategory(URL) • urlRelaxCategory(String) • urlRelaxPrice(URL) • urlRelaxPrice(String) • urlRelaxPromotion(URL) • urlRelaxPromotion(String) • urlSortingOption(URL, SortingOption) • urlSortingOption(String, SortingOption) • urlSortingRule(URL, SortingRule) • urlSortingRule(String, SortingRule)",
+      "headings": "Constant Summary • Property Summary • Constructor Summary • Method Summary • Methods inherited from class SearchModel • Methods inherited from class Object • Constant Details • CATEGORYID_PARAMETER • INVENTORY_LIST_IDS_PARAMETER • MAXIMUM_INVENTORY_LIST_IDS • MAXIMUM_PRODUCT_IDS • MAXIMUM_STORE_INVENTORY_FILTER_VALUES • PRICE_MAX_PARAMETER • PRICE_MIN_PARAMETER • PRODUCTID_PARAMETER • PROMOTIONID_PARAMETER • PROMOTION_PRODUCT_TYPE_ALL • PROMOTION_PRODUCT_TYPE_BONUS • PROMOTION_PRODUCT_TYPE_DISCOUNTED • PROMOTION_PRODUCT_TYPE_PARAMETER • PROMOTION_PRODUCT_TYPE_QUALIFYING • REFINE_NAME_PARAMETER_PREFIX • REFINE_VALUE_PARAMETER_PREFIX • SORTING_OPTION_PARAMETER • SORTING_RULE_PARAMETER • SORT_BY_PARAMETER_PREFIX • SORT_DIRECTION_PARAMETER_PREFIX • Property Details • category • categoryID • categorySearch • deepestCommonCategory • effectiveSearchMode • effectiveSortingRule • inventoryIDs • orderableProductsOnly • pageMetaTags • personalizedSort • priceMax • priceMin • productID • productIDs • productSearchHits • products • promotionID • promotionIDs • promotionProductType • recursiveCategorySearch • refinedByCategory • refinedByPrice • refinedByPromotion • refinedCategorySearch • refinementCategory • refinements • searchMode • searchPhraseSuggestions • searchableImageUploadURL • sortingRule • storeInventoryFilter • suggestedSearchPhrase • suggestedSearchPhrases • trackingEmptySearchesEnabled • visualSearch • Constructor Details • ProductSearchModel() • Method Details • addHitTypeRefinement(String...) • excludeHitType(String...) • getCategory() • getCategoryID() • getDeepestCommonCategory() • getEffectiveSearchMode() • getEffectiveSortingRule() • getInventoryIDs() • getOrderableProductsOnly() • getPageMetaTag(String) • getPageMetaTags() • getPriceMax() • getPriceMin() • getProductID() • getProductIDs() • getProductSearchHit(Product) • getProductSearchHits() • getProducts() • getPromotionID() • getPromotionIDs() • getPromotionProductType() • getRefinementCategory() • getRefinements() • getSearchMode() • getSearchPhraseSuggestions() • getSearchableImageUploadURL() • getSortingRule() • getStoreInventoryFilter() • getSuggestedSearchPhrase() • getSuggestedSearchPhrases() • isCategorySearch() • isPersonalizedSort() • isRecursiveCategorySearch() • isRefinedByCategory() • isRefinedByPrice() • isRefinedByPriceRange(Number, Number) • isRefinedByPromotion() • isRefinedByPromotion(String) • isRefinedCategorySearch() • isTrackingEmptySearchesEnabled() • isVisualSearch() • search() • setCategoryID(String) • setEnableTrackingEmptySearches(Boolean) • setInventoryListIDs(List) • setOrderableProductsOnly(Boolean) • setPriceMax(Number) • setPriceMin(Number) • setProductID(String) • setProductIDs(List) • setPromotionID(String) • setPromotionIDs(List) • setPromotionProductType(String) • setRecursiveCategorySearch(Boolean) • setRefinementCategory(Category) • setSearchMode(String) • setSearchableImageID(String) • setSortingCondition(String, Number) • setSortingOption(SortingOption) • setSortingRule(SortingRule) • setStoreInventoryFilter(StoreInventoryFilter) • urlForCategory(URL, String) • urlForCategory(String, String) • urlForProduct(URL, String, String) • urlForProduct(String, String, String) • urlForRefine(URL, String, String) • urlForRefine(String, String, String) • urlRefineCategory(URL, String) • urlRefineCategory(String, String) • urlRefinePrice(URL, Number, Number) • urlRefinePrice(String, Number, Number) • urlRefinePromotion(URL, String) • urlRefinePromotion(String, String) • urlRelaxCategory(URL) • urlRelaxCategory(String) • urlRelaxPrice(URL) • urlRelaxPrice(String) • urlRelaxPromotion(URL) • urlRelaxPromotion(String) • urlSortingOption(URL, SortingOption) • urlSortingOption(String, SortingOption) • urlSortingRule(URL, SortingRule) • urlSortingRule(String, SortingRule)",
       "preview": "- [dw.catalog.SearchModel](dw.catalog.SearchModel.md)"
     },
     {
@@ -727,6 +728,40 @@
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.catalog.VariationGroup.md",
       "headings": "Property Summary • Constructor Summary • Method Summary • Methods inherited from class Product • Methods inherited from class ExtensibleObject • Methods inherited from class PersistentObject • Methods inherited from class Object • Property Details • EAN • UPC • allProductLinks • brand • classificationCategory • custom • image • longDescription • manufacturerName • manufacturerSKU • masterProduct • name • onlineFrom • onlineTo • optionProduct • pageDescription • pageKeywords • pageTitle • pageURL • productLinks • shortDescription • taxClassID • template • thumbnail • unit • unitQuantity • Method Details • getAllProductLinks() • getAllProductLinks(Number) • getBrand() • getClassificationCategory() • getCustom() • getEAN() • getImage() • getLongDescription() • getManufacturerName() • getManufacturerSKU() • getMasterProduct() • getName() • getOnlineFrom() • getOnlineTo() • getPageDescription() • getPageKeywords() • getPageTitle() • getPageURL() • getProductLinks() • getProductLinks(Number) • getRecommendations(Number) • getShortDescription() • getTaxClassID() • getTemplate() • getThumbnail() • getUPC() • getUnit() • getUnitQuantity() • isOptionProduct()",
       "preview": "- [dw.object.PersistentObject](dw.object.PersistentObject.md)"
+    },
+    {
+      "id": "dw.commerceapps",
+      "title": "Package dw.commerceapps",
+      "category": "script-api",
+      "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.commerceapps.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.commerceapps.md",
+      "headings": "Classes"
+    },
+    {
+      "id": "dw.commerceapps.ConnectionHealthStatusCodes",
+      "title": "Class ConnectionHealthStatusCodes",
+      "category": "script-api",
+      "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.commerceapps.ConnectionHealthStatusCodes.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.commerceapps.ConnectionHealthStatusCodes.md",
+      "headings": "Constant Summary • Constructor Summary • Method Summary • Methods inherited from class Object • Constant Details • DETAIL_MESSAGE • DETAIL_REMEDIATION • STATUS_CODE_DEGRADED • STATUS_CODE_UNHEALTHY • Constructor Details • ConnectionHealthStatusCodes()",
+      "preview": "- [dw.commerceapps.ConnectionHealthStatusCodes](dw.commerceapps.ConnectionHealthStatusCodes.md)"
+    },
+    {
+      "id": "dw.commerceapps.hooks",
+      "title": "Package dw.commerceapps.hooks",
+      "category": "script-api",
+      "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.commerceapps.hooks.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.commerceapps.hooks.md",
+      "headings": "Classes"
+    },
+    {
+      "id": "dw.commerceapps.hooks.ConnectionHealthCheckHooks",
+      "title": "Class ConnectionHealthCheckHooks",
+      "category": "script-api",
+      "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.commerceapps.hooks.ConnectionHealthCheckHooks.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.commerceapps.hooks.ConnectionHealthCheckHooks.md",
+      "headings": "Constructor Summary • Method Summary • Methods inherited from class Object • Method Details • checkConnectionHealth()",
+      "preview": "- [dw.commerceapps.hooks.ConnectionHealthCheckHooks](dw.commerceapps.hooks.ConnectionHealthCheckHooks.md)"
     },
     {
       "id": "dw.content",
@@ -2535,6 +2570,15 @@
       "preview": "- [dw.order.hooks.ReturnHooks](dw.order.hooks.ReturnHooks.md)"
     },
     {
+      "id": "dw.order.hooks.ShippingHooks",
+      "title": "Class ShippingHooks",
+      "category": "script-api",
+      "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.order.hooks.ShippingHooks.html",
+      "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.order.hooks.ShippingHooks.md",
+      "headings": "Constant Summary • Constructor Summary • Method Summary • Methods inherited from class Object • Constant Details • SHIPPING_DOMAIN • extensionPointCalculate • extensionPointQuote • Method Details • calculate(LineItemCtnr) • quote(Shipment, ShippingMethodResultWO)",
+      "preview": "- [dw.order.hooks.ShippingHooks](dw.order.hooks.ShippingHooks.md)"
+    },
+    {
       "id": "dw.order.hooks.ShippingOrderHooks",
       "title": "Class ShippingOrderHooks",
       "category": "script-api",
@@ -2864,7 +2908,7 @@
       "category": "script-api",
       "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.order.ShippingMgr.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.order.ShippingMgr.md",
-      "headings": "Property Summary • Constructor Summary • Method Summary • Methods inherited from class Object • Property Details • allShippingMethods • defaultShippingMethod • Method Details • applyShippingCost(LineItemCtnr) • getAllShippingMethods() • getDefaultShippingMethod() • getProductShippingModel(Product) • getShipmentShippingModel(Shipment) • getShippingCost(ShippingMethod, Money)",
+      "headings": "Property Summary • Constructor Summary • Method Summary • Methods inherited from class Object • Property Details • allShippingMethods • defaultShippingMethod • Method Details • applyShipping(Basket) • applyShippingCost(LineItemCtnr) • getAllShippingMethods() • getDefaultShippingMethod() • getProductShippingModel(Product) • getShipmentShippingModel(Shipment) • getShippingCost(ShippingMethod, Money)",
       "preview": "- [dw.order.ShippingMgr](dw.order.ShippingMgr.md)"
     },
     {
@@ -3131,7 +3175,7 @@
       "category": "script-api",
       "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.suggest.SuggestModel.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/dw.suggest.SuggestModel.md",
-      "headings": "Constant Summary • Property Summary • Constructor Summary • Method Summary • Methods inherited from class Object • Constant Details • MAX_SUGGESTIONS • Property Details • brandSuggestions • categorySuggestions • contentSuggestions • customSuggestions • filteredByFolder • popularSearchPhrases • productSuggestions • recentSearchPhrases • Constructor Details • SuggestModel() • Method Details • addRefinementValues(String, String) • getBrandSuggestions() • getCategorySuggestions() • getContentSuggestions() • getCustomSuggestions() • getPopularSearchPhrases() • getProductSuggestions() • getRecentSearchPhrases() • isFilteredByFolder() • removeRefinementValues(String, String) • setCategoryID(String) • setFilteredByFolder(Boolean) • setMaxSuggestions(Number) • setRefinementValues(String, String) • setSearchPhrase(String)",
+      "headings": "Constant Summary • Property Summary • Constructor Summary • Method Summary • Methods inherited from class Object • Constant Details • MAX_SUGGESTIONS • Property Details • brandSuggestions • categorySuggestions • contentSuggestions • customSuggestions • effectiveSearchMode • filteredByFolder • popularSearchPhrases • productSuggestions • recentSearchPhrases • searchMode • Constructor Details • SuggestModel() • Method Details • addRefinementValues(String, String) • getBrandSuggestions() • getCategorySuggestions() • getContentSuggestions() • getCustomSuggestions() • getEffectiveSearchMode() • getPopularSearchPhrases() • getProductSuggestions() • getRecentSearchPhrases() • getSearchMode() • isFilteredByFolder() • removeRefinementValues(String, String) • setCategoryID(String) • setFilteredByFolder(Boolean) • setMaxSuggestions(Number) • setRefinementValues(String, String) • setSearchMode(String) • setSearchPhrase(String)",
       "preview": "- [dw.suggest.SuggestModel](dw.suggest.SuggestModel.md)"
     },
     {
@@ -4218,7 +4262,7 @@
     },
     {
       "id": "index",
-      "title": "B2C Commerce Script API 26.7",
+      "title": "B2C Commerce Script API 26.8",
       "category": "script-api",
       "url": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/index.html",
       "sourceUrl": "https://developer.salesforce.com/docs/commerce/b2c-commerce/references/b2c-script-api/index.md",

--- a/packages/b2c-tooling-sdk/data/script-api/index.md
+++ b/packages/b2c-tooling-sdk/data/script-api/index.md
@@ -1,4 +1,4 @@
-# B2C Commerce Script API 26.7
+# B2C Commerce Script API 26.8
 
 ## Packages
 | Package | Description |
@@ -7,6 +7,8 @@
 | [dw.alert](dw.alert.md) |  |
 | [dw.campaign](dw.campaign.md) | Contains classes that allow you to interact with promotions and campaigns. |
 | [dw.catalog](dw.catalog.md) | Contains classes that allow you to interact with Products. |
+| [dw.commerceapps](dw.commerceapps.md) |  |
+| [dw.commerceapps.hooks](dw.commerceapps.hooks.md) |  |
 | [dw.content](dw.content.md) | Contains classes that allow you to access content. |
 | [dw.crypto](dw.crypto.md) | Contains classes that allow you to perform cryptographic operations. |
 | [dw.customer](dw.customer.md) | Contains classes that allow you to interact with and manage Customer-related information. |

--- a/packages/b2c-tooling-sdk/data/tooling/index.json
+++ b/packages/b2c-tooling-sdk/data/tooling/index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generatedAt": "2026-07-10T21:10:52.949Z",
+  "generatedAt": "2026-08-03T18:28:01.841Z",
   "entries": [
     {
       "id": "guide-account-manager",
@@ -80,7 +80,7 @@
       "category": "tooling",
       "url": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/ide-integration.html",
       "sourceUrl": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/ide-integration.md",
-      "headings": "Script API IntelliSense • B2C DX VS Code Extension (recommended) • Standalone VS Code, WebStorm, or IntelliJ Ultimate • Neovim, Helix, Zed, Sublime, or other LSP-based editors • Notes • IntelliJ SFCC Plugin • Setup",
+      "headings": "Script API IntelliSense • Salesforce B2C Commerce VS Code Extension (recommended) • Standalone VS Code, WebStorm, or IntelliJ Ultimate • Neovim, Helix, Zed, Sublime, or other LSP-based editors • Notes • IntelliJ SFCC Plugin • Setup",
       "preview": "Configure IDE tooling like the IntelliJ SFCC plugin to consume resolved B2C CLI configuration, plus enable Script API IntelliSense via TypeScript definitions."
     },
     {

--- a/packages/b2c-tooling-sdk/data/xsd/commercefeaturestate.xsd
+++ b/packages/b2c-tooling-sdk/data/xsd/commercefeaturestate.xsd
@@ -43,6 +43,7 @@
             <xsd:enumeration value="ISV_APP" />
             <xsd:enumeration value="NATIVE_FEATURE" />
             <xsd:enumeration value="CUSTOM_FEATURE" />
+            <xsd:enumeration value="CUSTOM_APP" />
         </xsd:restriction>
     </xsd:simpleType>
 

--- a/packages/b2c-tooling-sdk/data/xsd/index.json
+++ b/packages/b2c-tooling-sdk/data/xsd/index.json
@@ -1,6 +1,7 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-09T21:59:05.031Z",
+  "generatedAt": "2026-08-03T18:24:52.137Z",
+  "platformDocVersion": "DWAPP 26.8",
   "entries": [
     {
       "id": "abtest",

--- a/packages/b2c-tooling-sdk/data/xsd/redirecturl.xsd
+++ b/packages/b2c-tooling-sdk/data/xsd/redirecturl.xsd
@@ -29,6 +29,8 @@
             <xsd:element name="destination-url" type="Generic.String.256" minOccurs="0" maxOccurs="1" />
             <xsd:element name="additional-url-params" type="Generic.String.2048" minOccurs="0" maxOccurs="1" />
             <xsd:element name="copy-source-params" type="CopySourceParamsType" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="online-from" type="xsd:dateTime" minOccurs="0" maxOccurs="1" nillable="true" />
+            <xsd:element name="online-to" type="xsd:dateTime" minOccurs="0" maxOccurs="1" nillable="true" />
         </xsd:sequence>
         <xsd:attribute name="uri" type="Generic.NonEmptyString.2048" use="optional" />
         <xsd:attribute name="source-id" type="Generic.NonEmptyString.256" use="optional" />

--- a/packages/b2c-tooling-sdk/scripts/generate-docs-index.ts
+++ b/packages/b2c-tooling-sdk/scripts/generate-docs-index.ts
@@ -6,7 +6,15 @@
 /**
  * Generates the search indexes for Script API documentation and XSD schemas.
  *
- * Run with: pnpm --filter @salesforce/b2c-tooling-sdk run generate:docs-index
+ * Both corpora come from the DWAPP documentation archive (not a git repo), so
+ * their platform version is recorded in each index's `platformDocVersion` field
+ * — the traceability equivalent of the git `source` block the prose corpora use.
+ * The version is passed as the first CLI arg (the refresh script forwards the
+ * DWAPP version it parsed from the archive); if omitted, any existing
+ * `platformDocVersion` already in the committed index is preserved so a manual
+ * regen never silently drops it.
+ *
+ * Run with: pnpm --filter @salesforce/b2c-tooling-sdk run generate:docs-index [platformDocVersion]
  */
 
 import * as fs from 'node:fs';
@@ -40,18 +48,41 @@ interface SchemaEntry {
 interface SearchIndex {
   version: string;
   generatedAt: string;
+  platformDocVersion?: string;
   entries: DocEntry[];
 }
 
 interface SchemaIndex {
   version: string;
   generatedAt: string;
+  platformDocVersion?: string;
   entries: SchemaEntry[];
 }
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT_API_DIR = path.resolve(__dirname, '../data/script-api');
 const XSD_DIR = path.resolve(__dirname, '../data/xsd');
+
+/**
+ * Resolves the platform doc version to write: an explicit CLI arg wins;
+ * otherwise the value already committed in `indexPath` is preserved so a manual
+ * regen (no arg) never drops the recorded version.
+ */
+function resolvePlatformDocVersion(cliVersion: string | undefined, indexPath: string): string | undefined {
+  if (cliVersion) return cliVersion;
+  try {
+    const existing = JSON.parse(fs.readFileSync(indexPath, 'utf-8')) as {platformDocVersion?: string};
+    return existing.platformDocVersion;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Normalizes a raw version token to the "DWAPP <x.y>" form job-steps also uses. */
+function normalizeVersion(v: string | undefined): string | undefined {
+  if (!v) return undefined;
+  return /^dwapp/i.test(v.trim()) ? v.trim() : `DWAPP ${v.trim()}`;
+}
 
 function extractTitle(content: string): string {
   // Match first # heading
@@ -110,7 +141,7 @@ function extractPreview(content: string): string | undefined {
   return preview;
 }
 
-async function generateScriptApiIndex(): Promise<void> {
+async function generateScriptApiIndex(platformDocVersion?: string): Promise<void> {
   const files = fs.readdirSync(SCRIPT_API_DIR).filter((f) => f.endsWith('.md'));
 
   const entries: DocEntry[] = [];
@@ -142,19 +173,24 @@ async function generateScriptApiIndex(): Promise<void> {
   // Sort by ID for consistent output
   entries.sort((a, b) => a.id.localeCompare(b.id));
 
+  const outputPath = path.join(SCRIPT_API_DIR, 'index.json');
+  const resolvedVersion = resolvePlatformDocVersion(platformDocVersion, outputPath);
   const index: SearchIndex = {
     version: '1.0.0',
     generatedAt: new Date().toISOString(),
+    ...(resolvedVersion && {platformDocVersion: resolvedVersion}),
     entries,
   };
 
-  const outputPath = path.join(SCRIPT_API_DIR, 'index.json');
   fs.writeFileSync(outputPath, JSON.stringify(index, null, 2));
 
-  console.log(`Generated Script API index with ${entries.length} entries at ${outputPath}`);
+  console.log(
+    `Generated Script API index with ${entries.length} entries` +
+      `${resolvedVersion ? ` (${resolvedVersion})` : ''} at ${outputPath}`,
+  );
 }
 
-async function generateXsdIndex(): Promise<void> {
+async function generateXsdIndex(platformDocVersion?: string): Promise<void> {
   const files = fs.readdirSync(XSD_DIR).filter((f) => f.endsWith('.xsd'));
 
   const entries: SchemaEntry[] = files.map((file) => ({
@@ -165,21 +201,27 @@ async function generateXsdIndex(): Promise<void> {
   // Sort by ID for consistent output
   entries.sort((a, b) => a.id.localeCompare(b.id));
 
+  const outputPath = path.join(XSD_DIR, 'index.json');
+  const resolvedVersion = resolvePlatformDocVersion(platformDocVersion, outputPath);
   const index: SchemaIndex = {
     version: '1.0.0',
     generatedAt: new Date().toISOString(),
+    ...(resolvedVersion && {platformDocVersion: resolvedVersion}),
     entries,
   };
 
-  const outputPath = path.join(XSD_DIR, 'index.json');
   fs.writeFileSync(outputPath, JSON.stringify(index, null, 2));
 
-  console.log(`Generated XSD index with ${entries.length} entries at ${outputPath}`);
+  console.log(
+    `Generated XSD index with ${entries.length} entries` +
+      `${resolvedVersion ? ` (${resolvedVersion})` : ''} at ${outputPath}`,
+  );
 }
 
 async function generateAllIndexes(): Promise<void> {
-  await generateScriptApiIndex();
-  await generateXsdIndex();
+  const platformDocVersion = normalizeVersion(process.argv[2]);
+  await generateScriptApiIndex(platformDocVersion);
+  await generateXsdIndex(platformDocVersion);
 }
 
 generateAllIndexes().catch((err) => {

--- a/packages/b2c-tooling-sdk/scripts/generate-guides-index.ts
+++ b/packages/b2c-tooling-sdk/scripts/generate-guides-index.ts
@@ -54,6 +54,8 @@ import {fileURLToPath} from 'node:url';
 
 import {load} from 'js-yaml';
 
+import {captureSourceProvenance, type SourceProvenance} from './source-provenance.js';
+
 /** Developer Center projects (categories) whose guides we index. */
 const CATEGORIES = ['commerce-api', 'pwa-kit-managed-runtime', 'sfnext', 'sfra', 'b2c-commerce'] as const;
 
@@ -72,6 +74,7 @@ interface DocEntry {
 interface SearchIndex {
   version: string;
   generatedAt: string;
+  source?: SourceProvenance;
   entries: DocEntry[];
 }
 
@@ -230,6 +233,8 @@ function loadEnrichment(): Map<string, EnrichmentEntry> {
 
 function main(): void {
   const contentDir = resolveDocsRepo();
+  // contentDir is `<repo>/content/en-us`; capture provenance from the repo root.
+  const source = captureSourceProvenance(path.resolve(contentDir, '..', '..'));
   const enrichment = loadEnrichment();
   const published = collectTocBasenames(contentDir);
   const tocRelations = collectTocRelations(contentDir);
@@ -298,6 +303,7 @@ function main(): void {
   const index: SearchIndex = {
     version: '2.0.0',
     generatedAt: new Date().toISOString(),
+    ...(source && {source}),
     entries,
   };
 
@@ -311,6 +317,7 @@ function main(): void {
       `${skippedOrphans} orphan files skipped as not TOC-referenced) ` +
       `at ${path.join(GUIDES_DIR, 'index.json')}`,
   );
+  if (source) console.log(`  source: ${source.sha.slice(0, 12)} (${source.committedAt})`);
 }
 
 main();

--- a/packages/b2c-tooling-sdk/scripts/generate-help-corpus.ts
+++ b/packages/b2c-tooling-sdk/scripts/generate-help-corpus.ts
@@ -76,6 +76,8 @@ import {fileURLToPath} from 'node:url';
 
 import {XMLParser} from 'fast-xml-parser';
 
+import {captureSourceProvenance, type SourceProvenance} from './source-provenance.js';
+
 // ---------------------------------------------------------------------------
 // Paths
 // ---------------------------------------------------------------------------
@@ -181,6 +183,7 @@ interface HelpEntry {
 interface SearchIndex {
   version: string;
   generatedAt: string;
+  source?: SourceProvenance;
   entries: HelpEntry[];
 }
 
@@ -719,6 +722,9 @@ function pagesFromMap(mapsDir: string, mapName: string): Page[] {
 // ---------------------------------------------------------------------------
 function main(): void {
   const contentBase = resolveContentRepo();
+  // contentBase is `<repo>/content/ht/en-us/b2c_merchandiser_administrator`;
+  // capture provenance from the repo root (four levels up).
+  const source = captureSourceProvenance(path.resolve(contentBase, '..', '..', '..', '..'));
   const mapsDir = path.join(contentBase, 'maps');
   const topicsDir = path.join(contentBase, 'topics');
 
@@ -835,6 +841,7 @@ function main(): void {
   const index: SearchIndex = {
     version: '2.0.0',
     generatedAt: new Date().toISOString(),
+    ...(source && {source}),
     entries,
   };
   fs.writeFileSync(path.join(HELP_DATA_DIR, 'index.json'), JSON.stringify(index, null, 2));
@@ -850,6 +857,7 @@ function main(): void {
         .map(([c, n]) => `${c}=${n}`)
         .join(', ')})`,
   );
+  if (source) console.log(`  source:  ${source.sha.slice(0, 12)} (${source.committedAt})`);
   console.log(`  index:   ${path.relative(REPO_ROOT, path.join(HELP_DATA_DIR, 'index.json'))}`);
   console.log(`  tarball: ${path.relative(REPO_ROOT, TARBALL)} (committed)`);
   console.log(`  staged:  ${path.relative(REPO_ROOT, CONTENT_DIR)}/ (transient, not committed)`);

--- a/packages/b2c-tooling-sdk/scripts/refresh-docs-data.ts
+++ b/packages/b2c-tooling-sdk/scripts/refresh-docs-data.ts
@@ -42,6 +42,12 @@
  * generate:guides-index to include it. It is intentionally not run here so this
  * refresh has no LLM/API-key dependency.
  *
+ * NOT covered here: the Salesforce Help corpus (data/help/) comes from the
+ * separate content-commerce-cloud DITA repo, not the DWAPP archive — refresh it
+ * with `generate:help-corpus`. The guides and help indexes each record the
+ * upstream git SHA they were built from in their index.json `source` block, so
+ * `git log <sha>..HEAD` in the source clone shows the delta before a refresh.
+ *
  * Partial-failure caveat: this is a maintainer script that mutates the committed
  * `data/` corpora in place and is NOT transactional. Each corpus's markdown is
  * replaced before its index is regenerated, so a mid-run failure (auth error,
@@ -159,7 +165,7 @@ async function main(): Promise<void> {
     run('pnpm', ['exec', 'tsx', 'scripts/generate-job-steps-docs.ts'], SDK_ROOT);
 
     console.log('→ Generating search indexes...');
-    run('pnpm', ['exec', 'tsx', 'scripts/generate-docs-index.ts'], SDK_ROOT);
+    run('pnpm', ['exec', 'tsx', 'scripts/generate-docs-index.ts', version], SDK_ROOT);
 
     // 8. Developer Center guides index (from a local commerce-cloud-docs clone).
     //    Metadata only — guide content is fetched online at read time.

--- a/packages/b2c-tooling-sdk/scripts/source-provenance.ts
+++ b/packages/b2c-tooling-sdk/scripts/source-provenance.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+/**
+ * Captures the git provenance (commit SHA, commit date, branch) of a source
+ * content repository at generation time. Written into each prose corpus's
+ * `index.json` as its `source` field so a maintainer can diff the committed
+ * corpus against the current upstream (`git log <sha>..HEAD` in the local clone)
+ * and see exactly what changed before a refresh.
+ *
+ * Only opaque values are recorded — deliberately NO repository URL — so no
+ * internal host name or maintainer credential can land in the published package.
+ *
+ * Best-effort: if the path is not a git repo or git is unavailable, returns
+ * `undefined` and the caller simply omits the provenance (generation never fails
+ * over missing git metadata).
+ */
+import {execFileSync} from 'node:child_process';
+
+export interface SourceProvenance {
+  sha: string;
+  committedAt: string;
+  ref?: string;
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore']}).trim();
+}
+
+/**
+ * @param repoPath any path inside the source repo working tree
+ */
+export function captureSourceProvenance(repoPath: string): SourceProvenance | undefined {
+  try {
+    const sha = git(repoPath, ['rev-parse', 'HEAD']);
+    const committedAt = git(repoPath, ['show', '-s', '--format=%cI', 'HEAD']);
+    let ref: string | undefined;
+    try {
+      const branch = git(repoPath, ['rev-parse', '--abbrev-ref', 'HEAD']);
+      if (branch && branch !== 'HEAD') ref = branch;
+    } catch {
+      // detached HEAD or unavailable
+    }
+    return {sha, committedAt, ...(ref && {ref})};
+  } catch {
+    console.warn(`Warning: could not read git provenance from ${repoPath}; omitting source metadata.`);
+    return undefined;
+  }
+}

--- a/packages/b2c-tooling-sdk/src/docs/index.ts
+++ b/packages/b2c-tooling-sdk/src/docs/index.ts
@@ -53,6 +53,7 @@ export type {
   SchemaEntry,
   SchemaIndex,
   SchemaSearchResult,
+  SourceProvenance,
 } from './types.js';
 
 // Search operations

--- a/packages/b2c-tooling-sdk/src/docs/types.ts
+++ b/packages/b2c-tooling-sdk/src/docs/types.ts
@@ -105,6 +105,26 @@ export interface DocEntry {
 }
 
 /**
+ * Provenance of the upstream content a bundled corpus was generated from.
+ *
+ * Recorded in the index so a maintainer can diff the committed corpus against
+ * the current source repo (`git log <sha>..HEAD` in the local clone) to see
+ * exactly what changed before a refresh. Absent on corpora sourced from the
+ * DWAPP archive rather than a git repo (Script API, job steps).
+ *
+ * Only opaque values are stored — no repository URL — so no internal host name
+ * or maintainer credential can leak into the published package.
+ */
+export interface SourceProvenance {
+  /** Full git commit SHA the corpus was generated from. */
+  sha: string;
+  /** Commit date (ISO 8601) of that SHA. */
+  committedAt: string;
+  /** Branch/ref checked out at generation time, if known. */
+  ref?: string;
+}
+
+/**
  * The search index structure stored in index.json.
  */
 export interface SearchIndex {
@@ -112,6 +132,14 @@ export interface SearchIndex {
   version: string;
   /** Timestamp when the index was generated */
   generatedAt: string;
+  /** Provenance of the upstream source content, when generated from a git repo. */
+  source?: SourceProvenance;
+  /**
+   * Platform documentation version the corpus was generated from (e.g. "DWAPP
+   * 26.8"), for corpora sourced from the DWAPP archive rather than a git repo
+   * (Script API). Absent on git-sourced corpora, which use {@link source}.
+   */
+  platformDocVersion?: string;
   /** Array of documentation entries */
   entries: DocEntry[];
 }
@@ -144,6 +172,8 @@ export interface SchemaIndex {
   version: string;
   /** Timestamp when the index was generated */
   generatedAt: string;
+  /** Platform documentation version the schemas were extracted from (e.g. "DWAPP 26.8"). */
+  platformDocVersion?: string;
   /** Array of schema entries */
   entries: SchemaEntry[];
 }


### PR DESCRIPTION
## Summary

Refreshes the bundled documentation corpora to the 26.8 release and adds source-provenance tracking to every corpus index so future refresh deltas are easy to spot.

### Corpus refresh
- **Script API / XSD / job steps** → DWAPP **26.8** (Script API 527 → 532 entries: adds the `dw.commerceapps` package, connection-health hooks, and `ShippingHooks`).
- **Developer Center guides** refreshed from `commerce-cloud-docs` (adds newly published guides such as SCAPI CDN caching, guest order access codes, and several Storefront Next topics). All 597 entries LLM-enriched via the missing-only enrichment pass.
- **Salesforce Help** corpus content unchanged this cycle; index re-stamped with provenance only.

### Provenance / delta tracking
Each corpus index now records where it was generated from, so a maintainer can diff the committed corpus against the current source before a refresh:
- Git-sourced prose corpora (guides, help) store the upstream commit in a `source` block `{ sha, committedAt, ref }`.
- DWAPP-sourced corpora (Script API, XSD, job steps) store the platform release in `platformDocVersion` (e.g. `"DWAPP 26.8"`).

Only **opaque values** are stored — deliberately **no repository URL** — so no internal host name or maintainer credential can land in the published package. New shared helper `scripts/source-provenance.ts`; `generate:docs-index` gains a version arg (forwarded by `refresh:docs-data`), and a manual regen preserves any committed version rather than dropping it.

The documentation skill (`.claude/skills/documentation/SKILL.md`) documents the Help corpus refresh, the provenance fields, and the `git log <sha>..HEAD` delta workflow.