### PR TITLE
feat: add idempotent site archive import sets

### DIFF
--- a/.changeset/add-idempotent-import-sets.md
+++ b/.changeset/add-idempotent-import-sets.md
@@ -1,0 +1,8 @@
+---
+'@salesforce/b2c-cli': minor
+'@salesforce/b2c-tooling-sdk': minor
+'@salesforce/b2c-dx-docs': patch
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Added ordered, idempotent site archive import sets with verified WebDAV receipts, retry-until-receipted behavior, and serialized concurrent runners.

--- a/.changeset/document-data-migrations-plugin.md
+++ b/.changeset/document-data-migrations-plugin.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-dx-docs': patch
+---
+
+Added the data migrations plugin to the third-party plugins guide so users can discover idempotent, version-controlled IMPEX and scripted deployments.

--- a/docs/cli/jobs.md
+++ b/docs/cli/jobs.md
@@ -22,7 +22,7 @@ Configure these resources in Business Manager under **Administration** > **Site 
 
 ### WebDAV Access
 
-The `job import`, `job export`, and `job log` commands also require WebDAV access for file transfer.
+The `job import`, `job import-set`, `job export`, and `job log` commands also require WebDAV access for file transfer and import-set state.
 
 ### Configuration
 
@@ -370,6 +370,74 @@ When you run a normal (non-`--split`) directory import and the assembled archive
 
 ---
 
