### PR TITLE
feat: Allow sandbox start/stop from command palette

### DIFF
--- a/.changeset/sandbox-palette-lifecycle.md
+++ b/.changeset/sandbox-palette-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'b2c-vs-extension': minor
+---
+
+Start, stop, and restart the active sandbox from the Command Palette (Realm Explorer context menus still target the selected sandbox)

--- a/docs/vscode-extension/index.md
+++ b/docs/vscode-extension/index.md
@@ -28,7 +28,7 @@ Generate new cartridges, controllers, hooks, jobs, and other boilerplate from a 
 
 ### Sandbox Realm Explorer
 
-Spin up, start, stop, clone, and clean up your on-demand sandboxes from a tree view. Cloned sandboxes are clearly marked, and the right-click menu only shows actions that make sense for the sandbox's current state.
+Spin up, start, stop, clone, and clean up your on-demand sandboxes from a tree view. Cloned sandboxes are clearly marked, and the right-click menu only shows actions that make sense for the sandbox's current state. From the Command Palette, **Start/Stop/Restart Sandbox** targets the active status-bar instance (OAuth + ODS sandbox hostname required).
 
 [![Sandbox Realm Explorer](./images/sandbox-explorer.png)](./images/sandbox-explorer.png)
 
@@ -58,7 +58,7 @@ Stream live `error-*.log`, `warn-*.log`, and `info-*.log` files from your sandbo
 
 ### Active Instance Status Bar
 
-The bottom-left of the window shows your active instance — the name, the hostname, and a pin icon if you've locked a particular folder as the project root. Click it to switch instances; every view updates instantly.
+The bottom-left of the window shows your active instance — the name, the hostname, and a pin icon if you've locked a particular folder as the project root. Click it to switch instances; every view updates instantly. Palette **Start/Stop/Restart Sandbox** commands use this active instance.
 
 ### B2C CLI Plugin Support
 

--- a/packages/b2c-vs-extension/README.md
+++ b/packages/b2c-vs-extension/README.md
@@ -26,7 +26,7 @@ Set breakpoints and log points, inspect variables, and step through cartridge co
 
 ### Manage sandbox realms
 
-Create, start, stop, restart, clone, extend, and delete on-demand sandboxes from the Sandbox Realm Explorer. Context menus adapt to each sandbox's current state.
+Create, start, stop, restart, clone, extend, and delete on-demand sandboxes from the Sandbox Realm Explorer. Context menus adapt to each sandbox's current state. From the Command Palette, **Start/Stop/Restart Sandbox** acts on the active status-bar instance.
 
 [![Sandbox Realm Explorer](https://raw.githubusercontent.com/SalesforceCommerceCloud/b2c-developer-tooling/main/docs/vscode-extension/images/sandbox-explorer.png)](https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/)
 

--- a/packages/b2c-vs-extension/package.json
+++ b/packages/b2c-vs-extension/package.json
@@ -2093,18 +2093,6 @@
           "when": "false"
         },
         {
-          "command": "b2c-dx.sandbox.start",
-          "when": "false"
-        },
-        {
-          "command": "b2c-dx.sandbox.stop",
-          "when": "false"
-        },
-        {
-          "command": "b2c-dx.sandbox.restart",
-          "when": "false"
-        },
-        {
           "command": "b2c-dx.sandbox.viewDetails",
           "when": "false"
         },

--- a/packages/b2c-vs-extension/src/sandbox-tree/active-sandbox.ts
+++ b/packages/b2c-vs-extension/src/sandbox-tree/active-sandbox.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import {isFriendlySandboxId} from '@salesforce/b2c-tooling-sdk';
+
+/**
+ * Derive an ODS friendly sandbox ID (realm-instance) from a B2C hostname.
+ * e.g. "zzzz-001.dx.commercecloud.salesforce.com" → "zzzz-001"
+ * Returns undefined when the hostname does not look like an ODS sandbox.
+ */
+export function friendlyIdFromHostname(hostname: string | undefined): string | undefined {
+  if (!hostname || typeof hostname !== 'string') return undefined;
+  const trimmed = hostname.trim();
+  if (!trimmed) return undefined;
+  const firstSegment = trimmed.split('.')[0] ?? '';
+  if (!firstSegment || !isFriendlySandboxId(firstSegment)) return undefined;
+  return firstSegment.toLowerCase();
+}

--- a/packages/b2c-vs-extension/src/sandbox-tree/sandbox-commands.ts
+++ b/packages/b2c-vs-extension/src/sandbox-tree/sandbox-commands.ts
@@ -3,10 +3,16 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
-import {getApiErrorMessage} from '@salesforce/b2c-tooling-sdk';
+import {
+  getApiErrorMessage,
+  parseFriendlySandboxId,
+  resolveSandboxId,
+  SandboxNotFoundError,
+} from '@salesforce/b2c-tooling-sdk';
 import {createOdsClient} from '@salesforce/b2c-tooling-sdk/clients';
 import * as vscode from 'vscode';
 import {registerSafeCommand, runWithSafety} from '../safety.js';
+import {friendlyIdFromHostname} from './active-sandbox.js';
 import {
   CLONE_PROFILES,
   getExplicitCloneTargetProfiles,
@@ -15,7 +21,7 @@ import {
   type CloneProfile,
 } from './sandbox-clone-helpers.js';
 import type {SandboxConfigProvider} from './sandbox-config.js';
-import type {RealmTreeItem, SandboxTreeDataProvider, SandboxTreeItem} from './sandbox-tree-provider.js';
+import {SandboxTreeItem, type RealmTreeItem, type SandboxTreeDataProvider} from './sandbox-tree-provider.js';
 
 const DEFAULT_ODS_HOST = 'admin.dx.commercecloud.salesforce.com';
 
@@ -170,8 +176,88 @@ export function registerSandboxCommands(
     );
   });
 
