### PR TITLE
@W-23748575: Require .project file in every CAP cartridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,3 @@ skills/eval/project/.git
 skills/eval/results-*.json
 # Python bytecode
 __pycache__/
-
-# build-it run logs (local only)
-docs/superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ skills/eval/project/.git
 skills/eval/results-*.json
 # Python bytecode
 __pycache__/
+
+# build-it run logs (local only)
+docs/superpowers/

--- a/packages/b2c-tooling-sdk/src/operations/cap/package.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cap/package.ts
@@ -13,9 +13,13 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import JSZip from 'jszip';
 import {getLogger} from '../../logging/logger.js';
+import {type Logger} from '../../logging/types.js';
 import {addDirectoryToZip} from '../util/zip.js';
 import {readManifest} from './install.js';
 import {type CommerceAppManifest} from './validate.js';
+
+/** Cartridge group directories, relative to `cartridges/`, that CAPs may contain. */
+const CARTRIDGE_GROUP_DIRS = ['site_cartridges', 'bm_cartridges'] as const;
 
 /**
  * Options for CAP packaging.
@@ -94,6 +98,8 @@ export async function commerceAppPackage(
   // Ensure output directory exists
   await fs.promises.mkdir(path.dirname(outputZipPath), {recursive: true});
 
+  ensureCartridgeProjectFiles(sourceDir, logger);
+
   logger.debug({sourceDir, outputPath: outputZipPath}, `Packaging CAP: ${archiveDirName}`);
 
   const zip = new JSZip();
@@ -110,4 +116,36 @@ export async function commerceAppPackage(
   logger.debug({outputPath: outputZipPath}, `CAP packaged to: ${outputZipPath}`);
 
   return {outputPath: outputZipPath, manifest};
+}
+
+/**
+ * Ensures every cartridge directory under `cartridges/site_cartridges/` and
+ * `cartridges/bm_cartridges/` has a `.project` file, auto-creating an empty
+ * one when missing. Existing `.project` files (empty or full Eclipse XML)
+ * are left untouched.
+ */
+function ensureCartridgeProjectFiles(sourceDir: string, logger: Logger): void {
+  const cartridgesDir = path.join(sourceDir, 'cartridges');
+  if (!fs.existsSync(cartridgesDir)) return;
+
+  for (const groupDir of CARTRIDGE_GROUP_DIRS) {
+    const groupPath = path.join(cartridgesDir, groupDir);
+    if (!fs.existsSync(groupPath)) continue;
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(groupPath, {withFileTypes: true});
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const projectFile = path.join(groupPath, entry.name, '.project');
+      if (!fs.existsSync(projectFile)) {
+        fs.writeFileSync(projectFile, '');
+        logger.debug({projectFile}, `Auto-created empty .project for cartridge: ${groupDir}/${entry.name}`);
+      }
+    }
+  }
 }

--- a/packages/b2c-tooling-sdk/src/operations/cap/validate.ts
+++ b/packages/b2c-tooling-sdk/src/operations/cap/validate.ts
@@ -193,6 +193,7 @@ export async function validateCap(target: string): Promise<CapValidationResult> 
  * - No pipeline/ directories
  * - No *.ds pipeline descriptor files
  * - Site cartridges must not have controllers/
+ * - Every cartridge must have a .project file (empty or full Eclipse XML)
  */
 function validateCartridges(cartridgesDir: string, errors: string[]): void {
   // Check entire cartridges tree for pipelines
@@ -218,6 +219,35 @@ function validateCartridges(cartridgesDir: string, errors: string[]): void {
         );
       }
     });
