### PR TITLE
fix(b2c-skills): correct cross-pack links that resolve nowhere

### DIFF
--- a/.changeset/fix-skills-cross-pack-links.md
+++ b/.changeset/fix-skills-cross-pack-links.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Fix six cross-pack skill links in `b2c-scapi-admin` and `b2c-scapi-shopper` that were one directory level short and resolved to paths that do not exist.

--- a/skills/b2c/skills/b2c-scapi-admin/SKILL.md
+++ b/skills/b2c/skills/b2c-scapi-admin/SKILL.md
@@ -71,7 +71,7 @@ b2c auth token --json
 
 > **Tenant scope is required.** For any SCAPI Admin call (system APIs *and* custom Admin APIs), the token must carry both the tenant scope `SALESFORCE_COMMERCE_API:<tenant_id>` and the API-specific scopes — see [Dual Scope Requirement](#dual-scope-requirement) below. The SCAPI subcommands (`b2c scapi custom status`, `b2c scapi schemas list`) add the tenant scope automatically; `b2c auth token` and raw curl do not.
 
-See [b2c-config skill](../../b2c-cli/skills/b2c-config/SKILL.md) for configuration details.
+See [b2c-config skill](../../../b2c-cli/skills/b2c-config/SKILL.md) for configuration details.
 
 ### Get Token Programmatically
 
@@ -452,9 +452,9 @@ Admin APIs have lower rate limits than Shopper APIs. See `docs_read commerce-api
 
 ## Related Skills
 
-- [b2c-config](../../b2c-cli/skills/b2c-config/SKILL.md) - Get admin tokens via CLI
+- [b2c-config](../../../b2c-cli/skills/b2c-config/SKILL.md) - Get admin tokens via CLI
 - [b2c-scapi-shopper](../b2c-scapi-shopper/SKILL.md) - Shopper-facing APIs
-- [b2c-scapi-schemas](../../b2c-cli/skills/b2c-scapi-schemas/SKILL.md) - Browse OpenAPI schemas
+- [b2c-scapi-schemas](../../../b2c-cli/skills/b2c-scapi-schemas/SKILL.md) - Browse OpenAPI schemas
 
 ## Reference Documentation
 

--- a/skills/b2c/skills/b2c-scapi-shopper/SKILL.md
+++ b/skills/b2c/skills/b2c-scapi-shopper/SKILL.md
@@ -70,7 +70,7 @@ b2c slas client create \
   --redirect-uri http://localhost:3000/callback
 ```
 
-See [b2c-slas skill](../../b2c-cli/skills/b2c-slas/SKILL.md) for full client management.
+See [b2c-slas skill](../../../b2c-cli/skills/b2c-slas/SKILL.md) for full client management.
 
 ### Get Guest Token
 
@@ -348,9 +348,9 @@ Find logs in Log Center under `scapi.verbose` category.
 
 ## Related Skills
 
-- [b2c-slas](../../b2c-cli/skills/b2c-slas/SKILL.md) - Create and manage SLAS clients
+- [b2c-slas](../../../b2c-cli/skills/b2c-slas/SKILL.md) - Create and manage SLAS clients
 - [b2c-slas-auth-patterns](../b2c-slas-auth-patterns/SKILL.md) - Advanced auth: OTP, passkeys, session bridge
-- [b2c-scapi-schemas](../../b2c-cli/skills/b2c-scapi-schemas/SKILL.md) - Browse OpenAPI schemas
+- [b2c-scapi-schemas](../../../b2c-cli/skills/b2c-scapi-schemas/SKILL.md) - Browse OpenAPI schemas
 - [b2c-custom-api-development](../b2c-custom-api-development/SKILL.md) - Create custom endpoints
 - [b2c-hooks](../b2c-hooks/SKILL.md) - The `order.afterPOST` hook that authorizes payment and places/fails a headless order
 - [b2c-ordering](../b2c-ordering/SKILL.md) - Order lifecycle, status transitions, and failure handling


### PR DESCRIPTION
Fixes #608.

Six links from `b2c-scapi-admin` and `b2c-scapi-shopper` into the sibling `b2c-cli` pack used two levels of `../` where three are needed, so they resolved to `skills/b2c/b2c-cli/...` — a path that doesn't exist. Anyone following them from a "Related Skills" section or an inline "See [b2c-slas skill](...)" pointer hit a dead link right where they needed the setup steps.

Changed `../../b2c-cli/` to `../../../b2c-cli/` on those six lines. All three targets (`b2c-config`, `b2c-slas`, `b2c-scapi-schemas`) exist on disk, and `skills/b2c-cli/skills/b2c-job/SKILL.md` already writes its cross-pack links with three levels — so this was a slip in two files, not a differing convention.

No behavior change; skill content is otherwise untouched.

The CI link-check suggestion from #608 is not included here — happy to open a follow-up for it if it's wanted.
