### PR TITLE
@W-23735205 Configure adaptive retries and bounded timeouts on the DAL DynamoDB client

### DIFF
--- a/.changeset/dal-adaptive-retries.md
+++ b/.changeset/dal-adaptive-retries.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/mrt-utilities': patch
+---
+
+Harden the data store's DynamoDB client against throttling: it now uses adaptive retries, a bounded number of attempts, and per-attempt connection/request timeouts so a slow or throttled call can no longer consume the whole request budget. Throttling failures are now distinguishable in error logs.

--- a/packages/mrt-utilities/src/data-store/production.ts
+++ b/packages/mrt-utilities/src/data-store/production.ts
@@ -13,6 +13,71 @@ import {logMRTError} from '../utils/utils.js';
 export {DataStoreNotFoundError, DataStoreServiceError, DataStoreUnavailableError} from './errors.js';
 
 /**
+ * Retry mode for the data store DynamoDB client.
+ *
+ * `'adaptive'` adds a client-side rate limiter that backs off proactively when the table
+ * signals throttling, instead of retrying blindly into an already-saturated table. The
+ * rate limiter keeps state on the client instance, so it only helps across invocations on
+ * a warm container — the memoized client preserves that state.
+ */
+const DAL_RETRY_MODE = 'adaptive';
+
+/**
+ * Maximum number of attempts (initial request + retries) per data store request.
+ *
+ * Bounds retry fan-out under sustained throttling. Chosen together with
+ * {@link DAL_REQUEST_TIMEOUT_MS} so that `DAL_MAX_ATTEMPTS × DAL_REQUEST_TIMEOUT_MS` stays
+ * comfortably under the surrounding request/function timeout.
+ */
+const DAL_MAX_ATTEMPTS = 2;
+
+/**
+ * Maximum time (ms) to wait for a connection to be established per attempt.
+ *
+ * A hard per-attempt ceiling so a slow/hung connection cannot consume the whole budget.
+ * The client is memoized on a warm container and reuses keep-alive connections, so most
+ * attempts do not open a new connection; a fresh connect exceeding this is already
+ * abnormal.
+ */
+const DAL_CONNECTION_TIMEOUT_MS = 300;
+
+/**
+ * Maximum time (ms) to wait for a response per attempt.
+ *
+ * A hard per-attempt ceiling. A single-key DynamoDB read is typically single-digit ms, so
+ * this leaves a large multiple of headroom over p99 while still failing fast on a genuine
+ * hang. See {@link DAL_MAX_ATTEMPTS} for the timeout/attempt invariant relative to the
+ * surrounding function timeout — with these defaults the worst-case timeout path is
+ * `DAL_MAX_ATTEMPTS × DAL_REQUEST_TIMEOUT_MS` = ~1s.
+ */
+const DAL_REQUEST_TIMEOUT_MS = 500;
+
+/**
+ * DynamoDB error names that indicate the request was throttled.
+ */
+const THROTTLING_ERROR_NAMES = new Set(['ThrottlingException', 'ProvisionedThroughputExceededException']);
+
+/**
+ * Create the DynamoDB client used by the data store, configured for resilient reads under
+ * throttling: adaptive retries, bounded attempts, and hard per-attempt timeouts.
+ *
+ * @returns A configured DynamoDB client
+ */
+export function createDalDynamoDBClient(): DynamoDBClient {
+  return new DynamoDBClient({
+    region: process.env.AWS_REGION,
+    retryMode: DAL_RETRY_MODE,
+    maxAttempts: DAL_MAX_ATTEMPTS,
+    // Passing a plain object lets the SDK construct its default NodeHttpHandler with these
+    // bounds — no direct dependency on the handler package required.
+    requestHandler: {
+      connectionTimeout: DAL_CONNECTION_TIMEOUT_MS,
+      requestTimeout: DAL_REQUEST_TIMEOUT_MS,
+    },
+  });
+}
+
+/**
  * A class for reading entries from the data store.
  *
  * This class uses a singleton pattern.
@@ -51,11 +116,7 @@ export class DataStore {
 
     if (!this._ddb) {
       this._tableName = `DataAccessLayer-${process.env.AWS_REGION}`;
-      this._ddb = DynamoDBDocumentClient.from(
-        new DynamoDBClient({
-          region: process.env.AWS_REGION,
-        }),
-      );
+      this._ddb = DynamoDBDocumentClient.from(createDalDynamoDBClient());
     }
 
     return this._ddb;
@@ -109,8 +170,10 @@ export class DataStore {
         }),
       );
     } catch (error) {
+      const errorName = error instanceof Error ? error.name : undefined;
+      const throttled = errorName !== undefined && THROTTLING_ERROR_NAMES.has(errorName);
       const logFn = DataStore._testLogMRTError ?? logMRTError;
-      logFn('data_store', error, {key, tableName: this._tableName});
+      logFn('data_store', error, {key, tableName: this._tableName, errorName, throttled});
       throw new DataStoreServiceError('Data store request failed.');
     }
 

--- a/packages/mrt-utilities/src/data-store/production.ts
+++ b/packages/mrt-utilities/src/data-store/production.ts
@@ -48,14 +48,51 @@ const DAL_CONNECTION_TIMEOUT_MS = 300;
  * this leaves a large multiple of headroom over p99 while still failing fast on a genuine
  * hang. See {@link DAL_MAX_ATTEMPTS} for the timeout/attempt invariant relative to the
  * surrounding function timeout — with these defaults the worst-case timeout path is
- * `DAL_MAX_ATTEMPTS × DAL_REQUEST_TIMEOUT_MS` = ~1s.
+ * roughly `DAL_MAX_ATTEMPTS × DAL_REQUEST_TIMEOUT_MS` (≈1s) plus adaptive-retry backoff
+ * between attempts.
  */
 const DAL_REQUEST_TIMEOUT_MS = 500;
 
 /**
- * DynamoDB error names that indicate the request was throttled.
+ * Error names that indicate the request was throttled.
+ *
+ * Mirrors the AWS SDK's own throttling classification so the telemetry flag agrees with
+ * what actually drove adaptive backoff, rather than a hand-maintained subset.
  */