+  }
+
+  // Every cartridge directory must have a .project file (presence check only —
+  // an existing non-empty Eclipse .project is just as valid as an empty one).
+  validateCartridgesHaveProjectFile(cartridgesDir, 'site_cartridges', errors);
+  validateCartridgesHaveProjectFile(cartridgesDir, 'bm_cartridges', errors);
+}
+
+/**
+ * Requires a `.project` file in every immediate child directory of
+ * `cartridgesDir/<groupName>` (e.g. `site_cartridges/int_myapp/.project`).
+ */
+function validateCartridgesHaveProjectFile(cartridgesDir: string, groupName: string, errors: string[]): void {
+  const groupDir = path.join(cartridgesDir, groupName);
+  if (!fs.existsSync(groupDir)) return;
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(groupDir, {withFileTypes: true});
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const cartridgeRoot = path.join(groupDir, entry.name);
+    if (!fs.existsSync(path.join(cartridgeRoot, '.project'))) {
+      errors.push(`Cartridge missing .project file: ${groupName}/${entry.name}`);
+    }
   }
 }
 

--- a/packages/b2c-tooling-sdk/test/operations/cap/package.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/cap/package.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {expect} from 'chai';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import JSZip from 'jszip';
+import {commerceAppPackage} from '../../../src/operations/cap/package.js';
+
+/** Build a minimal valid CAP in a temp directory, then call the callback */
+async function withTempCap(setup: (dir: string) => void, callback: (dir: string) => Promise<void>): Promise<void> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-cap-package-'));
+  try {
+    setup(tempDir);
+    await callback(tempDir);
+  } finally {
+    fs.rmSync(tempDir, {recursive: true, force: true});
+  }
+}
+
+function writeMinimalCap(dir: string): void {
+  const manifest = {id: 'test-app', name: 'Test App', version: '1.0.0', domain: 'tax'};
+  fs.writeFileSync(path.join(dir, 'commerce-app.json'), JSON.stringify(manifest));
+  fs.writeFileSync(path.join(dir, 'README.md'), '# Test App');
+}
+
+describe('operations/cap/package', () => {
+  describe('commerceAppPackage', () => {
+    it('auto-creates an empty .project for cartridges missing one', async () => {
+      await withTempCap(
+        (dir) => {
+          writeMinimalCap(dir);
+          fs.mkdirSync(path.join(dir, 'cartridges', 'site_cartridges', 'int_myapp', 'cartridge'), {recursive: true});
+          fs.mkdirSync(path.join(dir, 'cartridges', 'bm_cartridges', 'bm_myapp', 'cartridge'), {recursive: true});
+        },
+        async (dir) => {
+          const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-cap-package-out-'));
+          try {
+            await commerceAppPackage(dir, {outputPath: outputDir});
+
+            // Source directory gets the empty .project files written in place.
+            const siteProject = path.join(dir, 'cartridges', 'site_cartridges', 'int_myapp', '.project');
+            const bmProject = path.join(dir, 'cartridges', 'bm_cartridges', 'bm_myapp', '.project');
+            expect(fs.existsSync(siteProject)).to.be.true;
+            expect(fs.readFileSync(siteProject, 'utf-8')).to.equal('');
+            expect(fs.existsSync(bmProject)).to.be.true;
+            expect(fs.readFileSync(bmProject, 'utf-8')).to.equal('');
+
+            // And the zip includes them.
+            const zipPath = path.join(outputDir, 'test-app-v1.0.0.zip');
+            const zip = await JSZip.loadAsync(await fs.promises.readFile(zipPath));
+            expect(Object.keys(zip.files)).to.include('test-app-v1.0.0/cartridges/site_cartridges/int_myapp/.project');
+            expect(Object.keys(zip.files)).to.include('test-app-v1.0.0/cartridges/bm_cartridges/bm_myapp/.project');
+          } finally {
+            fs.rmSync(outputDir, {recursive: true, force: true});
+          }
+        },
+      );
+    });
+
+    it('does not overwrite an existing non-empty .project file', async () => {
+      await withTempCap(
+        (dir) => {
+          writeMinimalCap(dir);
+          const cartridgeRoot = path.join(dir, 'cartridges', 'site_cartridges', 'int_myapp');
+          fs.mkdirSync(path.join(cartridgeRoot, 'cartridge'), {recursive: true});
+          fs.writeFileSync(path.join(cartridgeRoot, '.project'), '<projectDescription>\n\t<name>int_myapp</name>\n');
+        },
+        async (dir) => {
+          const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-cap-package-out-'));
+          try {
+            await commerceAppPackage(dir, {outputPath: outputDir});
+            const projectFile = path.join(dir, 'cartridges', 'site_cartridges', 'int_myapp', '.project');
+            expect(fs.readFileSync(projectFile, 'utf-8')).to.equal('<projectDescription>\n\t<name>int_myapp</name>\n');
+          } finally {
+            fs.rmSync(outputDir, {recursive: true, force: true});
+          }
+        },
+      );
+    });
+
+    it('is a no-op when there is no cartridges/ directory', async () => {
+      await withTempCap(
+        (dir) => {
+          writeMinimalCap(dir);
+          fs.mkdirSync(path.join(dir, 'impex', 'install'), {recursive: true});
+        },
+        async (dir) => {
+          const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-cap-package-out-'));
+          try {
+            const result = await commerceAppPackage(dir, {outputPath: outputDir});
+            expect(fs.existsSync(result.outputPath)).to.be.true;
+          } finally {
+            fs.rmSync(outputDir, {recursive: true, force: true});
+          }
+        },
+      );
+    });
+  });
+});