+## b2c job import-set
+
+Apply an ordered directory of site archives idempotently. Each immediate child directory or `.zip` file is one import item; other files and hidden entries are ignored.
+
+### Usage
+
+```bash
+b2c job import-set DIRECTORY
+```
+
+For example:
+
+```text
+data-migrations/
+├── 20260801-add-preferences/
+│   ├── meta/
+│   └── sites/
+├── 20260802-seed-content.zip
+└── README.md                       # ignored
+```
+
+The CLI imports `20260801-add-preferences/` and then `20260802-seed-content.zip` in lexical filename order. Prefix item names with a timestamp or sequence number when order matters.
+
+### Flags
+
+In addition to [global flags](./index#global-flags):
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--set-id` | Stable state namespace for the set | Directory name |
+| `--dry-run` | Show pending and applied items without locking, importing, or writing state | `false` |
+| `--keep-archive`, `-k` | Keep each uploaded archive on the instance after import | `false` |
+| `--break-lock` | Remove an existing import-set lock before acquiring it | `false` |
+| `--stale-lock-seconds` | Take over a lock whose heartbeat is older than this many seconds | `1800` |
+| `--lock-poll-interval` | Seconds between checks while another runner holds the set lock | `3` |
+| `--timeout`, `-t` | Timeout in seconds for each import job | No timeout |
+| `--poll-interval` | Job polling interval in seconds | `3` |
+| `--show-log` | Show the job log when an import fails | `true` |
+
+### Examples
+
+```bash
+# Preview what would be imported
+b2c job import-set ./data-migrations --dry-run
+
+# Apply the set; repeat this command safely in local setup or CI
+b2c job import-set ./data-migrations --set-id storefront-data
+
+# Explicitly replace a lock after confirming its owner is no longer running
+b2c job import-set ./data-migrations --set-id storefront-data --break-lock
+```
+
+### Receipts and retry behavior
+
+The CLI hashes each item's contents and stores verified receipts in WebDAV under `Impex/b2c-cli/import-sets/<set-id>/receipts/`. An item with a matching receipt is skipped; an item with no valid receipt is imported and its receipt is written only after the platform import succeeds.
+
+This deliberately provides **at-least-once retry behavior until the receipt is durable**. If an import succeeds but the process crashes or WebDAV fails before the receipt is verified, the next invocation imports that item again. Site archive contents should therefore be safe to apply more than once.
+
+Once an item has a valid receipt, changing that same item's contents is an error. Add a new, later-sorting directory or zip file for the next change instead of editing an applied item. Use a stable `--set-id` in CI if the local directory name or checkout path may change.
+
+### Concurrent runners and stale locks
+
+Only one runner applies a set at a time. The CLI atomically creates a WebDAV collection as the set lock, writes owner metadata, and refreshes a heartbeat while imports run. Other runners wait and re-check receipts after acquiring the lock.
+
+A lock is automatically treated as stale after 30 minutes by default; tune this with `--stale-lock-seconds`. Use `--break-lock` only after confirming the recorded runner is gone. B2C Commerce WebDAV does not enforce conditional deletes, so stale or forced takeover is best-effort and is always reported in command output.
+
+---
+
 ## b2c job export
 
 Export a site archive from a B2C Commerce instance using the `sfcc-site-archive-export` system job.
@@ -451,4 +519,3 @@ When using `--global-data`, available types include:
 - `locales` - Locale configurations
 - `services` - Service configurations
 - And more (see OCAPI documentation)
-

--- a/docs/cli/jobs.md
+++ b/docs/cli/jobs.md
@@ -377,21 +377,27 @@ Apply an ordered directory of site archives idempotently. Each immediate child d
 ### Usage
 
 ```bash
-b2c job import-set DIRECTORY
+b2c job import-set [DIRECTORY]
 ```
+
+### Arguments
+
+| Argument | Description | Required | Default |
+|----------|-------------|----------|---------|
+| `DIRECTORY` | Directory whose immediate child directories and zip files form the ordered import set | No | `./migrations` |
 
 For example:
 
 ```text
-data-migrations/
-├── 20260801-add-preferences/
+migrations/
+├── 20260801T140000-add-preferences/
 │   ├── meta/
 │   └── sites/
-├── 20260802-seed-content.zip
+├── 20260802T091500-seed-content.zip
 └── README.md                       # ignored
 ```
 
-The CLI imports `20260801-add-preferences/` and then `20260802-seed-content.zip` in lexical filename order. Prefix item names with a timestamp or sequence number when order matters.
+The CLI imports `20260801T140000-add-preferences/` and then `20260802T091500-seed-content.zip` in lexical filename order. Name every item `YYYYMMDDTHHmmss-description` so the filename is both its ordering key and its stable, practically unique receipt identity across projects. Use UTC when teams work across time zones.
 
 ### Flags
 
@@ -399,7 +405,7 @@ In addition to [global flags](./index#global-flags):
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--set-id` | Stable state namespace for the set | Directory name |
+| `--set-id` | Advanced: remote receipt and lock namespace for an independent migration history | `migrations` |
 | `--dry-run` | Show pending and applied items without locking, importing, or writing state | `false` |
 | `--keep-archive`, `-k` | Keep each uploaded archive on the instance after import | `false` |
 | `--break-lock` | Remove an existing import-set lock before acquiring it | `false` |
@@ -413,22 +419,27 @@ In addition to [global flags](./index#global-flags):
 
 ```bash
 # Preview what would be imported
-b2c job import-set ./data-migrations --dry-run
+b2c job import-set --dry-run
 
-# Apply the set; repeat this command safely in local setup or CI
-b2c job import-set ./data-migrations --set-id storefront-data
+# Apply ./migrations; repeat this command safely in local setup or CI
+b2c job import-set
 
 # Explicitly replace a lock after confirming its owner is no longer running
-b2c job import-set ./data-migrations --set-id storefront-data --break-lock
+b2c job import-set --break-lock
+
+# Advanced: isolate a legacy migration history that cannot use unique timestamped names
+b2c job import-set ./legacy-migrations --set-id legacy-storefront-data
 ```
 
 ### Receipts and retry behavior
 
-The CLI hashes each item's contents and stores verified receipts in WebDAV under `Impex/b2c-cli/import-sets/<set-id>/receipts/`. An item with a matching receipt is skipped; an item with no valid receipt is imported and its receipt is written only after the platform import succeeds.
+The CLI creates and verifies a directory receipt on the target instance after each successful import. Receipt identity is based only on the item's directory or zip filename. An item whose name already has a receipt is skipped; its contents are not compared.
 
 This deliberately provides **at-least-once retry behavior until the receipt is durable**. If an import succeeds but the process crashes or WebDAV fails before the receipt is verified, the next invocation imports that item again. Site archive contents should therefore be safe to apply more than once.
 
-Once an item has a valid receipt, changing that same item's contents is an error. Add a new, later-sorting directory or zip file for the next change instead of editing an applied item. Use a stable `--set-id` in CI if the local directory name or checkout path may change.
+Never edit an applied item: instances that already have its name receipt continue to skip it, while a new instance would import the edited contents. Add a new, later-sorting directory or zip file for every change. Two projects using the same receipt namespace must also use distinct item names; the timestamp-and-description convention makes accidental collisions unlikely.
+
+Receipts and the concurrency lock use the fixed instance-wide `migrations` namespace by default, regardless of the local directory path. Most projects should not set `--set-id`; it exists only for intentionally independent histories or legacy item names that cannot follow the timestamp convention.
 
 ### Concurrent runners and stale locks
 

--- a/docs/guide/third-party-plugins.md
+++ b/docs/guide/third-party-plugins.md
@@ -1,5 +1,5 @@
 ---
-description: Community plugins for the B2C CLI including IntelliJ SFCC config integration, credential storage, docs search, catalog reduction, and pipeline visualization.
+description: Community plugins for the B2C CLI including data migrations, IntelliJ SFCC config integration, credential storage, docs search, catalog reduction, and pipeline visualization.
 ---
 
 # 3rd Party Plugins
@@ -25,6 +25,42 @@ b2c plugins uninstall b2c-plugin-intellij-sfcc-config
 ```
 
 ## Available Plugins
+
+### Data Migrations Plugin
+
+**Repository:** [sfcc-solutions-share/b2c-plugin-data-migrations](https://github.com/sfcc-solutions-share/b2c-plugin-data-migrations)
+
+Applies version-controlled data migrations to B2C Commerce instances. The plugin tracks migration state on each instance, so ordered IMPEX archives and JavaScript migration scripts run only once by default.
+
+#### Installation
+
+```bash
+b2c plugins install sfcc-solutions-share/b2c-plugin-data-migrations
+```
+
+#### Features
+
+- Runs pending directory-based site archives and JavaScript migrations in filename order
+- Records applied migrations on the instance for idempotent deployments
+- Supports dry runs, exclusions, migration notes, and runtime variables
+- Provides lifecycle hooks for project-specific setup and migration behavior
+- Deploys and manages reusable features that can include migrations, cartridges, and configuration
+
+#### Usage
+
+```bash
+# Apply pending migrations from ./migrations
+b2c migrations run
+
+# Preview pending migrations without applying them
+b2c migrations run --dry-run
+
+# Use a different migration directory and pass a runtime variable
+b2c migrations run --migrations-dir ./data/migrations --vars siteId=RefArch
+
+# Deploy a reusable feature
+b2c migrations feature deploy my-feature
+```
 
 ### IntelliJ SFCC Config Plugin
 

--- a/packages/b2c-cli/src/commands/job/import-set.ts
+++ b/packages/b2c-cli/src/commands/job/import-set.ts
@@ -13,11 +13,14 @@ import {
 } from '@salesforce/b2c-tooling-sdk/operations/jobs';
 import {t, withDocs} from '../../i18n/index.js';
 
+const DEFAULT_IMPORT_SET_DIRECTORY = './migrations';
+const DEFAULT_IMPORT_SET_ID = 'migrations';
+
 export default class JobImportSet extends JobCommand<typeof JobImportSet> {
   static args = {
     directory: Args.string({
       description: 'Directory whose immediate child directories and zip files form the ordered import set',
-      required: true,
+      default: DEFAULT_IMPORT_SET_DIRECTORY,
     }),
   };
 
@@ -32,16 +35,16 @@ export default class JobImportSet extends JobCommand<typeof JobImportSet> {
   static enableJsonFlag = true;
 
   static examples = [
-    '<%= config.bin %> <%= command.id %> ./impex',
-    '<%= config.bin %> <%= command.id %> ./impex --dry-run',
-    '<%= config.bin %> <%= command.id %> ./impex --set-id storefront-data',
-    '<%= config.bin %> <%= command.id %> ./impex --break-lock',
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --dry-run',
+    '<%= config.bin %> <%= command.id %> ./release-data',
+    '<%= config.bin %> <%= command.id %> --break-lock',
   ];
 
   static flags = {
     ...JobCommand.baseFlags,
     'set-id': Flags.string({
-      description: 'Stable state namespace (defaults to the directory name)',
+      description: 'Remote receipt and lock namespace for an independent migration history',
     }),
     'dry-run': Flags.boolean({
       description: 'Show pending and applied items without locking, importing, or writing state',
@@ -88,7 +91,7 @@ export default class JobImportSet extends JobCommand<typeof JobImportSet> {
     this.requireOAuthCredentials();
     this.requireWebDavCredentials();
 
-    const {directory} = this.args;
+    const directory = this.args.directory ?? DEFAULT_IMPORT_SET_DIRECTORY;
     const {
       'set-id': setId,
       'dry-run': dryRun,
@@ -107,9 +110,10 @@ export default class JobImportSet extends JobCommand<typeof JobImportSet> {
       if (jobEvaluation.action === 'confirm') await this.confirmOrBlock(jobEvaluation);
     }
 
+    const effectiveSetId = setId ?? DEFAULT_IMPORT_SET_ID;
     const context = this.createContext('job:import-set', {
       directory,
-      setId,
+      setId: effectiveSetId,
       dryRun,
       keepArchive,
       staleLockSeconds,
@@ -122,7 +126,7 @@ export default class JobImportSet extends JobCommand<typeof JobImportSet> {
         }),
       );
       return {
-        setId: setId ?? directory,
+        setId: effectiveSetId,
         directory,
         dryRun,
         runId: 'skipped',
@@ -142,7 +146,7 @@ export default class JobImportSet extends JobCommand<typeof JobImportSet> {
 
     try {
       const result = await this.operations.siteArchiveImportSet(this.instance, directory, {
-        setId,
+        setId: effectiveSetId,
         dryRun,
         keepArchive,
         breakLock,
@@ -262,7 +266,7 @@ export default class JobImportSet extends JobCommand<typeof JobImportSet> {
         this.warn(
           t(
             'commands.job.importSet.invalidReceipt',
-            'Receipt for {{item}} is missing or invalid; the item will be imported again.',
+            'Receipt marker for {{item}} is invalid; the item will be imported again.',
             {item: event.item.id},
           ),
         );

--- a/packages/b2c-cli/src/commands/job/import-set.ts
+++ b/packages/b2c-cli/src/commands/job/import-set.ts
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {Args, Flags} from '@oclif/core';
+import {JobCommand} from '@salesforce/b2c-tooling-sdk/cli';
+import {
+  siteArchiveImportSet,
+  JobExecutionError,
+  type ImportSetEvent,
+  type ImportSetResult,
+} from '@salesforce/b2c-tooling-sdk/operations/jobs';
+import {t, withDocs} from '../../i18n/index.js';
+
+export default class JobImportSet extends JobCommand<typeof JobImportSet> {
+  static args = {
+    directory: Args.string({
+      description: 'Directory whose immediate child directories and zip files form the ordered import set',
+      required: true,
+    }),
+  };
+
+  static description = withDocs(
+    t(
+      'commands.job.importSet.description',
+      'Apply an ordered set of site archives, skipping items already recorded on the instance',
+    ),
+    '/cli/jobs.html#b2c-job-import-set',
+  );
+
+  static enableJsonFlag = true;
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> ./impex',
+    '<%= config.bin %> <%= command.id %> ./impex --dry-run',
+    '<%= config.bin %> <%= command.id %> ./impex --set-id storefront-data',
+    '<%= config.bin %> <%= command.id %> ./impex --break-lock',
+  ];
+
+  static flags = {
+    ...JobCommand.baseFlags,
+    'set-id': Flags.string({
+      description: 'Stable state namespace (defaults to the directory name)',
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Show pending and applied items without locking, importing, or writing state',
+      default: false,
+    }),
+    'keep-archive': Flags.boolean({
+      char: 'k',
+      description: 'Keep each uploaded archive on the instance after import',
+      default: false,
+    }),
+    'break-lock': Flags.boolean({
+      description: 'Remove an existing import-set lock before acquiring it',
+      default: false,
+    }),
+    'stale-lock-seconds': Flags.integer({
+      description: 'Take over a lock whose heartbeat is older than this many seconds',
+      default: 1800,
+      min: 1,
+    }),
+    'lock-poll-interval': Flags.integer({
+      description: 'Seconds between checks while another runner holds the set lock',
+      default: 3,
+      min: 1,
+    }),
+    timeout: Flags.integer({
+      char: 't',
+      description: 'Per-import job timeout in seconds (default: no timeout)',
+      min: 1,
+    }),
+    'poll-interval': Flags.integer({
+      description: 'Job polling interval in seconds',
+      default: 3,
+      min: 1,
+    }),
+    'show-log': Flags.boolean({
+      description: 'Show the job log when an import fails',
+      default: true,
+    }),
+  };
+
+  protected operations = {siteArchiveImportSet};
+
+  async run(): Promise<ImportSetResult> {
+    this.requireOAuthCredentials();
+    this.requireWebDavCredentials();
+
+    const {directory} = this.args;
+    const {
+      'set-id': setId,
+      'dry-run': dryRun,
+      'keep-archive': keepArchive,
+      'break-lock': breakLock,
+      'stale-lock-seconds': staleLockSeconds,
+      'lock-poll-interval': lockPollIntervalSeconds,
+      timeout,
+      'poll-interval': pollIntervalSeconds,
+      'show-log': showLog = true,
+    } = this.flags;
+
+    if (!dryRun) {
+      const jobEvaluation = this.safetyGuard.evaluate({type: 'job', jobId: 'sfcc-site-archive-import'});
+      if (jobEvaluation.action === 'block') this.error(jobEvaluation.reason, {exit: 1});
+      if (jobEvaluation.action === 'confirm') await this.confirmOrBlock(jobEvaluation);
+    }
+
+    const context = this.createContext('job:import-set', {
+      directory,
+      setId,
+      dryRun,
+      keepArchive,
+      staleLockSeconds,
+    });
+    const beforeResult = await this.runBeforeHooks(context);
+    if (beforeResult.skip) {
+      this.log(
+        t('commands.job.importSet.skipped', 'Import set skipped: {{reason}}', {
+          reason: beforeResult.skipReason || 'skipped by plugin',
+        }),
+      );
+      return {
+        setId: setId ?? directory,
+        directory,
+        dryRun,
+        runId: 'skipped',
+        items: [],
+        imported: 0,
+        skipped: 0,
+        pending: 0,
+      };
+    }
+
+    const cleanupSafetyRule = this.safetyGuard.temporarilyAddRule({
+      method: 'DELETE',
+      path: '**/Impex/b2c-cli/**',
+      action: 'allow',
+    });
+    const startedAt = Date.now();
+
+    try {
+      const result = await this.operations.siteArchiveImportSet(this.instance, directory, {
+        setId,
+        dryRun,
+        keepArchive,
+        breakLock,
+        staleLockSeconds,
+        lockPollIntervalSeconds,
+        waitOptions: {
+          timeoutSeconds: timeout,
+          pollIntervalSeconds,
+          onPoll: ({status, elapsedSeconds}) => {
+            if (!this.jsonEnabled()) {
+              this.log(
+                t('commands.job.importSet.progress', '    Status: {{status}} ({{elapsed}}s elapsed)', {
+                  status,
+                  elapsed: String(elapsedSeconds),
+                }),
+              );
+            }
+          },
+        },
+        onEvent: (event) => this.handleEvent(event),
+      });
+
+      if (dryRun && !this.jsonEnabled()) {
+        for (const item of result.items) {
+          this.log(`  ${item.status === 'skipped' ? 'applied' : 'pending'}  ${item.id}`);
+        }
+      }
+
+      if (!this.jsonEnabled()) {
+        this.log(
+          dryRun
+            ? t('commands.job.importSet.dryRunSummary', 'Dry run: {{pending}} pending, {{skipped}} already applied', {
+                pending: String(result.pending),
+                skipped: String(result.skipped),
+              })
+            : t('commands.job.importSet.summary', 'Import set complete: {{imported}} imported, {{skipped}} skipped', {
+                imported: String(result.imported),
+                skipped: String(result.skipped),
+              }),
+        );
+      }
+
+      await this.runAfterHooks(context, {
+        success: true,
+        duration: Date.now() - startedAt,
+        data: result,
+      });
+      return result;
+    } catch (error) {
+      await this.runAfterHooks(context, {
+        success: false,
+        duration: Date.now() - startedAt,
+        error: error instanceof Error ? error : new Error(String(error)),
+        data: error instanceof JobExecutionError ? error.execution : undefined,
+      });
+
+      if (error instanceof JobExecutionError && showLog) await this.showJobLog(error.execution);
+      this.error(
+        t('commands.job.importSet.error', 'Import set failed: {{message}}', {
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    } finally {
+      cleanupSafetyRule();
+    }
+  }
+
+  private handleEvent(event: ImportSetEvent): void {
+    if (this.jsonEnabled()) return;
+
+    switch (event.type) {
+      case 'item-imported': {
+        this.log(`  ${event.index}/${event.total} imported   ${event.item.id}`);
+        break;
+      }
+      case 'item-importing': {
+        this.log(`  ${event.index}/${event.total} importing  ${event.item.id}`);
+        break;
+      }
+      case 'item-skipped': {
+        this.log(`  ${event.index}/${event.total} skipped    ${event.item.id}`);
+        break;
+      }
+      case 'lock-acquired': {
+        this.log(t('commands.job.importSet.lockAcquired', 'Acquired import-set lock.'));
+        break;
+      }
+      case 'lock-takeover': {
+        const age = event.ageSeconds === undefined ? 'unknown' : Math.floor(event.ageSeconds).toString();
+        this.warn(
+          event.forced
+            ? t('commands.job.importSet.lockBreak', 'Breaking the existing import-set lock.')
+            : t('commands.job.importSet.lockStale', 'Taking over stale import-set lock (age: {{age}}s).', {age}),
+        );
+        break;
+      }
+      case 'lock-wait': {
+        this.log(t('commands.job.importSet.lockWait', 'Another runner holds the import-set lock; waiting...'));
+        break;
+      }
+      case 'plan': {
+        this.log(
+          t(
+            'commands.job.importSet.plan',
+            'Import set {{setId}}: {{total}} item(s), {{pending}} pending, {{skipped}} already applied',
+            {
+              setId: event.setId,
+              total: String(event.total),
+              pending: String(event.pending),
+              skipped: String(event.skipped),
+            },
+          ),
+        );
+        break;
+      }
+      case 'receipt-invalid': {
+        this.warn(
+          t(
+            'commands.job.importSet.invalidReceipt',
+            'Receipt for {{item}} is missing or invalid; the item will be imported again.',
+            {item: event.item.id},
+          ),
+        );
+        break;
+      }
+    }
+  }
+}

--- a/packages/b2c-cli/test/commands/job/import-set.test.ts
+++ b/packages/b2c-cli/test/commands/job/import-set.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {expect} from 'chai';
+import {afterEach, beforeEach} from 'mocha';
+import sinon from 'sinon';
+import {JobExecutionError} from '@salesforce/b2c-tooling-sdk/operations/jobs';
+import JobImportSet from '../../../src/commands/job/import-set.js';
+import {createIsolatedConfigHooks, createTestCommand} from '../../helpers/test-setup.js';
+
+describe('job import-set', () => {
+  const hooks = createIsolatedConfigHooks();
+
+  beforeEach(hooks.beforeEach);
+
+  afterEach(hooks.afterEach);
+
+  async function createCommand(flags: Record<string, unknown>, args: Record<string, unknown>) {
+    return createTestCommand(JobImportSet, hooks.getConfig(), flags, args);
+  }
+
+  function stubCommon(command: any) {
+    const instance = {config: {hostname: 'example.com'}};
+    sinon.stub(command, 'requireOAuthCredentials').returns(void 0);
+    sinon.stub(command, 'requireWebDavCredentials').returns(void 0);
+    sinon.stub(command, 'instance').get(() => instance);
+    sinon.stub(command, 'log').returns(void 0);
+    sinon.stub(command, 'warn').returns(void 0);
+    sinon.stub(command, 'createContext').callsFake((...arguments_: unknown[]) => {
+      const [operationType, metadata] = arguments_ as [string, Record<string, unknown>];
+      return {
+        operationType,
+        metadata,
+        startTime: Date.now(),
+      };
+    });
+    return instance;
+  }
+
+  function result(overrides: Record<string, unknown> = {}) {
+    return {
+      setId: 'storefront-data',
+      directory: './impex',
+      dryRun: false,
+      runId: 'run-1',
+      items: [],
+      imported: 2,
+      skipped: 1,
+      pending: 0,
+      ...overrides,
+    };
+  }
+
+  it('forwards import-set, lock, and job options to the SDK operation', async () => {
+    const command: any = await createCommand(
+      {
+        json: true,
+        'set-id': 'storefront-data',
+        'keep-archive': true,
+        'break-lock': true,
+        'stale-lock-seconds': 900,
+        'lock-poll-interval': 5,
+        timeout: 600,
+        'poll-interval': 2,
+      },
+      {directory: './impex'},
+    );
+    const instance = stubCommon(command);
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    sinon.stub(command, 'runAfterHooks').resolves(void 0);
+    const importSetStub = sinon.stub().resolves(result());
+    command.operations = {siteArchiveImportSet: importSetStub};
+
+    const output = await command.run();
+
+    expect(output.imported).to.equal(2);
+    expect(importSetStub.calledOnce).to.equal(true);
+    expect(importSetStub.getCall(0).args[0]).to.equal(instance);
+    expect(importSetStub.getCall(0).args[1]).to.equal('./impex');
+    const options = importSetStub.getCall(0).args[2];
+    expect(options).to.include({
+      setId: 'storefront-data',
+      keepArchive: true,
+      breakLock: true,
+      staleLockSeconds: 900,
+      lockPollIntervalSeconds: 5,
+    });
+    expect(options.waitOptions).to.include({timeoutSeconds: 600, pollIntervalSeconds: 2});
+  });
+
+  it('returns without importing when a lifecycle hook skips the operation', async () => {
+    const command: any = await createCommand({json: true}, {directory: './impex'});
+    stubCommon(command);
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: true, skipReason: 'deployment policy'});
+    const importSetStub = sinon.stub().rejects(new Error('Unexpected import'));
+    command.operations = {siteArchiveImportSet: importSetStub};
+
+    const output = await command.run();
+
+    expect(importSetStub.called).to.equal(false);
+    expect(output.runId).to.equal('skipped');
+  });
+
+  it('shows the platform job log when an item import fails', async () => {
+    const command: any = await createCommand({json: true, 'show-log': true}, {directory: './impex'});
+    stubCommon(command);
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    sinon.stub(command, 'runAfterHooks').resolves(void 0);
+    const execution: any = {id: 'execution-1', execution_status: 'finished', exit_status: {code: 'ERROR'}};
+    command.operations = {
+      siteArchiveImportSet: sinon.stub().rejects(new JobExecutionError('Import failed', execution)),
+    };
+    const showLogStub = sinon.stub(command, 'showJobLog').resolves(void 0);
+    sinon.stub(command, 'error').throws(new Error('Expected command error'));
+
+    try {
+      await command.run();
+      expect.fail('Expected command error');
+    } catch {
+      // Expected.
+    }
+
+    expect(showLogStub.calledOnceWith(execution)).to.equal(true);
+  });
+});

--- a/packages/b2c-cli/test/commands/job/import-set.test.ts
+++ b/packages/b2c-cli/test/commands/job/import-set.test.ts
@@ -90,6 +90,20 @@ describe('job import-set', () => {
     expect(options.waitOptions).to.include({timeoutSeconds: 600, pollIntervalSeconds: 2});
   });
 
+  it('uses the migrations directory when no directory is provided', async () => {
+    const command: any = await createCommand({json: true}, {});
+    const instance = stubCommon(command);
+    sinon.stub(command, 'runBeforeHooks').resolves({skip: false});
+    sinon.stub(command, 'runAfterHooks').resolves(void 0);
+    const importSetStub = sinon.stub().resolves(result({directory: './migrations'}));
+    command.operations = {siteArchiveImportSet: importSetStub};
+
+    await command.run();
+
+    expect(importSetStub.calledOnceWith(instance, './migrations', sinon.match.object)).to.equal(true);
+    expect(importSetStub.firstCall.args[2].setId).to.equal('migrations');
+  });
+
   it('returns without importing when a lifecycle hook skips the operation', async () => {
     const command: any = await createCommand({json: true}, {directory: './impex'});
     stubCommon(command);

--- a/packages/b2c-tooling-sdk/src/cli/lifecycle.ts
+++ b/packages/b2c-tooling-sdk/src/cli/lifecycle.ts
@@ -48,6 +48,7 @@ import type {Logger} from '../logging/index.js';
 export type B2COperationType =
   | 'job:run'
   | 'job:import'
+  | 'job:import-set'
   | 'job:export'
   | 'code:deploy'
   | 'code:download'

--- a/packages/b2c-tooling-sdk/src/operations/jobs/import-set.ts
+++ b/packages/b2c-tooling-sdk/src/operations/jobs/import-set.ts
@@ -6,11 +6,13 @@
 import {createHash, randomUUID} from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import {HTTPError} from '../../errors/http-error.js';
 import type {B2CInstance} from '../../instance/index.js';
 import {siteArchiveImport, type SiteArchiveImportOptions, type SiteArchiveImportResult} from './site-archive.js';
 import type {WaitForJobOptions} from './run.js';
 
 const DEFAULT_STATE_ROOT = 'Impex/b2c-cli/import-sets';
+const DEFAULT_SET_ID = 'migrations';
 const DEFAULT_STALE_LOCK_SECONDS = 30 * 60;
 const DEFAULT_LOCK_POLL_INTERVAL_SECONDS = 3;
 const DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30;
@@ -23,21 +25,15 @@ export interface ImportSetItem {
   target: string;
   /** Source kind. */
   kind: 'directory' | 'zip';
-  /** Deterministic SHA-256 of the contents and, for directories, relative paths. */
-  sha256: string;
 }
 
-/** Durable receipt written after an import completes successfully. */
+/** Durable directory receipt created after an import completes successfully. */
 export interface ImportSetReceipt {
   version: 1;
   setId: string;
   itemId: string;
-  sha256: string;
-  source: string;
-  appliedAt: string;
-  runId: string;
-  executionId?: string;
-  archiveFilename?: string;
+  /** WebDAV directory whose existence records the applied item name. */
+  receiptPath: string;
 }
 
 /** Result for one item in an import set. */
@@ -82,7 +78,7 @@ export interface ImportSetLockOwner {
 
 /** Options for {@link siteArchiveImportSet}. */
 export interface SiteArchiveImportSetOptions {
-  /** Stable set ID. Defaults to the import-set directory name. */
+  /** Stable receipt and lock namespace. Defaults to `migrations`. */
   setId?: string;
   /** Plan imports without creating state, locking, importing, or writing receipts. */
   dryRun?: boolean;
@@ -117,20 +113,6 @@ export interface SiteArchiveImportSetOptions {
   sleep?: (milliseconds: number) => Promise<void>;
 }
 
-/** Thrown when an applied item ID now resolves to different contents. */
-export class ImportSetChangedError extends Error {
-  constructor(
-    public readonly item: ImportSetItem,
-    public readonly receipt: ImportSetReceipt,
-  ) {
-    super(
-      `Import-set item "${item.id}" has changed since it was applied ` +
-        `(receipt ${receipt.sha256}, local ${item.sha256}). Add a new item instead of modifying an applied import.`,
-    );
-    this.name = 'ImportSetChangedError';
-  }
-}
-
 /** Thrown when WebDAV lock or receipt state cannot be safely read or written. */
 export class ImportSetStateError extends Error {
   constructor(message: string) {
@@ -145,6 +127,11 @@ interface JsonReadResult<T> {
   value?: T;
 }
 
+interface ReceiptDirectoryReadResult {
+  found: boolean;
+  valid: boolean;
+}
+
 interface LockInfo {
   owner?: ImportSetLockOwner;
   ageSeconds?: number;
@@ -152,7 +139,7 @@ interface LockInfo {
 
 /**
  * Discovers the immediate child directories and zip archives in an import-set
- * directory, sorts them by name, and computes deterministic content hashes.
+ * directory and sorts them by name.
  */
 export async function discoverImportSet(directory: string): Promise<ImportSetItem[]> {
   const resolvedDirectory = path.resolve(directory);
@@ -171,23 +158,18 @@ export async function discoverImportSet(directory: string): Promise<ImportSetIte
     throw new Error(`No import directories or zip archives found in ${resolvedDirectory}`);
   }
 
-  return Promise.all(
-    candidates.map(async (entry) => {
-      const target = path.join(resolvedDirectory, entry.name);
-      return {
-        id: entry.name,
-        target,
-        kind: entry.isDirectory() ? ('directory' as const) : ('zip' as const),
-        sha256: await hashImportTarget(target),
-      };
-    }),
-  );
+  return candidates.map((entry) => ({
+    id: entry.name,
+    target: path.join(resolvedDirectory, entry.name),
+    kind: entry.isDirectory() ? ('directory' as const) : ('zip' as const),
+  }));
 }
 
 /**
- * Applies an ordered set of site archives exactly until a verified receipt is
- * written for each item. A missing or invalid receipt always leaves the item
- * pending, even if a previous process may have completed the platform import.
+ * Applies an ordered set of site archives exactly until a verified receipt
+ * directory is created for each item name. A missing or invalid receipt always
+ * leaves the item pending, even if a previous process may have completed the
+ * platform import.
  *
  * The operation uses an exclusive WebDAV directory (`MKCOL`) as a best-effort
  * set-wide lock. B2C Commerce does not provide conditional WebDAV deletes, so
@@ -199,7 +181,7 @@ export async function siteArchiveImportSet(
   options: SiteArchiveImportSetOptions = {},
 ): Promise<ImportSetResult> {
   const resolvedDirectory = path.resolve(directory);
-  const setId = options.setId ?? path.basename(resolvedDirectory);
+  const setId = options.setId ?? DEFAULT_SET_ID;
   validateSetId(setId);
   validateStateRoot(options.stateRoot ?? DEFAULT_STATE_ROOT);
 
@@ -266,18 +248,8 @@ export async function siteArchiveImportSet(
       });
 
       if (heartbeatError) throw heartbeatError;
-      const receipt: ImportSetReceipt = {
-        version: 1,
-        setId,
-        itemId: itemResult.id,
-        sha256: itemResult.sha256,
-        source: path.basename(itemResult.target),
-        appliedAt: new Date().toISOString(),
-        runId,
-        executionId: importResult.execution.id,
-        archiveFilename: importResult.archiveFilename,
-      };
-      await writeAndVerifyReceipt(instance, receiptPath(receiptsRoot, itemResult.id), receipt);
+      const receipt = createReceipt(setId, receiptsRoot, itemResult.id);
+      await writeAndVerifyReceipt(instance, receipt.receiptPath);
 
       itemResult.status = 'imported';
       itemResult.receipt = receipt;
@@ -314,20 +286,17 @@ async function evaluateReceipts(
     const remotePath = receiptPath(receiptsRoot, item.id);
     // Receipt reads are intentionally sequential to avoid bursting WebDAV on large sets.
     // eslint-disable-next-line no-await-in-loop
-    const read = await readJson<ImportSetReceipt>(instance, remotePath);
+    const read = await readReceiptDirectory(instance, remotePath);
     if (!read.found) {
       results.push({...item, status: 'pending'});
       continue;
     }
-    if (!read.valid || !isReceipt(read.value, setId, item.id)) {
+    if (!read.valid) {
       onEvent?.({type: 'receipt-invalid', item, receiptPath: remotePath});
       results.push({...item, status: 'pending'});
       continue;
     }
-    if (read.value.sha256 !== item.sha256) {
-      throw new ImportSetChangedError(item, read.value);
-    }
-    results.push({...item, status: 'skipped', receipt: read.value});
+    results.push({...item, status: 'skipped', receipt: createReceipt(setId, receiptsRoot, item.id)});
   }
   return results;
 }
@@ -500,21 +469,38 @@ async function putJson(instance: B2CInstance, remotePath: string, value: unknown
   }
 }
 
-async function writeAndVerifyReceipt(
-  instance: B2CInstance,
-  remotePath: string,
-  receipt: ImportSetReceipt,
-): Promise<void> {
-  await putJson(instance, remotePath, receipt);
-  const verification = await readJson<ImportSetReceipt>(instance, remotePath);
-  if (
-    !verification.found ||
-    !verification.valid ||
-    !isReceipt(verification.value, receipt.setId, receipt.itemId) ||
-    verification.value?.runId !== receipt.runId ||
-    verification.value.sha256 !== receipt.sha256
-  ) {
-    throw new ImportSetStateError(`Receipt verification failed for ${receipt.itemId}; the import will be retried.`);
+async function readReceiptDirectory(instance: B2CInstance, remotePath: string): Promise<ReceiptDirectoryReadResult> {
+  try {
+    const entries = await instance.webdav.propfind(remotePath, '0');
+    return {found: true, valid: entries[0]?.isCollection === true};
+  } catch (error) {
+    if (error instanceof HTTPError && error.response.status === 404) return {found: false, valid: false};
+    throw new ImportSetStateError(
+      `Unable to read WebDAV receipt directory ${remotePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function writeAndVerifyReceipt(instance: B2CInstance, remotePath: string): Promise<void> {
+  let response = await instance.webdav.request(remotePath, {method: 'MKCOL'});
+  if (response.status === 405) {
+    const existing = await readReceiptDirectory(instance, remotePath);
+    if (!existing.valid) {
+      await deletePath(instance, remotePath);
+      response = await instance.webdav.request(remotePath, {method: 'MKCOL'});
+    }
+  }
+  if (response.status !== 201 && response.status !== 405) {
+    throw new ImportSetStateError(
+      `Unable to create WebDAV receipt directory ${remotePath}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const verification = await readReceiptDirectory(instance, remotePath);
+  if (!verification.found || !verification.valid) {
+    throw new ImportSetStateError(
+      `Receipt directory verification failed for ${remotePath}; the import will be retried.`,
+    );
   }
 }
 
@@ -527,21 +513,12 @@ async function deletePath(instance: B2CInstance, remotePath: string): Promise<vo
   }
 }
 
-function isReceipt(value: ImportSetReceipt | undefined, setId: string, itemId: string): value is ImportSetReceipt {
-  return (
-    value?.version === 1 &&
-    value.setId === setId &&
-    value.itemId === itemId &&
-    /^[a-f\d]{64}$/.test(value.sha256) &&
-    typeof value.source === 'string' &&
-    Number.isFinite(Date.parse(value.appliedAt)) &&
-    typeof value.runId === 'string' &&
-    value.runId.length > 0
-  );
+function createReceipt(setId: string, receiptsRoot: string, itemId: string): ImportSetReceipt {
+  return {version: 1, setId, itemId, receiptPath: receiptPath(receiptsRoot, itemId)};
 }
 
 function receiptPath(receiptsRoot: string, itemId: string): string {
-  return `${receiptsRoot}/${createHash('sha256').update(itemId).digest('hex')}.json`;
+  return `${receiptsRoot}/${createHash('sha256').update(itemId).digest('hex')}`;
 }
 
 function emitPlan(options: SiteArchiveImportSetOptions, setId: string, items: ImportSetItemResult[]): void {
@@ -585,62 +562,4 @@ function validateStateRoot(stateRoot: string): void {
   if (segments[0]?.toLowerCase() !== 'impex' || segments.some((segment) => segment === '.' || segment === '..')) {
     throw new Error(`Import-set state root must be a path under Impex: ${stateRoot}`);
   }
-}
-
-async function hashImportTarget(target: string): Promise<string> {
-  const stat = await fs.promises.lstat(target);
-  const hash = createHash('sha256');
-  if (stat.isFile()) {
-    hash.update('F\0');
-    await updateHashFromFile(hash, target);
-    return hash.digest('hex');
-  }
-  if (!stat.isDirectory()) throw new Error(`Unsupported import-set item: ${target}`);
-
-  const entries = await collectDirectoryEntries(target);
-  for (const entry of entries) {
-    hash.update(entry.kind === 'directory' ? 'D\0' : 'F\0');
-    hash.update(entry.relativePath);
-    hash.update('\0');
-    if (entry.kind === 'file') {
-      // Reading files sequentially keeps hashing deterministic and bounds memory usage.
-      // eslint-disable-next-line no-await-in-loop
-      await updateHashFromFile(hash, entry.absolutePath);
-      hash.update('\0');
-    }
-  }
-  return hash.digest('hex');
-}
-
-async function collectDirectoryEntries(
-  root: string,
-): Promise<Array<{kind: 'directory' | 'file'; relativePath: string; absolutePath: string}>> {
-  const result: Array<{kind: 'directory' | 'file'; relativePath: string; absolutePath: string}> = [];
-
-  async function visit(directory: string): Promise<void> {
-    const entries = await fs.promises.readdir(directory, {withFileTypes: true});
-    entries.sort((a, b) => a.name.localeCompare(b.name, 'en', {numeric: false}));
-    for (const entry of entries) {
-      const absolutePath = path.join(directory, entry.name);
-      const relativePath = path.relative(root, absolutePath).split(path.sep).join('/');
-      if (entry.isSymbolicLink()) {
-        throw new Error(`Symbolic links are not supported in import sets: ${absolutePath}`);
-      }
-      if (entry.isDirectory()) {
-        result.push({kind: 'directory', relativePath, absolutePath});
-        // eslint-disable-next-line no-await-in-loop
-        await visit(absolutePath);
-      } else if (entry.isFile()) {
-        result.push({kind: 'file', relativePath, absolutePath});
-      }
-    }
-  }
-
-  await visit(root);
-  return result;
-}
-
-async function updateHashFromFile(hash: ReturnType<typeof createHash>, filename: string): Promise<void> {
-  const stream = fs.createReadStream(filename);
-  for await (const chunk of stream) hash.update(chunk);
 }

--- a/packages/b2c-tooling-sdk/src/operations/jobs/import-set.ts
+++ b/packages/b2c-tooling-sdk/src/operations/jobs/import-set.ts
@@ -1,0 +1,646 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {createHash, randomUUID} from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type {B2CInstance} from '../../instance/index.js';
+import {siteArchiveImport, type SiteArchiveImportOptions, type SiteArchiveImportResult} from './site-archive.js';
+import type {WaitForJobOptions} from './run.js';
+
+const DEFAULT_STATE_ROOT = 'Impex/b2c-cli/import-sets';
+const DEFAULT_STALE_LOCK_SECONDS = 30 * 60;
+const DEFAULT_LOCK_POLL_INTERVAL_SECONDS = 3;
+const DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30;
+
+/** A local archive in an import set. */
+export interface ImportSetItem {
+  /** Stable item ID, derived from the immediate child name. */
+  id: string;
+  /** Absolute local path to the directory or zip archive. */
+  target: string;
+  /** Source kind. */
+  kind: 'directory' | 'zip';
+  /** Deterministic SHA-256 of the contents and, for directories, relative paths. */
+  sha256: string;
+}
+
+/** Durable receipt written after an import completes successfully. */
+export interface ImportSetReceipt {
+  version: 1;
+  setId: string;
+  itemId: string;
+  sha256: string;
+  source: string;
+  appliedAt: string;
+  runId: string;
+  executionId?: string;
+  archiveFilename?: string;
+}
+
+/** Result for one item in an import set. */
+export interface ImportSetItemResult extends ImportSetItem {
+  status: 'pending' | 'skipped' | 'imported';
+  receipt?: ImportSetReceipt;
+  importResult?: SiteArchiveImportResult;
+}
+
+/** Result of planning or applying an import set. */
+export interface ImportSetResult {
+  setId: string;
+  directory: string;
+  dryRun: boolean;
+  runId: string;
+  items: ImportSetItemResult[];
+  imported: number;
+  skipped: number;
+  pending: number;
+}
+
+/** Progress events emitted while planning and applying an import set. */
+export type ImportSetEvent =
+  | {type: 'plan'; setId: string; total: number; pending: number; skipped: number; dryRun: boolean}
+  | {type: 'lock-acquired'; setId: string; runId: string}
+  | {type: 'lock-wait'; setId: string; owner?: ImportSetLockOwner; ageSeconds?: number}
+  | {type: 'lock-takeover'; setId: string; owner?: ImportSetLockOwner; ageSeconds?: number; forced: boolean}
+  | {type: 'item-skipped'; item: ImportSetItem; receipt: ImportSetReceipt; index: number; total: number}
+  | {type: 'item-importing'; item: ImportSetItem; index: number; total: number}
+  | {type: 'item-imported'; item: ImportSetItem; receipt: ImportSetReceipt; index: number; total: number}
+  | {type: 'receipt-invalid'; item: ImportSetItem; receiptPath: string};
+
+/** Owner information stored inside the WebDAV lock directory. */
+export interface ImportSetLockOwner {
+  version: 1;
+  setId: string;
+  runId: string;
+  createdAt: string;
+  heartbeatAt: string;
+  owner?: string;
+}
+
+/** Options for {@link siteArchiveImportSet}. */
+export interface SiteArchiveImportSetOptions {
+  /** Stable set ID. Defaults to the import-set directory name. */
+  setId?: string;
+  /** Plan imports without creating state, locking, importing, or writing receipts. */
+  dryRun?: boolean;
+  /** Keep uploaded archives in Impex/src/instance after each import. */
+  keepArchive?: boolean;
+  /** WebDAV state root. Defaults to Impex/b2c-cli/import-sets. */
+  stateRoot?: string;
+  /** Age after which a lock heartbeat is considered stale. Defaults to 1800 seconds. */
+  staleLockSeconds?: number;
+  /** Poll interval while another runner owns the set lock. Defaults to 3 seconds. */
+  lockPollIntervalSeconds?: number;
+  /** Lock heartbeat interval. Defaults to 30 seconds. */
+  heartbeatIntervalSeconds?: number;
+  /** Immediately remove an existing lock before attempting to acquire it. */
+  breakLock?: boolean;
+  /** Optional owner label stored in lock metadata. */
+  owner?: string;
+  /** Wait options forwarded to each site archive import. */
+  waitOptions?: WaitForJobOptions;
+  /** Receives planning, locking, and item progress events. */
+  onEvent?: (event: ImportSetEvent) => void;
+  /**
+   * Archive importer override. Defaults to {@link siteArchiveImport}.
+   * Useful when embedding the operation with a custom import policy.
+   */
+  importArchive?: (
+    instance: B2CInstance,
+    target: string,
+    options: SiteArchiveImportOptions,
+  ) => Promise<SiteArchiveImportResult>;
+  /** Sleep implementation used while polling for a lock. */
+  sleep?: (milliseconds: number) => Promise<void>;
+}
+
+/** Thrown when an applied item ID now resolves to different contents. */
+export class ImportSetChangedError extends Error {
+  constructor(
+    public readonly item: ImportSetItem,
+    public readonly receipt: ImportSetReceipt,
+  ) {
+    super(
+      `Import-set item "${item.id}" has changed since it was applied ` +
+        `(receipt ${receipt.sha256}, local ${item.sha256}). Add a new item instead of modifying an applied import.`,
+    );
+    this.name = 'ImportSetChangedError';
+  }
+}
+
+/** Thrown when WebDAV lock or receipt state cannot be safely read or written. */
+export class ImportSetStateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ImportSetStateError';
+  }
+}
+
+interface JsonReadResult<T> {
+  found: boolean;
+  valid: boolean;
+  value?: T;
+}
+
+interface LockInfo {
+  owner?: ImportSetLockOwner;
+  ageSeconds?: number;
+}
+
+/**
+ * Discovers the immediate child directories and zip archives in an import-set
+ * directory, sorts them by name, and computes deterministic content hashes.
+ */
+export async function discoverImportSet(directory: string): Promise<ImportSetItem[]> {
+  const resolvedDirectory = path.resolve(directory);
+  const stat = await fs.promises.stat(resolvedDirectory).catch(() => undefined);
+  if (!stat?.isDirectory()) {
+    throw new Error(`Import-set directory does not exist: ${resolvedDirectory}`);
+  }
+
+  const entries = await fs.promises.readdir(resolvedDirectory, {withFileTypes: true});
+  const candidates = entries
+    .filter((entry) => !entry.name.startsWith('.'))
+    .filter((entry) => entry.isDirectory() || (entry.isFile() && path.extname(entry.name).toLowerCase() === '.zip'))
+    .sort((a, b) => a.name.localeCompare(b.name, 'en', {numeric: false}));
+
+  if (candidates.length === 0) {
+    throw new Error(`No import directories or zip archives found in ${resolvedDirectory}`);
+  }
+
+  return Promise.all(
+    candidates.map(async (entry) => {
+      const target = path.join(resolvedDirectory, entry.name);
+      return {
+        id: entry.name,
+        target,
+        kind: entry.isDirectory() ? ('directory' as const) : ('zip' as const),
+        sha256: await hashImportTarget(target),
+      };
+    }),
+  );
+}
+
+/**
+ * Applies an ordered set of site archives exactly until a verified receipt is
+ * written for each item. A missing or invalid receipt always leaves the item
+ * pending, even if a previous process may have completed the platform import.
+ *
+ * The operation uses an exclusive WebDAV directory (`MKCOL`) as a best-effort
+ * set-wide lock. B2C Commerce does not provide conditional WebDAV deletes, so
+ * stale lock takeover is intentionally observable through progress events.
+ */
+export async function siteArchiveImportSet(
+  instance: B2CInstance,
+  directory: string,
+  options: SiteArchiveImportSetOptions = {},
+): Promise<ImportSetResult> {
+  const resolvedDirectory = path.resolve(directory);
+  const setId = options.setId ?? path.basename(resolvedDirectory);
+  validateSetId(setId);
+  validateStateRoot(options.stateRoot ?? DEFAULT_STATE_ROOT);
+
+  const runId = randomUUID();
+  const items = await discoverImportSet(resolvedDirectory);
+  const stateRoot = (options.stateRoot ?? DEFAULT_STATE_ROOT).replace(/\/+$/, '');
+  const setRoot = `${stateRoot}/${setId}`;
+  const receiptsRoot = `${setRoot}/receipts`;
+  const lockPath = `${setRoot}/lock`;
+  const sleep =
+    options.sleep ?? ((milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  const importArchive = options.importArchive ?? siteArchiveImport;
+
+  let itemResults = await evaluateReceipts(instance, setId, receiptsRoot, items, options.onEvent);
+  emitPlan(options, setId, itemResults);
+
+  if (options.dryRun || itemResults.every((item) => item.status === 'skipped')) {
+    return buildResult(setId, resolvedDirectory, Boolean(options.dryRun), runId, itemResults);
+  }
+
+  await ensureCollection(instance, stateRoot, sleep);
+  await ensureCollection(instance, setRoot, sleep);
+  await ensureCollection(instance, receiptsRoot, sleep);
+
+  const lockOwner = await acquireLock(instance, lockPath, setId, runId, options, sleep);
+  let heartbeatError: Error | undefined;
+  let heartbeatChain = Promise.resolve();
+  const heartbeatInterval = Math.max(1, options.heartbeatIntervalSeconds ?? DEFAULT_HEARTBEAT_INTERVAL_SECONDS);
+  const heartbeatTimer = setInterval(() => {
+    heartbeatChain = heartbeatChain
+      .then(() => heartbeatLock(instance, lockPath, lockOwner))
+      .catch((error: unknown) => {
+        heartbeatError = error instanceof Error ? error : new Error(String(error));
+      });
+  }, heartbeatInterval * 1000);
+  heartbeatTimer.unref();
+  let operationError: unknown;
+
+  try {
+    // Another runner may have completed work while this process waited.
+    itemResults = await evaluateReceipts(instance, setId, receiptsRoot, items, options.onEvent);
+    const total = itemResults.length;
+
+    for (const [index, itemResult] of itemResults.entries()) {
+      if (itemResult.status === 'skipped') {
+        options.onEvent?.({
+          type: 'item-skipped',
+          item: itemResult,
+          receipt: itemResult.receipt!,
+          index: index + 1,
+          total,
+        });
+        continue;
+      }
+
+      if (heartbeatError) throw heartbeatError;
+      await heartbeatLock(instance, lockPath, lockOwner);
+      options.onEvent?.({type: 'item-importing', item: itemResult, index: index + 1, total});
+
+      const importResult = await importArchive(instance, itemResult.target, {
+        keepArchive: options.keepArchive,
+        wait: true,
+        waitOptions: options.waitOptions,
+      });
+
+      if (heartbeatError) throw heartbeatError;
+      const receipt: ImportSetReceipt = {
+        version: 1,
+        setId,
+        itemId: itemResult.id,
+        sha256: itemResult.sha256,
+        source: path.basename(itemResult.target),
+        appliedAt: new Date().toISOString(),
+        runId,
+        executionId: importResult.execution.id,
+        archiveFilename: importResult.archiveFilename,
+      };
+      await writeAndVerifyReceipt(instance, receiptPath(receiptsRoot, itemResult.id), receipt);
+
+      itemResult.status = 'imported';
+      itemResult.receipt = receipt;
+      itemResult.importResult = importResult;
+      options.onEvent?.({type: 'item-imported', item: itemResult, receipt, index: index + 1, total});
+    }
+
+    return buildResult(setId, resolvedDirectory, false, runId, itemResults);
+  } catch (error) {
+    operationError = error;
+    throw error;
+  } finally {
+    clearInterval(heartbeatTimer);
+    await heartbeatChain;
+    try {
+      await releaseLock(instance, lockPath, runId);
+    } catch (error) {
+      // Preserve an import or receipt error so callers can report the real
+      // failure. An unreleased lock will become eligible for stale takeover.
+      if (operationError === undefined) throw error;
+    }
+  }
+}
+
+async function evaluateReceipts(
+  instance: B2CInstance,
+  setId: string,
+  receiptsRoot: string,
+  items: ImportSetItem[],
+  onEvent?: (event: ImportSetEvent) => void,
+): Promise<ImportSetItemResult[]> {
+  const results: ImportSetItemResult[] = [];
+  for (const item of items) {
+    const remotePath = receiptPath(receiptsRoot, item.id);
+    // Receipt reads are intentionally sequential to avoid bursting WebDAV on large sets.
+    // eslint-disable-next-line no-await-in-loop
+    const read = await readJson<ImportSetReceipt>(instance, remotePath);
+    if (!read.found) {
+      results.push({...item, status: 'pending'});
+      continue;
+    }
+    if (!read.valid || !isReceipt(read.value, setId, item.id)) {
+      onEvent?.({type: 'receipt-invalid', item, receiptPath: remotePath});
+      results.push({...item, status: 'pending'});
+      continue;
+    }
+    if (read.value.sha256 !== item.sha256) {
+      throw new ImportSetChangedError(item, read.value);
+    }
+    results.push({...item, status: 'skipped', receipt: read.value});
+  }
+  return results;
+}
+
+async function acquireLock(
+  instance: B2CInstance,
+  lockPath: string,
+  setId: string,
+  runId: string,
+  options: SiteArchiveImportSetOptions,
+  sleep: (milliseconds: number) => Promise<void>,
+): Promise<ImportSetLockOwner> {
+  const staleSeconds = Math.max(1, options.staleLockSeconds ?? DEFAULT_STALE_LOCK_SECONDS);
+  const pollMilliseconds = Math.max(1, options.lockPollIntervalSeconds ?? DEFAULT_LOCK_POLL_INTERVAL_SECONDS) * 1000;
+  let forceBreak = Boolean(options.breakLock);
+  let waitNotified = false;
+
+  while (true) {
+    // MKCOL is the only conditional creation primitive B2C WebDAV enforces.
+    // eslint-disable-next-line no-await-in-loop
+    const response = await instance.webdav.request(lockPath, {method: 'MKCOL'});
+    if (response.status === 201) {
+      const now = new Date().toISOString();
+      const owner: ImportSetLockOwner = {
+        version: 1,
+        setId,
+        runId,
+        createdAt: now,
+        heartbeatAt: now,
+        owner: options.owner,
+      };
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await putJson(instance, `${lockPath}/owner.json`, owner);
+      } catch (error) {
+        await deletePath(instance, lockPath);
+        throw error;
+      }
+      options.onEvent?.({type: 'lock-acquired', setId, runId});
+      return owner;
+    }
+
+    if (response.status !== 405 && response.status !== 409) {
+      throw new ImportSetStateError(
+        `Unable to acquire import-set lock ${lockPath}: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    const info = await readLockInfo(instance, lockPath);
+    const stale = info.ageSeconds !== undefined && info.ageSeconds >= staleSeconds;
+    if (forceBreak || stale) {
+      options.onEvent?.({
+        type: 'lock-takeover',
+        setId,
+        owner: info.owner,
+        ageSeconds: info.ageSeconds,
+        forced: forceBreak,
+      });
+      // B2C WebDAV ignores conditional DELETE, so stale takeover is best effort.
+      // eslint-disable-next-line no-await-in-loop
+      await deletePath(instance, lockPath);
+      forceBreak = false;
+      waitNotified = false;
+      continue;
+    }
+
+    if (!waitNotified) {
+      options.onEvent?.({type: 'lock-wait', setId, owner: info.owner, ageSeconds: info.ageSeconds});
+      waitNotified = true;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(pollMilliseconds);
+  }
+}
+
+async function heartbeatLock(instance: B2CInstance, lockPath: string, owner: ImportSetLockOwner): Promise<void> {
+  const ownerPath = `${lockPath}/owner.json`;
+  const current = await readJson<ImportSetLockOwner>(instance, ownerPath);
+  if (!current.found || !current.valid || current.value?.runId !== owner.runId) {
+    throw new ImportSetStateError(`Import-set lock ${lockPath} is no longer owned by run ${owner.runId}`);
+  }
+  owner.heartbeatAt = new Date().toISOString();
+  await putJson(instance, ownerPath, owner);
+}
+
+async function releaseLock(instance: B2CInstance, lockPath: string, runId: string): Promise<void> {
+  const current = await readJson<ImportSetLockOwner>(instance, `${lockPath}/owner.json`);
+  if (current.found && current.valid && current.value?.runId === runId) {
+    await deletePath(instance, lockPath);
+  }
+}
+
+async function readLockInfo(instance: B2CInstance, lockPath: string): Promise<LockInfo> {
+  const ownerRead = await readJson<ImportSetLockOwner>(instance, `${lockPath}/owner.json`);
+  const owner = ownerRead.valid ? ownerRead.value : undefined;
+  const timestamp = owner?.heartbeatAt ?? owner?.createdAt;
+  if (timestamp) {
+    const milliseconds = Date.parse(timestamp);
+    if (Number.isFinite(milliseconds)) {
+      return {owner, ageSeconds: Math.max(0, (Date.now() - milliseconds) / 1000)};
+    }
+  }
+
+  try {
+    const entries = await instance.webdav.propfind(lockPath, '0');
+    const modified = entries[0]?.lastModified;
+    return {
+      owner,
+      ageSeconds: modified ? Math.max(0, (Date.now() - modified.getTime()) / 1000) : undefined,
+    };
+  } catch {
+    return {owner};
+  }
+}
+
+async function ensureCollection(
+  instance: B2CInstance,
+  remotePath: string,
+  sleep: (milliseconds: number) => Promise<void>,
+): Promise<void> {
+  const segments = remotePath.split('/').filter(Boolean);
+  if (segments.length < 2) throw new ImportSetStateError(`Invalid WebDAV state path: ${remotePath}`);
+
+  let current = segments[0];
+  for (const segment of segments.slice(1)) {
+    current = `${current}/${segment}`;
+    // eslint-disable-next-line no-await-in-loop
+    const response = await instance.webdav.request(current, {method: 'MKCOL'});
+    if (response.status === 201 || response.status === 405) continue;
+    if (response.status === 409) {
+      // Concurrent creators can receive 409 while the winning collection becomes visible.
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(25);
+      // eslint-disable-next-line no-await-in-loop
+      const head = await instance.webdav.request(current, {method: 'HEAD'});
+      if (head.ok) continue;
+    }
+    throw new ImportSetStateError(
+      `Unable to create WebDAV collection ${current}: ${response.status} ${response.statusText}`,
+    );
+  }
+}
+
+async function readJson<T>(instance: B2CInstance, remotePath: string): Promise<JsonReadResult<T>> {
+  const response = await instance.webdav.request(remotePath, {method: 'GET'});
+  if (response.status === 404) return {found: false, valid: false};
+  if (!response.ok) {
+    throw new ImportSetStateError(
+      `Unable to read WebDAV state ${remotePath}: ${response.status} ${response.statusText}`,
+    );
+  }
+  try {
+    return {found: true, valid: true, value: JSON.parse(await response.text()) as T};
+  } catch {
+    return {found: true, valid: false};
+  }
+}
+
+async function putJson(instance: B2CInstance, remotePath: string, value: unknown): Promise<void> {
+  const response = await instance.webdav.request(remotePath, {
+    method: 'PUT',
+    headers: {'Content-Type': 'application/json'},
+    body: `${JSON.stringify(value, null, 2)}\n`,
+  });
+  if (!response.ok) {
+    throw new ImportSetStateError(
+      `Unable to write WebDAV state ${remotePath}: ${response.status} ${response.statusText}`,
+    );
+  }
+}
+
+async function writeAndVerifyReceipt(
+  instance: B2CInstance,
+  remotePath: string,
+  receipt: ImportSetReceipt,
+): Promise<void> {
+  await putJson(instance, remotePath, receipt);
+  const verification = await readJson<ImportSetReceipt>(instance, remotePath);
+  if (
+    !verification.found ||
+    !verification.valid ||
+    !isReceipt(verification.value, receipt.setId, receipt.itemId) ||
+    verification.value?.runId !== receipt.runId ||
+    verification.value.sha256 !== receipt.sha256
+  ) {
+    throw new ImportSetStateError(`Receipt verification failed for ${receipt.itemId}; the import will be retried.`);
+  }
+}
+
+async function deletePath(instance: B2CInstance, remotePath: string): Promise<void> {
+  const response = await instance.webdav.request(remotePath, {method: 'DELETE'});
+  if (!response.ok && response.status !== 404) {
+    throw new ImportSetStateError(
+      `Unable to delete WebDAV state ${remotePath}: ${response.status} ${response.statusText}`,
+    );
+  }
+}
+
+function isReceipt(value: ImportSetReceipt | undefined, setId: string, itemId: string): value is ImportSetReceipt {
+  return (
+    value?.version === 1 &&
+    value.setId === setId &&
+    value.itemId === itemId &&
+    /^[a-f\d]{64}$/.test(value.sha256) &&
+    typeof value.source === 'string' &&
+    Number.isFinite(Date.parse(value.appliedAt)) &&
+    typeof value.runId === 'string' &&
+    value.runId.length > 0
+  );
+}
+
+function receiptPath(receiptsRoot: string, itemId: string): string {
+  return `${receiptsRoot}/${createHash('sha256').update(itemId).digest('hex')}.json`;
+}
+
+function emitPlan(options: SiteArchiveImportSetOptions, setId: string, items: ImportSetItemResult[]): void {
+  options.onEvent?.({
+    type: 'plan',
+    setId,
+    total: items.length,
+    pending: items.filter((item) => item.status === 'pending').length,
+    skipped: items.filter((item) => item.status === 'skipped').length,
+    dryRun: Boolean(options.dryRun),
+  });
+}
+
+function buildResult(
+  setId: string,
+  directory: string,
+  dryRun: boolean,
+  runId: string,
+  items: ImportSetItemResult[],
+): ImportSetResult {
+  return {
+    setId,
+    directory,
+    dryRun,
+    runId,
+    items,
+    imported: items.filter((item) => item.status === 'imported').length,
+    skipped: items.filter((item) => item.status === 'skipped').length,
+    pending: items.filter((item) => item.status === 'pending').length,
+  };
+}
+
+function validateSetId(setId: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(setId)) {
+    throw new Error(`Invalid import-set ID "${setId}". Use 1-128 letters, numbers, dots, underscores, or hyphens.`);
+  }
+}
+
+function validateStateRoot(stateRoot: string): void {
+  const segments = stateRoot.split('/').filter(Boolean);
+  if (segments[0]?.toLowerCase() !== 'impex' || segments.some((segment) => segment === '.' || segment === '..')) {
+    throw new Error(`Import-set state root must be a path under Impex: ${stateRoot}`);
+  }
+}
+
+async function hashImportTarget(target: string): Promise<string> {
+  const stat = await fs.promises.lstat(target);
+  const hash = createHash('sha256');
+  if (stat.isFile()) {
+    hash.update('F\0');
+    await updateHashFromFile(hash, target);
+    return hash.digest('hex');
+  }
+  if (!stat.isDirectory()) throw new Error(`Unsupported import-set item: ${target}`);
+
+  const entries = await collectDirectoryEntries(target);
+  for (const entry of entries) {
+    hash.update(entry.kind === 'directory' ? 'D\0' : 'F\0');
+    hash.update(entry.relativePath);
+    hash.update('\0');
+    if (entry.kind === 'file') {
+      // Reading files sequentially keeps hashing deterministic and bounds memory usage.
+      // eslint-disable-next-line no-await-in-loop
+      await updateHashFromFile(hash, entry.absolutePath);
+      hash.update('\0');
+    }
+  }
+  return hash.digest('hex');
+}
+
+async function collectDirectoryEntries(
+  root: string,
+): Promise<Array<{kind: 'directory' | 'file'; relativePath: string; absolutePath: string}>> {
+  const result: Array<{kind: 'directory' | 'file'; relativePath: string; absolutePath: string}> = [];
+
+  async function visit(directory: string): Promise<void> {
+    const entries = await fs.promises.readdir(directory, {withFileTypes: true});
+    entries.sort((a, b) => a.name.localeCompare(b.name, 'en', {numeric: false}));
+    for (const entry of entries) {
+      const absolutePath = path.join(directory, entry.name);
+      const relativePath = path.relative(root, absolutePath).split(path.sep).join('/');
+      if (entry.isSymbolicLink()) {
+        throw new Error(`Symbolic links are not supported in import sets: ${absolutePath}`);
+      }
+      if (entry.isDirectory()) {
+        result.push({kind: 'directory', relativePath, absolutePath});
+        // eslint-disable-next-line no-await-in-loop
+        await visit(absolutePath);
+      } else if (entry.isFile()) {
+        result.push({kind: 'file', relativePath, absolutePath});
+      }
+    }
+  }
+
+  await visit(root);
+  return result;
+}
+
+async function updateHashFromFile(hash: ReturnType<typeof createHash>, filename: string): Promise<void> {
+  const stream = fs.createReadStream(filename);
+  for await (const chunk of stream) hash.update(chunk);
+}

--- a/packages/b2c-tooling-sdk/src/operations/jobs/index.ts
+++ b/packages/b2c-tooling-sdk/src/operations/jobs/index.ts
@@ -102,7 +102,7 @@ export {
 } from './site-archive.js';
 
 // Ordered, idempotent import sets
-export {discoverImportSet, siteArchiveImportSet, ImportSetChangedError, ImportSetStateError} from './import-set.js';
+export {discoverImportSet, siteArchiveImportSet, ImportSetStateError} from './import-set.js';
 
 export type {
   ImportSetItem,

--- a/packages/b2c-tooling-sdk/src/operations/jobs/index.ts
+++ b/packages/b2c-tooling-sdk/src/operations/jobs/index.ts
@@ -21,6 +21,7 @@
  * ## System Jobs
  *
  * - {@link siteArchiveImport} - Import a site archive
+ * - {@link siteArchiveImportSet} - Apply an ordered, receipted set of site archives
  * - {@link siteArchiveImportSplit} - Import a large site archive in multiple parts
  * - {@link siteArchiveExport} - Export a site archive
  * - {@link siteArchiveExportToPath} - Export and save to local path
@@ -99,6 +100,19 @@ export {
   siteArchiveExportToBuffer,
   siteArchiveExportToPath,
 } from './site-archive.js';
+
+// Ordered, idempotent import sets
+export {discoverImportSet, siteArchiveImportSet, ImportSetChangedError, ImportSetStateError} from './import-set.js';
+
+export type {
+  ImportSetItem,
+  ImportSetReceipt,
+  ImportSetItemResult,
+  ImportSetResult,
+  ImportSetEvent,
+  ImportSetLockOwner,
+  SiteArchiveImportSetOptions,
+} from './import-set.js';
 
 export type {
   SiteArchiveImportOptions,

--- a/packages/b2c-tooling-sdk/test/operations/jobs/import-set.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/jobs/import-set.test.ts
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {expect} from 'chai';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {B2CInstance} from '@salesforce/b2c-tooling-sdk/instance';
+import {
+  discoverImportSet,
+  ImportSetChangedError,
+  siteArchiveImportSet,
+  type ImportSetEvent,
+  type SiteArchiveImportSetOptions,
+} from '@salesforce/b2c-tooling-sdk/operations/jobs';
+
+class FakeWebDav {
+  readonly directories = new Set(['Impex']);
+  readonly files = new Map<string, string>();
+  readonly requests: Array<{method: string; path: string}> = [];
+  failNextReceiptWrite = false;
+
+  async request(remotePath: string, init: RequestInit = {}): Promise<Response> {
+    const method = init.method ?? 'GET';
+    this.requests.push({method, path: remotePath});
+
+    if (method === 'MKCOL') {
+      if (this.directories.has(remotePath)) return response(405);
+      if (!this.directories.has(path.posix.dirname(remotePath))) return response(409);
+      this.directories.add(remotePath);
+      return response(201);
+    }
+
+    if (method === 'HEAD') {
+      return response(this.directories.has(remotePath) || this.files.has(remotePath) ? 200 : 404);
+    }
+
+    if (method === 'GET') {
+      const value = this.files.get(remotePath);
+      return value === undefined ? response(404) : new Response(value, {status: 200});
+    }
+
+    if (method === 'PUT') {
+      if (!this.directories.has(path.posix.dirname(remotePath))) return response(409);
+      if (this.failNextReceiptWrite && remotePath.includes('/receipts/')) {
+        this.failNextReceiptWrite = false;
+        return response(500);
+      }
+      this.files.set(remotePath, String(init.body ?? ''));
+      return response(this.files.has(remotePath) ? 204 : 201);
+    }
+
+    if (method === 'DELETE') {
+      const existed =
+        this.directories.has(remotePath) ||
+        this.files.has(remotePath) ||
+        [...this.directories].some((entry) => entry.startsWith(`${remotePath}/`)) ||
+        [...this.files.keys()].some((entry) => entry.startsWith(`${remotePath}/`));
+      for (const entry of [...this.directories]) {
+        if (entry === remotePath || entry.startsWith(`${remotePath}/`)) this.directories.delete(entry);
+      }
+      for (const entry of [...this.files.keys()]) {
+        if (entry === remotePath || entry.startsWith(`${remotePath}/`)) this.files.delete(entry);
+      }
+      return response(existed ? 204 : 404);
+    }
+
+    return response(405);
+  }
+
+  async propfind(remotePath: string): Promise<Array<{lastModified: Date}>> {
+    if (!this.directories.has(remotePath)) throw new Error('Not found');
+    return [{lastModified: new Date()}];
+  }
+}
+
+function response(status: number): Response {
+  return new Response(null, {status});
+}
+
+function createImportDirectory(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-import-set-'));
+  const first = path.join(root, '20260101T000000-metadata');
+  fs.mkdirSync(path.join(first, 'meta'), {recursive: true});
+  fs.writeFileSync(path.join(first, 'meta', 'system-objecttype-extensions.xml'), '<metadata/>');
+  fs.writeFileSync(path.join(root, '20260102T000000-sites.zip'), 'zip-content');
+  fs.writeFileSync(path.join(root, 'README.md'), 'ignored');
+  return root;
+}
+
+function createHarness(): {
+  instance: B2CInstance;
+  webdav: FakeWebDav;
+  imported: string[];
+  options: SiteArchiveImportSetOptions;
+} {
+  const webdav = new FakeWebDav();
+  const imported: string[] = [];
+  const instance = {webdav, config: {hostname: 'test.demandware.net'}} as unknown as B2CInstance;
+  const options: SiteArchiveImportSetOptions = {
+    sleep: () => Promise.resolve(),
+    importArchive: async (_instance, target) => {
+      imported.push(path.basename(target));
+      return {
+        execution: {id: `execution-${imported.length}`, execution_status: 'finished'},
+        archiveFilename: `${path.basename(target)}.uploaded.zip`,
+        archiveKept: false,
+      };
+    },
+  };
+  return {instance, webdav, imported, options};
+}
+
+describe('operations/jobs/import-set', () => {
+  let importDirectory: string;
+
+  beforeEach(() => {
+    importDirectory = createImportDirectory();
+  });
+
+  afterEach(() => {
+    fs.rmSync(importDirectory, {recursive: true, force: true});
+  });
+
+  it('discovers immediate directories and zip archives in filename order', async () => {
+    const items = await discoverImportSet(importDirectory);
+
+    expect(items.map((item) => item.id)).to.deep.equal(['20260101T000000-metadata', '20260102T000000-sites.zip']);
+    expect(items.map((item) => item.kind)).to.deep.equal(['directory', 'zip']);
+    expect(items.every((item) => /^[a-f0-9]{64}$/.test(item.sha256))).to.equal(true);
+  });
+
+  it('imports pending items, verifies receipts, and skips them on the next run', async () => {
+    const {instance, imported, options} = createHarness();
+
+    const first = await siteArchiveImportSet(instance, importDirectory, options);
+    const second = await siteArchiveImportSet(instance, importDirectory, options);
+
+    expect(imported).to.deep.equal(['20260101T000000-metadata', '20260102T000000-sites.zip']);
+    expect(first.imported).to.equal(2);
+    expect(first.skipped).to.equal(0);
+    expect(second.imported).to.equal(0);
+    expect(second.skipped).to.equal(2);
+  });
+
+  it('reruns an import when the previous receipt write failed', async () => {
+    const {instance, webdav, imported, options} = createHarness();
+    webdav.failNextReceiptWrite = true;
+
+    try {
+      await siteArchiveImportSet(instance, importDirectory, options);
+      expect.fail('Expected receipt write failure');
+    } catch (error) {
+      expect((error as Error).message).to.include('Unable to write WebDAV state');
+    }
+
+    const result = await siteArchiveImportSet(instance, importDirectory, options);
+
+    expect(imported.filter((item) => item === '20260101T000000-metadata')).to.have.lengthOf(2);
+    expect(result.imported).to.equal(2);
+  });
+
+  it('reruns an import whose receipt is invalid', async () => {
+    const {instance, webdav, imported, options} = createHarness();
+    await siteArchiveImportSet(instance, importDirectory, options);
+    const receiptPath = [...webdav.files.keys()].find((remotePath) => remotePath.includes('/receipts/'))!;
+    webdav.files.set(receiptPath, 'incomplete');
+
+    const result = await siteArchiveImportSet(instance, importDirectory, options);
+
+    expect(imported.filter((item) => item === '20260101T000000-metadata')).to.have.lengthOf(2);
+    expect(result.imported).to.equal(1);
+    expect(result.skipped).to.equal(1);
+  });
+
+  it('rejects changed contents under an already-applied item ID', async () => {
+    const {instance, imported, options} = createHarness();
+    await siteArchiveImportSet(instance, importDirectory, options);
+    fs.writeFileSync(
+      path.join(importDirectory, '20260101T000000-metadata', 'meta', 'system-objecttype-extensions.xml'),
+      '<metadata changed="true"/>',
+    );
+
+    try {
+      await siteArchiveImportSet(instance, importDirectory, options);
+      expect.fail('Expected changed item error');
+    } catch (error) {
+      expect(error).to.be.instanceOf(ImportSetChangedError);
+    }
+    expect(imported).to.have.lengthOf(2);
+  });
+
+  it('uses MKCOL locking and waits for an active runner', async () => {
+    const {instance, webdav, imported, options} = createHarness();
+    const setId = path.basename(importDirectory);
+    const setRoot = `Impex/b2c-cli/import-sets/${setId}`;
+    for (const directory of [
+      'Impex/b2c-cli',
+      'Impex/b2c-cli/import-sets',
+      setRoot,
+      `${setRoot}/receipts`,
+      `${setRoot}/lock`,
+    ]) {
+      webdav.directories.add(directory);
+    }
+    webdav.files.set(
+      `${setRoot}/lock/owner.json`,
+      JSON.stringify({
+        version: 1,
+        setId,
+        runId: 'other-run',
+        createdAt: new Date().toISOString(),
+        heartbeatAt: new Date().toISOString(),
+      }),
+    );
+    const events: ImportSetEvent[] = [];
+    let slept = false;
+    options.onEvent = (event) => events.push(event);
+    options.sleep = async () => {
+      if (!slept) {
+        slept = true;
+        await webdav.request(`${setRoot}/lock`, {method: 'DELETE'});
+      }
+    };
+
+    await siteArchiveImportSet(instance, importDirectory, options);
+
+    expect(imported).to.have.lengthOf(2);
+    expect(events.some((event) => event.type === 'lock-wait')).to.equal(true);
+    expect(webdav.requests.some((request) => request.method === 'MKCOL' && request.path.endsWith('/lock'))).to.equal(
+      true,
+    );
+  });
+
+  it('takes over stale locks and emits a visible takeover event', async () => {
+    const {instance, webdav, options} = createHarness();
+    const setId = path.basename(importDirectory);
+    const setRoot = `Impex/b2c-cli/import-sets/${setId}`;
+    for (const directory of [
+      'Impex/b2c-cli',
+      'Impex/b2c-cli/import-sets',
+      setRoot,
+      `${setRoot}/receipts`,
+      `${setRoot}/lock`,
+    ]) {
+      webdav.directories.add(directory);
+    }
+    webdav.files.set(
+      `${setRoot}/lock/owner.json`,
+      JSON.stringify({
+        version: 1,
+        setId,
+        runId: 'stale-run',
+        createdAt: '2020-01-01T00:00:00.000Z',
+        heartbeatAt: '2020-01-01T00:00:00.000Z',
+      }),
+    );
+    const events: ImportSetEvent[] = [];
+    options.onEvent = (event) => events.push(event);
+    options.staleLockSeconds = 1;
+
+    await siteArchiveImportSet(instance, importDirectory, options);
+
+    expect(events.some((event) => event.type === 'lock-takeover')).to.equal(true);
+  });
+
+  it('does not create WebDAV state or import during a dry run', async () => {
+    const {instance, webdav, imported, options} = createHarness();
+
+    const result = await siteArchiveImportSet(instance, importDirectory, {...options, dryRun: true});
+
+    expect(result.pending).to.equal(2);
+    expect(imported).to.have.lengthOf(0);
+    expect(webdav.requests.some((request) => ['MKCOL', 'PUT', 'DELETE'].includes(request.method))).to.equal(false);
+  });
+});

--- a/packages/b2c-tooling-sdk/test/operations/jobs/import-set.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/jobs/import-set.test.ts
@@ -7,10 +7,10 @@ import {expect} from 'chai';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import {HTTPError} from '@salesforce/b2c-tooling-sdk/errors';
 import type {B2CInstance} from '@salesforce/b2c-tooling-sdk/instance';
 import {
   discoverImportSet,
-  ImportSetChangedError,
   siteArchiveImportSet,
   type ImportSetEvent,
   type SiteArchiveImportSetOptions,
@@ -20,15 +20,19 @@ class FakeWebDav {
   readonly directories = new Set(['Impex']);
   readonly files = new Map<string, string>();
   readonly requests: Array<{method: string; path: string}> = [];
-  failNextReceiptWrite = false;
+  failNextReceiptCreation = false;
 
   async request(remotePath: string, init: RequestInit = {}): Promise<Response> {
     const method = init.method ?? 'GET';
     this.requests.push({method, path: remotePath});
 
     if (method === 'MKCOL') {
-      if (this.directories.has(remotePath)) return response(405);
+      if (this.directories.has(remotePath) || this.files.has(remotePath)) return response(405);
       if (!this.directories.has(path.posix.dirname(remotePath))) return response(409);
+      if (this.failNextReceiptCreation && remotePath.includes('/receipts/')) {
+        this.failNextReceiptCreation = false;
+        return response(500);
+      }
       this.directories.add(remotePath);
       return response(201);
     }
@@ -44,10 +48,6 @@ class FakeWebDav {
 
     if (method === 'PUT') {
       if (!this.directories.has(path.posix.dirname(remotePath))) return response(409);
-      if (this.failNextReceiptWrite && remotePath.includes('/receipts/')) {
-        this.failNextReceiptWrite = false;
-        return response(500);
-      }
       this.files.set(remotePath, String(init.body ?? ''));
       return response(this.files.has(remotePath) ? 204 : 201);
     }
@@ -70,9 +70,11 @@ class FakeWebDav {
     return response(405);
   }
 
-  async propfind(remotePath: string): Promise<Array<{lastModified: Date}>> {
-    if (!this.directories.has(remotePath)) throw new Error('Not found');
-    return [{lastModified: new Date()}];
+  async propfind(remotePath: string): Promise<Array<{href: string; isCollection: boolean; lastModified: Date}>> {
+    if (!this.directories.has(remotePath) && !this.files.has(remotePath)) {
+      throw new HTTPError('Not found', response(404), 'PROPFIND');
+    }
+    return [{href: remotePath, isCollection: this.directories.has(remotePath), lastModified: new Date()}];
   }
 }
 
@@ -129,11 +131,10 @@ describe('operations/jobs/import-set', () => {
 
     expect(items.map((item) => item.id)).to.deep.equal(['20260101T000000-metadata', '20260102T000000-sites.zip']);
     expect(items.map((item) => item.kind)).to.deep.equal(['directory', 'zip']);
-    expect(items.every((item) => /^[a-f0-9]{64}$/.test(item.sha256))).to.equal(true);
   });
 
   it('imports pending items, verifies receipts, and skips them on the next run', async () => {
-    const {instance, imported, options} = createHarness();
+    const {instance, webdav, imported, options} = createHarness();
 
     const first = await siteArchiveImportSet(instance, importDirectory, options);
     const second = await siteArchiveImportSet(instance, importDirectory, options);
@@ -143,17 +144,36 @@ describe('operations/jobs/import-set', () => {
     expect(first.skipped).to.equal(0);
     expect(second.imported).to.equal(0);
     expect(second.skipped).to.equal(2);
+    expect([...webdav.directories].filter((entry) => entry.includes('/receipts/'))).to.have.lengthOf(2);
+    expect([...webdav.files.keys()].some((entry) => entry.includes('/receipts/'))).to.equal(false);
   });
 
-  it('reruns an import when the previous receipt write failed', async () => {
+  it('uses the same default receipt namespace for equivalent directories at different local paths', async () => {
+    const {instance, imported, options} = createHarness();
+    const anotherDirectory = createImportDirectory();
+
+    try {
+      const first = await siteArchiveImportSet(instance, importDirectory, options);
+      const second = await siteArchiveImportSet(instance, anotherDirectory, options);
+
+      expect(first.setId).to.equal('migrations');
+      expect(second.setId).to.equal('migrations');
+      expect(imported).to.have.lengthOf(2);
+      expect(second.skipped).to.equal(2);
+    } finally {
+      fs.rmSync(anotherDirectory, {recursive: true, force: true});
+    }
+  });
+
+  it('reruns an import when the previous receipt directory creation failed', async () => {
     const {instance, webdav, imported, options} = createHarness();
-    webdav.failNextReceiptWrite = true;
+    webdav.failNextReceiptCreation = true;
 
     try {
       await siteArchiveImportSet(instance, importDirectory, options);
       expect.fail('Expected receipt write failure');
     } catch (error) {
-      expect((error as Error).message).to.include('Unable to write WebDAV state');
+      expect((error as Error).message).to.include('Unable to create WebDAV receipt directory');
     }
 
     const result = await siteArchiveImportSet(instance, importDirectory, options);
@@ -162,10 +182,11 @@ describe('operations/jobs/import-set', () => {
     expect(result.imported).to.equal(2);
   });
 
-  it('reruns an import whose receipt is invalid', async () => {
+  it('reruns an import and replaces an invalid non-directory receipt marker', async () => {
     const {instance, webdav, imported, options} = createHarness();
     await siteArchiveImportSet(instance, importDirectory, options);
-    const receiptPath = [...webdav.files.keys()].find((remotePath) => remotePath.includes('/receipts/'))!;
+    const receiptPath = [...webdav.directories].find((remotePath) => remotePath.includes('/receipts/'))!;
+    webdav.directories.delete(receiptPath);
     webdav.files.set(receiptPath, 'incomplete');
 
     const result = await siteArchiveImportSet(instance, importDirectory, options);
@@ -175,7 +196,7 @@ describe('operations/jobs/import-set', () => {
     expect(result.skipped).to.equal(1);
   });
 
-  it('rejects changed contents under an already-applied item ID', async () => {
+  it('uses only the item name as receipt identity', async () => {
     const {instance, imported, options} = createHarness();
     await siteArchiveImportSet(instance, importDirectory, options);
     fs.writeFileSync(
@@ -183,18 +204,26 @@ describe('operations/jobs/import-set', () => {
       '<metadata changed="true"/>',
     );
 
-    try {
-      await siteArchiveImportSet(instance, importDirectory, options);
-      expect.fail('Expected changed item error');
-    } catch (error) {
-      expect(error).to.be.instanceOf(ImportSetChangedError);
-    }
+    const result = await siteArchiveImportSet(instance, importDirectory, options);
+
     expect(imported).to.have.lengthOf(2);
+    expect(result.skipped).to.equal(2);
+  });
+
+  it('keeps applied state when regular WebDAV files are cleaned', async () => {
+    const {instance, webdav, imported, options} = createHarness();
+    await siteArchiveImportSet(instance, importDirectory, options);
+
+    webdav.files.clear();
+    const result = await siteArchiveImportSet(instance, importDirectory, options);
+
+    expect(imported).to.have.lengthOf(2);
+    expect(result.skipped).to.equal(2);
   });
 
   it('uses MKCOL locking and waits for an active runner', async () => {
     const {instance, webdav, imported, options} = createHarness();
-    const setId = path.basename(importDirectory);
+    const setId = 'migrations';
     const setRoot = `Impex/b2c-cli/import-sets/${setId}`;
     for (const directory of [
       'Impex/b2c-cli',
@@ -236,7 +265,7 @@ describe('operations/jobs/import-set', () => {
 
   it('takes over stale locks and emits a visible takeover event', async () => {
     const {instance, webdav, options} = createHarness();
-    const setId = path.basename(importDirectory);
+    const setId = 'migrations';
     const setRoot = `Impex/b2c-cli/import-sets/${setId}`;
     for (const directory of [
       'Impex/b2c-cli',

--- a/skills/b2c-cli/skills/b2c-job/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-job/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: b2c-job
-description: Run and monitor jobs on B2C Commerce instances using the b2c CLI, including site archive import/export and search indexing. Use this skill whenever the user needs to trigger a job, import a site archive, export site data, rebuild search indexes, check job status, or troubleshoot failed job executions — even if they just say "import this folder" or "rebuild the search index".
+description: Run and monitor jobs on B2C Commerce instances using the b2c CLI, including site archive import/export, ordered idempotent import sets, and search indexing. Use this skill whenever the user needs to trigger a job, import one or more site archives, apply data migrations once, export site data, rebuild search indexes, check job status, or troubleshoot failed job executions — even if they just say "import this folder", "apply these migrations", or "rebuild the search index".
 ---
 
 # B2C Job Skill
@@ -97,6 +97,43 @@ b2c job import ./my-site-data --show-log
 b2c job import ./my-site-data sites/RefArch libraries/mylib
 b2c job import ./my-site-data 'libraries/**'
 ```
+
+### Apply an Ordered, Idempotent Import Set
+
+Use `job import-set` when a directory contains multiple site archives that should be applied in order and skipped after the instance has a verified receipt. This is the canonical guidance for import-set behavior; the `b2c-site-import-export` and `b2c-webdav` skills route here for archive structure and state-transfer questions.
+
+Each immediate child directory or `.zip` file is one item. Hidden entries and other files are ignored, and item names are sorted lexically:
+
+```text
+data-migrations/
+├── 20260801-add-preferences/
+│   ├── meta/
+│   └── sites/
+├── 20260802-seed-content.zip
+└── README.md                       # ignored
+```
+
+```bash
+# Show pending and already-applied items without writing anything
+b2c job import-set ./data-migrations --dry-run
+
+# Apply the set; use a stable ID in CI
+b2c job import-set ./data-migrations --set-id storefront-data
+
+# Keep uploaded archives if they are needed for inspection
+b2c job import-set ./data-migrations --set-id storefront-data --keep-archive
+```
+
+Important semantics:
+
+- The CLI stores content-hash receipts under `Impex/b2c-cli/import-sets/<set-id>/receipts/` on WebDAV. Matching receipts are skipped.
+- Missing or invalid receipts are always retried. If the platform import succeeds and the process crashes before a receipt is written and verified, the next run imports that item again. Design each archive to tolerate reapplication.
+- Never edit an item after it has a valid receipt. A hash mismatch fails the command; add a new, later-sorting item for the next change.
+- A WebDAV collection lock serializes runners for the same set. Waiting runners re-check receipts after acquiring it.
+- The lock heartbeat becomes stale after 30 minutes by default. Adjust with `--stale-lock-seconds`; use `--break-lock` only after confirming the old owner has stopped. Stale takeover is best-effort because B2C WebDAV does not enforce conditional deletes.
+- `--timeout` applies to each archive import, `--poll-interval` controls job polling, and `--lock-poll-interval` controls lock waiting.
+
+The set ID defaults to the directory basename. Prefer an explicit stable `--set-id` in automation so moving or renaming the local folder does not create a new receipt namespace.
 
 ### Export Site Archives
 

--- a/skills/b2c-cli/skills/b2c-job/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-job/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: b2c-job
-description: Run and monitor jobs on B2C Commerce instances using the b2c CLI, including site archive import/export, ordered idempotent import sets, and search indexing. Use this skill whenever the user needs to trigger a job, import one or more site archives, apply data migrations once, export site data, rebuild search indexes, check job status, or troubleshoot failed job executions — even if they just say "import this folder", "apply these migrations", or "rebuild the search index".
+description: Run and monitor jobs on B2C Commerce instances using the b2c CLI, including individual site archive imports and exports and search indexing. Use this skill whenever the user needs to trigger an existing job, import a single site archive, export site data, rebuild search indexes, check job status, or troubleshoot a failed job execution — even if they just say "run this job", "import this archive", or "rebuild the search index".
 ---
 
 # B2C Job Skill
@@ -98,42 +98,16 @@ b2c job import ./my-site-data sites/RefArch libraries/mylib
 b2c job import ./my-site-data 'libraries/**'
 ```
 
-### Apply an Ordered, Idempotent Import Set
+### Import Sets
 
-Use `job import-set` when a directory contains multiple site archives that should be applied in order and skipped after the instance has a verified receipt. This is the canonical guidance for import-set behavior; the `b2c-site-import-export` and `b2c-webdav` skills route here for archive structure and state-transfer questions.
-
-Each immediate child directory or `.zip` file is one item. Hidden entries and other files are ignored, and item names are sorted lexically:
-
-```text
-data-migrations/
-├── 20260801-add-preferences/
-│   ├── meta/
-│   └── sites/
-├── 20260802-seed-content.zip
-└── README.md                       # ignored
-```
+`job import-set` applies the archives in `./migrations` in order and skips imports already recorded on the target instance:
 
 ```bash
-# Show pending and already-applied items without writing anything
-b2c job import-set ./data-migrations --dry-run
-
-# Apply the set; use a stable ID in CI
-b2c job import-set ./data-migrations --set-id storefront-data
-
-# Keep uploaded archives if they are needed for inspection
-b2c job import-set ./data-migrations --set-id storefront-data --keep-archive
+b2c job import-set --dry-run
+b2c job import-set
 ```
 
-Important semantics:
-
-- The CLI stores content-hash receipts under `Impex/b2c-cli/import-sets/<set-id>/receipts/` on WebDAV. Matching receipts are skipped.
-- Missing or invalid receipts are always retried. If the platform import succeeds and the process crashes before a receipt is written and verified, the next run imports that item again. Design each archive to tolerate reapplication.
-- Never edit an item after it has a valid receipt. A hash mismatch fails the command; add a new, later-sorting item for the next change.
-- A WebDAV collection lock serializes runners for the same set. Waiting runners re-check receipts after acquiring it.
-- The lock heartbeat becomes stale after 30 minutes by default. Adjust with `--stale-lock-seconds`; use `--break-lock` only after confirming the old owner has stopped. Stale takeover is best-effort because B2C WebDAV does not enforce conditional deletes.
-- `--timeout` applies to each archive import, `--poll-interval` controls job polling, and `--lock-poll-interval` controls lock waiting.
-
-The set ID defaults to the directory basename. Prefer an explicit stable `--set-id` in automation so moving or renaming the local folder does not create a new receipt namespace.
+For the canonical archive layout, timestamp naming convention, receipt and retry behavior, concurrency, and recovery flags, use the `b2c-cli:b2c-site-import-export` skill's **Apply an Ordered, Idempotent Import Set** section.
 
 ### Export Site Archives
 
@@ -266,4 +240,4 @@ b2c job wait <job-id> <execution-id> --poll-interval 5
 
 - `b2c:b2c-custom-job-steps` - For **creating** new custom job steps and **chaining them with standard steps** (includes the standard step catalog, IMPEX hand-off, and in-flow-vs-CLI guidance)
 - `b2c-cli:b2c-docs` - To look up standard job step type IDs and their parameters (`b2c docs read job-steps`)
-- `b2c-cli:b2c-site-import-export` - For site archive structure and metadata XML patterns
+- `b2c-cli:b2c-site-import-export` - Canonical site archive and idempotent import-set guidance

--- a/skills/b2c-cli/skills/b2c-job/evals/trigger-evals.json
+++ b/skills/b2c-cli/skills/b2c-job/evals/trigger-evals.json
@@ -4,6 +4,8 @@
   {"query": "The nightly product export job keeps failing on our sandbox and I can't figure out why from Business Manager. Is there a way to run it and see the detailed logs?", "should_trigger": true},
   {"query": "I just updated a bunch of product descriptions via a data feed and now I need to make sure the search index picks them up before our QA team tests tomorrow morning. How do I kick off a reindex and confirm it completed?", "should_trigger": true},
   {"query": "I need to trigger a site export job on my instance and then download the resulting archive. How do I run the export and get the output files?", "should_trigger": true},
+  {"query": "We have a folder of numbered site archives that CI should apply in order, but reruns must skip migrations already recorded on the sandbox. How should we run that?", "should_trigger": true},
+  {"query": "Our data import completed and then the runner crashed before recording success. I want the next run to retry until a durable receipt exists.", "should_trigger": true},
   {"query": "We have a scheduled import that runs at 2am but it seems to be stuck in a running state for over 3 hours. I need to check what's happening with it — is there a way to see the execution status and logs for currently running processes on the instance?", "should_trigger": true},
   {"query": "I need to write a batch processing script that runs nightly to clean up expired promotions. What's the job step pattern?", "should_trigger": false},
   {"query": "How do I set up a cron job on our CI server to automatically run our test suite every night?", "should_trigger": false},

--- a/skills/b2c-cli/skills/b2c-job/evals/trigger-evals.json
+++ b/skills/b2c-cli/skills/b2c-job/evals/trigger-evals.json
@@ -4,8 +4,6 @@
   {"query": "The nightly product export job keeps failing on our sandbox and I can't figure out why from Business Manager. Is there a way to run it and see the detailed logs?", "should_trigger": true},
   {"query": "I just updated a bunch of product descriptions via a data feed and now I need to make sure the search index picks them up before our QA team tests tomorrow morning. How do I kick off a reindex and confirm it completed?", "should_trigger": true},
   {"query": "I need to trigger a site export job on my instance and then download the resulting archive. How do I run the export and get the output files?", "should_trigger": true},
-  {"query": "We have a folder of numbered site archives that CI should apply in order, but reruns must skip migrations already recorded on the sandbox. How should we run that?", "should_trigger": true},
-  {"query": "Our data import completed and then the runner crashed before recording success. I want the next run to retry until a durable receipt exists.", "should_trigger": true},
   {"query": "We have a scheduled import that runs at 2am but it seems to be stuck in a running state for over 3 hours. I need to check what's happening with it — is there a way to see the execution status and logs for currently running processes on the instance?", "should_trigger": true},
   {"query": "I need to write a batch processing script that runs nightly to clean up expired promotions. What's the job step pattern?", "should_trigger": false},
   {"query": "How do I set up a cron job on our CI server to automatically run our test suite every night?", "should_trigger": false},

--- a/skills/b2c-cli/skills/b2c-site-import-export/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-site-import-export/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: b2c-site-import-export
-description: Import and export site archives containing metadata XML on B2C Commerce instances using the b2c CLI. Use this skill whenever the user needs to import a site archive directory or zip to an instance, export site configuration as XML, structure a site archive folder (sites/site_template/meta/), write or debug metadata XML files (system-objecttype-extensions.xml, custom-objecttype-definitions.xml, preferences.xml), or push custom attributes, custom object types, or site preferences to a sandbox via site import. Also use when an import job fails with schema validation errors — even if they just say "push metadata to the sandbox" or "import my XML files".
+description: Import and export site archives containing metadata XML on B2C Commerce instances using the b2c CLI. Use this skill whenever the user needs to import a site archive directory or zip to an instance, apply an ordered set of archives idempotently, export site configuration as XML, structure a site archive folder (sites/site_template/meta/), write or debug metadata XML files (system-objecttype-extensions.xml, custom-objecttype-definitions.xml, preferences.xml), or push custom attributes, custom object types, or site preferences to a sandbox via site import. Also use when an import job fails with schema validation errors — even if they just say "push metadata to the sandbox" or "import my XML files".
 ---
 
 # Site Import/Export Skill
@@ -42,6 +42,19 @@ b2c job import ./my-site-data --show-log
 # Import an archive that already exists on the instance (in Impex/src/instance/)
 b2c job import existing-archive.zip --remote
 ```
+
+### Import an Ordered Set Once
+
+When a folder contains multiple archive directories or zip files that should be applied in filename order and skipped after a verified receipt exists, use:
+
+```bash
+b2c job import-set ./data-migrations --set-id storefront-data
+b2c job import-set ./data-migrations --set-id storefront-data --dry-run
+```
+
+Each immediate child directory or `.zip` file is one item. Keep each item as a valid site archive and prefix names with a timestamp or sequence number when order matters. Do not edit applied items; add a new item for each later change.
+
+For the authoritative receipt, retry, locking, crash-recovery, and stale-lock behavior, use the `b2c-cli:b2c-job` skill's **Apply an Ordered, Idempotent Import Set** section.
 
 ### Import Archives Larger Than the Instance Limit
 
@@ -264,7 +277,7 @@ b2c job import ./my-data --show-log
 1. **Test imports on sandbox first** before importing to staging/production
 2. Import waits for completion by default — use `--no-wait` only when you want to return immediately
 3. **Use `--show-log`** to debug failed imports
-4. **Keep archives organized** by feature or change type
+4. **Keep archives organized** by feature or change type; use `job import-set` when a growing ordered set should be safely repeatable
 5. **Version control your metadata** XML files
 
 ### Configuring External Services
@@ -290,4 +303,4 @@ Where `services-folder/services.xml` follows the patterns in the `b2c:b2c-webser
 
 - `b2c:b2c-webservices` - Service configurations (HTTP, FTP, SOAP), services.xml format
 - `b2c:b2c-metadata` - System object extensions and custom object definitions
-- `b2c-cli:b2c-job` - Running jobs and monitoring import status
+- `b2c-cli:b2c-job` - Canonical import-set receipt/locking behavior, running jobs, and monitoring import status

--- a/skills/b2c-cli/skills/b2c-site-import-export/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-site-import-export/SKILL.md
@@ -43,18 +43,48 @@ b2c job import ./my-site-data --show-log
 b2c job import existing-archive.zip --remote
 ```
 
-### Import an Ordered Set Once
+### Apply an Ordered, Idempotent Import Set
 
-When a folder contains multiple archive directories or zip files that should be applied in filename order and skipped after a verified receipt exists, use:
+Use `job import-set` when a directory contains multiple site archives that must be applied in order and skipped after the instance records their successful import. This section is the canonical import-set workflow.
 
-```bash
-b2c job import-set ./data-migrations --set-id storefront-data
-b2c job import-set ./data-migrations --set-id storefront-data --dry-run
+Each immediate child directory or `.zip` file is one item. Hidden entries and other files are ignored, and item names are sorted lexically:
+
+```text
+migrations/
+├── 20260801T140000-add-preferences/
+│   ├── meta/
+│   └── sites/
+├── 20260802T091500-seed-content.zip
+└── README.md                       # ignored
 ```
 
-Each immediate child directory or `.zip` file is one item. Keep each item as a valid site archive and prefix names with a timestamp or sequence number when order matters. Do not edit applied items; add a new item for each later change.
+Name every item `YYYYMMDDTHHmmss-description`, using UTC for cross-time-zone teams. The timestamp supplies ordering and makes receipt-name collisions across projects extremely unlikely.
 
-For the authoritative receipt, retry, locking, crash-recovery, and stale-lock behavior, use the `b2c-cli:b2c-job` skill's **Apply an Ordered, Idempotent Import Set** section.
+```bash
+# Show pending and already-applied items without writing anything
+b2c job import-set --dry-run
+
+# Apply the default ./migrations directory
+b2c job import-set
+
+# Apply a different directory
+b2c job import-set ./data-migrations
+
+# Keep uploaded archives for inspection
+b2c job import-set --keep-archive
+```
+
+Important semantics:
+
+- The CLI writes a durable receipt on the target instance after each successful import. Receipt identity is based only on the item name, so that name is skipped on later runs, including runs from other machines.
+- A missing or invalid receipt always causes another import. If the import succeeds and the process crashes before its receipt is written and verified, the next run imports that item again. Make archives safe to reapply.
+- Never edit an item after it has a valid receipt. Instances that already applied that name continue to skip it; add a new, later-sorting item for the next change.
+- Projects sharing an instance-wide receipt namespace must use distinct item names. UTC timestamps plus descriptive suffixes make accidental cross-project collisions unlikely.
+- Only one runner applies a given history at a time. Waiting runners re-check receipts after acquiring the lock.
+- A lock becomes stale after 30 minutes by default. Adjust this with `--stale-lock-seconds`; use `--break-lock` only after confirming the old owner has stopped.
+- `--timeout` applies to each archive import, `--poll-interval` controls job polling, and `--lock-poll-interval` controls lock waiting.
+
+The default directory is `./migrations`. Receipt and lock identity use the fixed instance-wide `migrations` namespace, regardless of the local path. Most users should omit `--set-id`; use it only when intentionally creating an independent history or preserving a legacy namespace.
 
 ### Import Archives Larger Than the Instance Limit
 
@@ -303,4 +333,4 @@ Where `services-folder/services.xml` follows the patterns in the `b2c:b2c-webser
 
 - `b2c:b2c-webservices` - Service configurations (HTTP, FTP, SOAP), services.xml format
 - `b2c:b2c-metadata` - System object extensions and custom object definitions
-- `b2c-cli:b2c-job` - Canonical import-set receipt/locking behavior, running jobs, and monitoring import status
+- `b2c-cli:b2c-job` - Running and monitoring jobs, including individual archive imports

--- a/skills/b2c-cli/skills/b2c-site-import-export/evals/trigger-evals.json
+++ b/skills/b2c-cli/skills/b2c-site-import-export/evals/trigger-evals.json
@@ -4,6 +4,7 @@
   {"query": "I wrote a custom-objecttype-definitions.xml for a new object type and I need to import it to the sandbox. How do I structure the site archive folder and run the import with the CLI?", "should_trigger": true},
   {"query": "I need to export the full site configuration from our staging instance so I can diff it against production before we go live. What's the best way to pull down all the metadata, preferences, and custom object definitions as XML files?", "should_trigger": true},
   {"query": "We're setting up a new sandbox and I need to replicate the entire configuration from another instance — site preferences, custom attributes, payment methods, shipping configs, the works. How do I package all that into a site archive and import it?", "should_trigger": true},
+  {"query": "I have several numbered metadata archive folders and zip files that need to import in order, while later runs skip the ones already applied.", "should_trigger": true},
   {"query": "I have a sites/site_template/meta directory with a bunch of XML files but the import keeps failing with a schema validation error. The error message references system-objecttype-extensions.xml line 47. How do I debug what's wrong with my archive structure?", "should_trigger": true},
   {"query": "I need to download the log files from my sandbox to debug a checkout error that happened this morning.", "should_trigger": false},
   {"query": "How do I push my cartridge code changes up to the sandbox so I can test them? I've been editing files locally in my IDE.", "should_trigger": false},

--- a/skills/b2c-cli/skills/b2c-site-import-export/evals/trigger-evals.json
+++ b/skills/b2c-cli/skills/b2c-site-import-export/evals/trigger-evals.json
@@ -5,6 +5,7 @@
   {"query": "I need to export the full site configuration from our staging instance so I can diff it against production before we go live. What's the best way to pull down all the metadata, preferences, and custom object definitions as XML files?", "should_trigger": true},
   {"query": "We're setting up a new sandbox and I need to replicate the entire configuration from another instance — site preferences, custom attributes, payment methods, shipping configs, the works. How do I package all that into a site archive and import it?", "should_trigger": true},
   {"query": "I have several numbered metadata archive folders and zip files that need to import in order, while later runs skip the ones already applied.", "should_trigger": true},
+  {"query": "Our data import completed and then the runner crashed before recording success. I want the next run to retry until a durable receipt exists.", "should_trigger": true},
   {"query": "I have a sites/site_template/meta directory with a bunch of XML files but the import keeps failing with a schema validation error. The error message references system-objecttype-extensions.xml line 47. How do I debug what's wrong with my archive structure?", "should_trigger": true},
   {"query": "I need to download the log files from my sandbox to debug a checkout error that happened this morning.", "should_trigger": false},
   {"query": "How do I push my cartridge code changes up to the sandbox so I can test them? I've been editing files locally in my IDE.", "should_trigger": false},

--- a/skills/b2c-cli/skills/b2c-webdav/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-webdav/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: b2c-webdav
-description: List, upload, download, and manage files on B2C Commerce instances via WebDAV. Use this skill whenever the user needs to upload files to IMPEX directories, download exports from an instance, list remote files, create or delete directories, or zip/unzip files on the server. Also use when managing file transfers to sandboxes or browsing instance file systems -- even if they just say 'upload a file to the instance' or 'check what's in the IMPEX folder'.
+description: List, upload, download, and manage files on B2C Commerce instances via WebDAV. Use this skill whenever the user needs to upload files to IMPEX directories, download exports from an instance, list remote files, create or delete directories, zip/unzip files on the server, or understand the WebDAV state behind idempotent import sets. Also use when managing file transfers to sandboxes or browsing instance file systems -- even if they just say 'upload a file to the instance' or 'check what's in the IMPEX folder'.
 ---
 
 # B2C WebDAV Skill
@@ -120,6 +120,18 @@ b2c webdav zip src/instance/my-folder
 b2c webdav unzip src/instance/archive.zip
 ```
 
+### WebDAV State for Idempotent Import Sets
+
+Do not manually script marker files when the goal is to apply a local set of site archives once. Use the higher-level command:
+
+```bash
+b2c job import-set ./data-migrations --set-id storefront-data
+```
+
+It manages content-hash receipts and a heartbeat lock under `Impex/b2c-cli/import-sets/<set-id>/`. A missing or invalid receipt causes the archive to run again, including after a successful import followed by a process crash before receipt verification.
+
+The lock uses atomic WebDAV collection creation (`MKCOL`). B2C Commerce does not provide reliable native locks or enforce ETag preconditions for writes/deletes, so stale takeover is best-effort. For the canonical workflow, flags, and recovery rules, use the `b2c-cli:b2c-job` skill's **Apply an Ordered, Idempotent Import Set** section.
+
 ### More Commands
 
 See `b2c webdav --help` for a full list of available commands and options in the `webdav` topic.
@@ -128,4 +140,4 @@ See `b2c webdav --help` for a full list of available commands and options in the
 
 - `b2c-cli:b2c-logs` - Filtered log retrieval, search, and real-time tailing (preferred for log exploration)
 - `b2c-cli:b2c-code` - Higher-level code deployment (preferred for cartridge upload)
-- `b2c-cli:b2c-job` - Import/export site archives
+- `b2c-cli:b2c-job` - Import/export site archives and canonical idempotent import-set guidance

--- a/skills/b2c-cli/skills/b2c-webdav/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-webdav/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: b2c-webdav
-description: List, upload, download, and manage files on B2C Commerce instances via WebDAV. Use this skill whenever the user needs to upload files to IMPEX directories, download exports from an instance, list remote files, create or delete directories, zip/unzip files on the server, or understand the WebDAV state behind idempotent import sets. Also use when managing file transfers to sandboxes or browsing instance file systems -- even if they just say 'upload a file to the instance' or 'check what's in the IMPEX folder'.
+description: List, upload, download, and manage files on B2C Commerce instances via WebDAV. Use this skill whenever the user needs to upload files to IMPEX directories, download exports from an instance, list remote files, create or delete directories, zip or unzip files on the server, manage file transfers to sandboxes, or browse instance file systems — even if they just say "upload a file to the instance" or "check what's in the IMPEX folder".
 ---
 
 # B2C WebDAV Skill
@@ -120,17 +120,17 @@ b2c webdav zip src/instance/my-folder
 b2c webdav unzip src/instance/archive.zip
 ```
 
-### WebDAV State for Idempotent Import Sets
+### Import-Set Managed State
 
 Do not manually script marker files when the goal is to apply a local set of site archives once. Use the higher-level command:
 
 ```bash
-b2c job import-set ./data-migrations --set-id storefront-data
+b2c job import-set
 ```
 
-It manages content-hash receipts and a heartbeat lock under `Impex/b2c-cli/import-sets/<set-id>/`. A missing or invalid receipt causes the archive to run again, including after a successful import followed by a process crash before receipt verification.
+The command manages its own receipt directories so routine file cleanup does not remove applied state and reruns work across machines. Do not edit or delete that managed state unless deliberately resetting an import history: removing a receipt makes the corresponding archive eligible to run again.
 
-The lock uses atomic WebDAV collection creation (`MKCOL`). B2C Commerce does not provide reliable native locks or enforce ETag preconditions for writes/deletes, so stale takeover is best-effort. For the canonical workflow, flags, and recovery rules, use the `b2c-cli:b2c-job` skill's **Apply an Ordered, Idempotent Import Set** section.
+For the canonical workflow, naming convention, retry behavior, and recovery rules, use the `b2c-cli:b2c-site-import-export` skill's **Apply an Ordered, Idempotent Import Set** section.
 
 ### More Commands
 
@@ -140,4 +140,5 @@ See `b2c webdav --help` for a full list of available commands and options in the
 
 - `b2c-cli:b2c-logs` - Filtered log retrieval, search, and real-time tailing (preferred for log exploration)
 - `b2c-cli:b2c-code` - Higher-level code deployment (preferred for cartridge upload)
-- `b2c-cli:b2c-job` - Import/export site archives and canonical idempotent import-set guidance
+- `b2c-cli:b2c-site-import-export` - Canonical site archive and idempotent import-set guidance
+- `b2c-cli:b2c-job` - Run and monitor jobs


### PR DESCRIPTION
## Summary

- add `b2c job import-set` and an SDK operation for ordered, idempotent site archive imports
- use a default `./migrations` directory and timestamped item naming convention
- record successful item names as verified WebDAV directory receipts that survive routine file cleanup
- retry imports until a receipt is durable, and coordinate concurrent runners with a WebDAV collection lock
- document the existing third-party data migrations plugin and make site import/export the canonical skill for import sets

## Testing

- `pnpm --filter @salesforce/b2c-tooling-sdk run test:agent` — 2,111 passing, 7 pending
- `pnpm --filter @salesforce/b2c-cli run test:agent` — 1,449 passing
- `pnpm run lint:agent`
- SDK and CLI typechecks
- validated all three updated skills
- live default-instance conformance: first pass applied pending items; repeat pass reported 0 imported and 2 skipped; WebDAV reported two receipt collections and no receipt files

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`test:agent` package suites)
- [x] Changed TypeScript is formatted and the staged diff passes `git diff --check`