-const THROTTLING_ERROR_NAMES = new Set(['ThrottlingException', 'ProvisionedThroughputExceededException']);
+const THROTTLING_ERROR_NAMES = new Set([
+  'ThrottlingException',
+  'ProvisionedThroughputExceededException',
+  'RequestLimitExceeded',
+  'RequestThrottled',
+  'RequestThrottledException',
+  'TooManyRequestsException',
+  'ThrottledException',
+  'Throttling',
+]);
+
+/**
+ * Whether an error represents a throttling response.
+ *
+ * Checks the SDK's retryable-throttling trait and an HTTP 429 status in addition to the
+ * known throttling error names, so throttles surfaced only via metadata are still flagged.
+ */
+function isThrottlingError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const candidate = error as {
+    name?: unknown;
+    $retryable?: {throttling?: unknown};
+    $metadata?: {httpStatusCode?: unknown};
+  };
+  if (candidate.$retryable?.throttling === true) {
+    return true;
+  }
+  if (candidate.$metadata?.httpStatusCode === 429) {
+    return true;
+  }
+  return typeof candidate.name === 'string' && THROTTLING_ERROR_NAMES.has(candidate.name);
+}
 
 /**
  * Create the DynamoDB client used by the data store, configured for resilient reads under
@@ -69,10 +106,14 @@ export function createDalDynamoDBClient(): DynamoDBClient {
     retryMode: DAL_RETRY_MODE,
     maxAttempts: DAL_MAX_ATTEMPTS,
     // Passing a plain object lets the SDK construct its default NodeHttpHandler with these
-    // bounds — no direct dependency on the handler package required.
+    // bounds — no direct dependency on the handler package required. `throwOnRequestTimeout`
+    // is required for `requestTimeout` to actually abort a hung request: without it the
+    // handler only logs a warning and lets the request run on. Safe here because a DAL read
+    // is a simple request/response, not a long-lived stream.
     requestHandler: {
       connectionTimeout: DAL_CONNECTION_TIMEOUT_MS,
       requestTimeout: DAL_REQUEST_TIMEOUT_MS,
+      throwOnRequestTimeout: true,
     },
   });
 }
@@ -171,7 +212,7 @@ export class DataStore {
       );
     } catch (error) {
       const errorName = error instanceof Error ? error.name : undefined;
-      const throttled = errorName !== undefined && THROTTLING_ERROR_NAMES.has(errorName);
+      const throttled = isThrottlingError(error);
       const logFn = DataStore._testLogMRTError ?? logMRTError;
       logFn('data_store', error, {key, tableName: this._tableName, errorName, throttled});
       throw new DataStoreServiceError('Data store request failed.');

--- a/packages/mrt-utilities/test/data-store.test.ts
+++ b/packages/mrt-utilities/test/data-store.test.ts
@@ -8,6 +8,7 @@ import {expect} from 'chai';
 import sinon from 'sinon';
 import type {DynamoDBDocumentClient} from '@aws-sdk/lib-dynamodb';
 import {
+  createDalDynamoDBClient,
   DataStore,
   DataStoreNotFoundError,
   DataStoreServiceError,
@@ -129,7 +130,7 @@ describe('DataStore', () => {
     }
 
     it('throws DataStoreServiceError and logs internal error when send throws', async () => {
-      const dynamoError = new Error('DynamoDB throttled');
+      const dynamoError = new Error('boom');
       mockSend.rejects(dynamoError);
 
       const logStub = sinon.stub();
@@ -148,8 +149,58 @@ describe('DataStore', () => {
         logStub.calledOnceWith('data_store', dynamoError, {
           key: 'my-key',
           tableName: 'DataAccessLayer-ca-central-1',
+          errorName: 'Error',
+          throttled: false,
         }),
       ).to.be.true;
+    });
+
+    for (const throttleName of ['ThrottlingException', 'ProvisionedThroughputExceededException']) {
+      it(`marks ${throttleName} as throttled in the log context`, async () => {
+        const dynamoError = new Error('rate exceeded');
+        dynamoError.name = throttleName;
+        mockSend.rejects(dynamoError);
+
+        const logStub = sinon.stub();
+        DataStore._testLogMRTError = logStub;
+
+        const store = DataStore.getDataStore();
+
+        try {
+          await store.getEntry('my-key');
+          expect.fail('should have thrown');
+        } catch (e) {
+          expect(e).to.be.an.instanceOf(DataStoreServiceError);
+        }
+        expect(
+          logStub.calledOnceWith('data_store', dynamoError, {
+            key: 'my-key',
+            tableName: 'DataAccessLayer-ca-central-1',
+            errorName: throttleName,
+            throttled: true,
+          }),
+        ).to.be.true;
+      });
+    }
+
+    it('records errorName as undefined and not throttled for a non-Error rejection', async () => {
+      // Reject with a raw string (not an Error) to exercise the non-Error branch.
+      mockSend.callsFake(() => Promise.reject('a string failure'));
+
+      const logStub = sinon.stub();
+      DataStore._testLogMRTError = logStub;
+
+      const store = DataStore.getDataStore();
+
+      try {
+        await store.getEntry('my-key');
+        expect.fail('should have thrown');
+      } catch (e) {
+        expect(e).to.be.an.instanceOf(DataStoreServiceError);
+      }
+      const context = logStub.firstCall.args[2] as {errorName: unknown; throttled: boolean};
+      expect(context.errorName).to.equal(undefined);
+      expect(context.throttled).to.equal(false);
     });
   });
 });
@@ -178,5 +229,45 @@ describe('DataStoreServiceError', () => {
     expect(err.name).to.equal('DataStoreServiceError');
     expect(err.message).to.equal('this request failed');
     expect(err).to.be.an.instanceOf(Error);
+  });
+});
+
+describe('createDalDynamoDBClient', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = {...process.env};
+    process.env.AWS_REGION = 'ca-central-1';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('configures the client region from AWS_REGION', async () => {
+    const client = createDalDynamoDBClient();
+    expect(await client.config.region()).to.equal('ca-central-1');
+  });
+
+  it('bounds retries with maxAttempts', async () => {
+    const client = createDalDynamoDBClient();
+    expect(await client.config.maxAttempts()).to.equal(2);
+  });
+
+  it('uses the adaptive retry strategy', async () => {
+    const client = createDalDynamoDBClient();
+    const strategy = (await client.config.retryStrategy()) as {mode?: string};
+    expect(strategy.mode).to.equal('adaptive');
+  });
+
+  it('applies bounded connection and request timeouts to the request handler', async () => {
+    const client = createDalDynamoDBClient();
+    const config = await (
+      client.config.requestHandler as unknown as {
+        configProvider: Promise<{connectionTimeout?: number; requestTimeout?: number}>;
+      }
+    ).configProvider;
+    expect(config.connectionTimeout).to.equal(300);
+    expect(config.requestTimeout).to.equal(500);
   });
 });

--- a/packages/mrt-utilities/test/data-store.test.ts
+++ b/packages/mrt-utilities/test/data-store.test.ts
@@ -155,7 +155,12 @@ describe('DataStore', () => {
       ).to.be.true;
     });
 
-    for (const throttleName of ['ThrottlingException', 'ProvisionedThroughputExceededException']) {
+    for (const throttleName of [
+      'ThrottlingException',
+      'ProvisionedThroughputExceededException',
+      'RequestLimitExceeded',
+      'TooManyRequestsException',
+    ]) {
       it(`marks ${throttleName} as throttled in the log context`, async () => {
         const dynamoError = new Error('rate exceeded');
         dynamoError.name = throttleName;
@@ -182,6 +187,50 @@ describe('DataStore', () => {
         ).to.be.true;
       });
     }
+
+    it('marks an error carrying the retryable throttling trait as throttled', async () => {
+      const dynamoError = Object.assign(new Error('slow down'), {
+        name: 'ServiceError',
+        $retryable: {throttling: true},
+      });
+      mockSend.rejects(dynamoError);
+
+      const logStub = sinon.stub();
+      DataStore._testLogMRTError = logStub;
+
+      const store = DataStore.getDataStore();
+
+      try {
+        await store.getEntry('my-key');
+        expect.fail('should have thrown');
+      } catch (e) {
+        expect(e).to.be.an.instanceOf(DataStoreServiceError);
+      }
+      const context = logStub.firstCall.args[2] as {throttled: boolean};
+      expect(context.throttled).to.equal(true);
+    });
+
+    it('marks an HTTP 429 response as throttled', async () => {
+      const dynamoError = Object.assign(new Error('too many requests'), {
+        name: 'ServiceError',
+        $metadata: {httpStatusCode: 429},
+      });
+      mockSend.rejects(dynamoError);
+
+      const logStub = sinon.stub();
+      DataStore._testLogMRTError = logStub;
+
+      const store = DataStore.getDataStore();
+
+      try {
+        await store.getEntry('my-key');
+        expect.fail('should have thrown');
+      } catch (e) {
+        expect(e).to.be.an.instanceOf(DataStoreServiceError);
+      }
+      const context = logStub.firstCall.args[2] as {throttled: boolean};
+      expect(context.throttled).to.equal(true);
+    });
 
     it('records errorName as undefined and not throttled for a non-Error rejection', async () => {
       // Reject with a raw string (not an Error) to exercise the non-Error branch.
@@ -264,10 +313,16 @@ describe('createDalDynamoDBClient', () => {
     const client = createDalDynamoDBClient();
     const config = await (
       client.config.requestHandler as unknown as {
-        configProvider: Promise<{connectionTimeout?: number; requestTimeout?: number}>;
+        configProvider: Promise<{
+          connectionTimeout?: number;
+          requestTimeout?: number;
+          throwOnRequestTimeout?: boolean;
+        }>;
       }
     ).configProvider;
     expect(config.connectionTimeout).to.equal(300);
     expect(config.requestTimeout).to.equal(500);
+    // Required for requestTimeout to actually abort a hung request rather than only warn.
+    expect(config.throwOnRequestTimeout).to.equal(true);
   });
 });


### PR DESCRIPTION
## Summary

- Configure the data store (DAL) DynamoDB client for resilient reads under throttling: adaptive retry mode, bounded `maxAttempts` (2), and hard per-attempt connection (300ms) and request (500ms) timeouts
- Add `throwOnRequestTimeout` so the request timeout actually aborts a hung request instead of only logging a warning
- Detect throttling failures (retryable-throttling trait, HTTP 429, and known throttling error names) and surface a `throttled` flag in the existing error log context so throttle rates are observable in telemetry
- Timeout/attempt values are documented as named constants, chosen relative to the surrounding function timeout (worst-case timeout path ≈ 1s, well under it) and a single-key read's single-digit-ms latency

Existing `DataStore` behavior (not-found, unavailable, and service-error paths) is unchanged, and the change adds no new logging beyond enriching the one existing error-log call.

## Testing

- `pnpm --filter @salesforce/mrt-utilities run test:agent` — 545 passing
- `pnpm --filter @salesforce/mrt-utilities run lint:agent`
- `pnpm --filter @salesforce/mrt-utilities run typecheck:agent`
- Verified against the resolved SDK handler that the request timeout aborts a stalled response with a `TimeoutError`

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass
- [x] Modified files are formatted

@W-23735205