--- a/packages/b2c-tooling-sdk/test/operations/cap/validate.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/cap/validate.test.ts
@@ -140,6 +140,7 @@ describe('operations/cap/validate', () => {
           );
           fs.mkdirSync(siteCartridgeDir, {recursive: true});
           fs.writeFileSync(path.join(siteCartridgeDir, 'MyController.js'), '// controller');
+          fs.writeFileSync(path.join(dir, 'cartridges', 'site_cartridges', 'int_myapp', '.project'), '');
         },
         async (dir) => {
           const result = await validateCap(dir);
@@ -156,6 +157,7 @@ describe('operations/cap/validate', () => {
           const pipelineDir = path.join(dir, 'cartridges', 'site_cartridges', 'int_myapp', 'cartridge', 'pipeline');
           fs.mkdirSync(pipelineDir, {recursive: true});
           fs.writeFileSync(path.join(pipelineDir, 'Start.xml'), '<pipeline/>');
+          fs.writeFileSync(path.join(dir, 'cartridges', 'site_cartridges', 'int_myapp', '.project'), '');
         },
         async (dir) => {
           const result = await validateCap(dir);
@@ -172,6 +174,7 @@ describe('operations/cap/validate', () => {
           const cartDir = path.join(dir, 'cartridges', 'site_cartridges', 'int_myapp', 'cartridge');
           fs.mkdirSync(cartDir, {recursive: true});
           fs.writeFileSync(path.join(cartDir, 'Start.ds'), '<pipeline/>');
+          fs.writeFileSync(path.join(dir, 'cartridges', 'site_cartridges', 'int_myapp', '.project'), '');
         },
         async (dir) => {
           const result = await validateCap(dir);
@@ -221,6 +224,79 @@ describe('operations/cap/validate', () => {
       );
     });
 
+    it('should error when a site cartridge is missing .project', async () => {
+      await withTempCap(
+        (dir) => {
+          writeMinimalCap(dir);
+          const cartridgeDir = path.join(dir, 'cartridges', 'site_cartridges', 'int_myapp', 'cartridge');
+          fs.mkdirSync(cartridgeDir, {recursive: true});
+          fs.writeFileSync(path.join(cartridgeDir, 'index.js'), '// noop');
+        },
+        async (dir) => {
+          const result = await validateCap(dir);
+          expect(result.valid).to.be.false;
+          expect(result.errors).to.include('Cartridge missing .project file: site_cartridges/int_myapp');
+        },
+      );
+    });
+
+    it('should error when a bm cartridge is missing .project', async () => {
+      await withTempCap(
+        (dir) => {
+          writeMinimalCap(dir);
+          const cartridgeDir = path.join(dir, 'cartridges', 'bm_cartridges', 'bm_myapp', 'cartridge');
+          fs.mkdirSync(cartridgeDir, {recursive: true});
+          fs.writeFileSync(path.join(cartridgeDir, 'index.js'), '// noop');
+        },
+        async (dir) => {
+          const result = await validateCap(dir);
+          expect(result.valid).to.be.false;
+          expect(result.errors).to.include('Cartridge missing .project file: bm_cartridges/bm_myapp');
+        },
+      );
+    });
+
+    it('should pass when a cartridge has an empty .project file', async () => {
+      await withTempCap(
+        (dir) => {
+          writeMinimalCap(dir);
+          const cartridgeRoot = path.join(dir, 'cartridges', 'site_cartridges', 'int_myapp');
+          fs.mkdirSync(path.join(cartridgeRoot, 'cartridge'), {recursive: true});
+          fs.writeFileSync(path.join(cartridgeRoot, '.project'), '');
+        },
+        async (dir) => {
+          const result = await validateCap(dir);
+          expect(result.errors.some((e) => e.includes('missing .project'))).to.be.false;
+        },
+      );
+    });
+
+    it('should pass when a cartridge has a full Eclipse XML .project file', async () => {
+      await withTempCap(
+        (dir) => {
+          writeMinimalCap(dir);
+          const cartridgeRoot = path.join(dir, 'cartridges', 'site_cartridges', 'int_myapp');
+          fs.mkdirSync(path.join(cartridgeRoot, 'cartridge'), {recursive: true});
+          const eclipseProjectXml = [
+            '<?xml version="1.0" encoding="UTF-8"?>',
+            '<projectDescription>',
+            '\t<name>int_myapp</name>',
+            '\t<comment></comment>',
+            '\t<projects></projects>',
+            '\t<buildSpec></buildSpec>',
+            '\t<natures></natures>',
+            '</projectDescription>',
+            '',
+          ].join('\n');
+          fs.writeFileSync(path.join(cartridgeRoot, '.project'), eclipseProjectXml);
+        },
+        async (dir) => {
+          const result = await validateCap(dir);
+          expect(result.errors.some((e) => e.includes('missing .project'))).to.be.false;
+        },
+      );
+    });
+
     it('should allow controllers in bm_cartridges', async () => {
       await withTempCap(
         (dir) => {
@@ -228,6 +304,7 @@ describe('operations/cap/validate', () => {
           const bmControllers = path.join(dir, 'cartridges', 'bm_cartridges', 'bm_myapp', 'cartridge', 'controllers');
           fs.mkdirSync(bmControllers, {recursive: true});
           fs.writeFileSync(path.join(bmControllers, 'BM_Controller.js'), '// bm controller');
+          fs.writeFileSync(path.join(dir, 'cartridges', 'bm_cartridges', 'bm_myapp', '.project'), '');
         },
         async (dir) => {
           const result = await validateCap(dir);

--- a/skills/b2c-cli/skills/b2c-cap/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-cap/SKILL.md
@@ -88,6 +88,8 @@ b2c cap package ./commerce-avalara-tax-app-v0.2.5
 b2c cap package ./commerce-avalara-tax-app-v0.2.5 --output ./dist/my-app.zip
 ```
 
+> Every cartridge under `cartridges/site_cartridges/` and `cartridges/bm_cartridges/` must have a `.project` file. `cap package` auto-creates an empty one for any cartridge missing it (existing `.project` files, empty or full Eclipse XML, are left untouched); `cap validate` fails if any cartridge is still missing one.
+
 ### Install a CAP
 
 ```bash


### PR DESCRIPTION
## Summary
- `b2c cap package` auto-creates an empty `.project` for any cartridge root missing one
- `b2c cap validate` fails when a site/BM cartridge lacks `.project` (empty or Eclipse XML both pass)
- Tests cover missing/empty/full `.project` and package auto-add behavior

## Test plan
- [ ] `pnpm exec mocha --forbid-only test/operations/cap/validate.test.ts test/operations/cap/package.test.ts` in `packages/b2c-tooling-sdk`
- [ ] Package a CAP missing `.project` and confirm the file is auto-added
- [ ] Validate a CAP missing `.project` and confirm a clear error

@W-23748575