-  const sandboxOperation = (operationType: 'start' | 'stop' | 'restart') => async (node: SandboxTreeItem) => {
-    if (!node) return;
+  const operateOnActiveSandbox = async (operationType: 'start' | 'stop' | 'restart') => {
+    const config = configProvider.getConfigProvider().getConfig();
+    if (!config) {
+      vscode.window.showErrorMessage('No B2C Commerce configuration found. Configure dw.json or SFCC_* env vars.');
+      return;
+    }
+    if (!config.hasOAuthConfig()) {
+      vscode.window.showErrorMessage('OAuth credentials required. Set clientId and clientSecret in dw.json.');
+      return;
+    }
+
+    const hostname = typeof config.values.hostname === 'string' ? config.values.hostname : undefined;
+    const friendlyId = friendlyIdFromHostname(hostname);
+    if (!friendlyId) {
+      vscode.window.showErrorMessage(
+        'Active instance hostname does not look like an ODS sandbox. Switch to a sandbox instance or use Realm Explorer.',
+      );
+      return;
+    }
+
+    if (operationType === 'stop') {
+      const choice = await vscode.window.showWarningMessage(
+        `Stop sandbox "${friendlyId}"? Running processes will be terminated.`,
+        {modal: true},
+        'Stop',
+        'Cancel',
+      );
+      if (choice !== 'Stop') return;
+    }
+
+    const gerund = `${operationType.charAt(0).toUpperCase() + operationType.slice(1)}ing`;
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `${gerund} sandbox ${friendlyId}...`,
+      },
+      async () => {
+        try {
+          const odsClient = await getOdsClientFromConfig(configProvider);
+          const sandboxId = await resolveSandboxId(odsClient, friendlyId);
+          const result = await runWithSafety(
+            () =>
+              odsClient.POST('/sandboxes/{sandboxId}/operations', {
+                params: {path: {sandboxId}},
+                body: {operation: operationType},
+              }),
+            `${operationType.charAt(0).toUpperCase() + operationType.slice(1)} sandbox "${friendlyId}"?`,
+          );
+          if (result.error) {
+            vscode.window.showErrorMessage(
+              `Sandbox ${operationType} failed: ${getApiErrorMessage(result.error, result.response)}`,
+            );
+            return;
+          }
+          vscode.window.showInformationMessage(`Sandbox ${operationType} initiated for ${friendlyId}.`);
+          const realm = parseFriendlySandboxId(friendlyId)?.realm;
+          if (realm) {
+            treeProvider.refreshRealm(realm);
+            treeProvider.startPollingRealm(realm);
+          }
+        } catch (err) {
+          if (err instanceof SandboxNotFoundError) {
+            vscode.window.showErrorMessage(err.message);
+            return;
+          }
+          const message = err instanceof Error ? err.message : String(err);
+          vscode.window.showErrorMessage(`Sandbox ${operationType} failed: ${message}`);
+        }
+      },
+    );
+  };
+
+  /**
+   * Context menu: acts on the selected Realm Explorer item.
+   * Command Palette (no arg): acts on the active dw.json / status-bar instance.
+   * Stop confirms in both paths.
+   */
+  const sandboxOperation = (operationType: 'start' | 'stop' | 'restart') => async (node?: SandboxTreeItem) => {
+    if (!(node instanceof SandboxTreeItem)) {
+      await operateOnActiveSandbox(operationType);
+      return;
+    }
 
     if (operationType === 'stop') {
       const choice = await vscode.window.showWarningMessage(

--- a/packages/b2c-vs-extension/src/test/active-sandbox.test.ts
+++ b/packages/b2c-vs-extension/src/test/active-sandbox.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as assert from 'assert';
+import {friendlyIdFromHostname} from '../sandbox-tree/active-sandbox.js';
+
+suite('friendlyIdFromHostname', () => {
+  test('parses dx.commercecloud hostname', () => {
+    assert.strictEqual(friendlyIdFromHostname('zzzz-001.dx.commercecloud.salesforce.com'), 'zzzz-001');
+  });
+
+  test('parses unified demandware hostname', () => {
+    assert.strictEqual(friendlyIdFromHostname('zzzz-005.test01.dx.unified.demandware.net'), 'zzzz-005');
+  });
+
+  test('returns undefined for staging-like non-friendly host', () => {
+    assert.strictEqual(friendlyIdFromHostname('staging.demandware.net'), undefined);
+  });
+
+  test('returns undefined for production-like host without instance suffix', () => {
+    assert.strictEqual(friendlyIdFromHostname('www.example.com'), undefined);
+  });
+
+  test('returns undefined for empty or missing hostname', () => {
+    assert.strictEqual(friendlyIdFromHostname(undefined), undefined);
+    assert.strictEqual(friendlyIdFromHostname(''), undefined);
+    assert.strictEqual(friendlyIdFromHostname('   '), undefined);
+  });
+});


### PR DESCRIPTION

## Summary

Extends the existing start/stop/restart commands to work from the command palette, operating upon the
currently active instance.

All changes were made by Cursor AI.

## Testing

Unit tests were added around a new function for domain to friendly sandbox name, but otherwise I tested by installing the extension locally and running the commands.

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [ ] Tests pass (`pnpm test`)
- [ ] Code is formatted (`pnpm run format`)
