### PR TITLE
@W-23735176 Shard-aware Data Store read

### DIFF
--- a/.changeset/shard-aware-dal-read.md
+++ b/.changeset/shard-aware-dal-read.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/mrt-utilities': minor
+---
+
+Make DataStore.getEntry shard-aware. When the MRT_NUM_SHARDS environment variable is set to a value greater than 1, reads are spread across shard partitions by selecting a random shard, relieving read pressure on a single hot partition. When MRT_NUM_SHARDS is unset or 1, behavior is unchanged. The getEntry signature and return shape are unchanged, so this is backward compatible.

--- a/packages/mrt-utilities/src/data-store/production.ts
+++ b/packages/mrt-utilities/src/data-store/production.ts
@@ -133,6 +133,8 @@ export class DataStore {
   static _testDocumentClient: DynamoDBDocumentClient | null = null;
   /** @internal Test hook: inject logMRTError for unit tests */
   static _testLogMRTError: ((namespace: string, err: unknown, context?: Record<string, unknown>) => void) | null = null;
+  /** @internal Test hook: inject a deterministic random source (returns [0, 1)) for unit tests */
+  static _testRandom: (() => number) | null = null;
 
   private constructor() {
     // Private constructor for singleton; use DataStore.getDataStore() instead.
@@ -161,6 +163,33 @@ export class DataStore {
     }
 
     return this._ddb;
+  }
+
+  /**
+   * Resolve the DynamoDB partition key for a read, applying shard selection.
+   *
+   * Reads the shard count from `MRT_NUM_SHARDS` (default 1) and picks a random
+   * shard `i` in `[0, N)`. Shard 0 is the legacy unsuffixed partition key, so
+   * when `MRT_NUM_SHARDS` is unset or 1 this is identical to today's behavior.
+   * There is no runtime fallback: writers fan out to every shard, so every shard
+   * a reader can pick is guaranteed to exist.
+   *
+   * @private
+   * @returns The `projectEnvironment` partition key value to read
+   */
+  private resolveShardPartitionKey(): string {
+    const base = `${process.env.MOBIFY_PROPERTY_ID} ${process.env.DEPLOY_TARGET}`;
+
+    const parsed = Number(process.env.MRT_NUM_SHARDS);
+    const numShards = Number.isInteger(parsed) && parsed > 1 ? parsed : 1;
+    if (numShards === 1) {
+      return base;
+    }
+
+    const random = DataStore._testRandom ?? Math.random;
+    const shard = Math.floor(random() * numShards);
+    // shard 0 is the legacy unsuffixed partition; shards 1..N-1 carry a suffix.
+    return shard === 0 ? base : `${base} ${shard}`;
   }
 
   /**
@@ -199,13 +228,14 @@ export class DataStore {
     }
 
     const ddb = this.getClient();
+    const projectEnvironment = this.resolveShardPartitionKey();
     let response: GetCommandOutput;
     try {
       response = await ddb.send(
         new GetCommand({
           TableName: this._tableName,
           Key: {
-            projectEnvironment: `${process.env.MOBIFY_PROPERTY_ID} ${process.env.DEPLOY_TARGET}`,
+            projectEnvironment,
             key,
           },
         }),
@@ -214,7 +244,7 @@ export class DataStore {
       const errorName = error instanceof Error ? error.name : undefined;
       const throttled = isThrottlingError(error);
       const logFn = DataStore._testLogMRTError ?? logMRTError;
-      logFn('data_store', error, {key, tableName: this._tableName, errorName, throttled});
+      logFn('data_store', error, {key, projectEnvironment, tableName: this._tableName, errorName, throttled});
       throw new DataStoreServiceError('Data store request failed.');
     }
 

--- a/packages/mrt-utilities/test/data-store.test.ts
+++ b/packages/mrt-utilities/test/data-store.test.ts
@@ -25,6 +25,7 @@ describe('DataStore', () => {
     (DataStore as unknown as {_instance: DataStore | null})._instance = null;
     DataStore._testDocumentClient = null;
     DataStore._testLogMRTError = null;
+    DataStore._testRandom = null;
 
     mockSend = sinon.stub();
     mockDocumentClient = {send: mockSend} as unknown as DynamoDBDocumentClient;
@@ -40,6 +41,7 @@ describe('DataStore', () => {
     (DataStore as unknown as {_instance: DataStore | null})._instance = null;
     DataStore._testDocumentClient = null;
     DataStore._testLogMRTError = null;
+    DataStore._testRandom = null;
     sinon.restore();
   });
 
@@ -148,6 +150,7 @@ describe('DataStore', () => {
       expect(
         logStub.calledOnceWith('data_store', dynamoError, {
           key: 'my-key',
+          projectEnvironment: 'my-project my-target',
           tableName: 'DataAccessLayer-ca-central-1',
           errorName: 'Error',
           throttled: false,
@@ -180,6 +183,7 @@ describe('DataStore', () => {
         expect(
           logStub.calledOnceWith('data_store', dynamoError, {
             key: 'my-key',
+            projectEnvironment: 'my-project my-target',
             tableName: 'DataAccessLayer-ca-central-1',
             errorName: throttleName,
             throttled: true,
@@ -250,6 +254,103 @@ describe('DataStore', () => {
       const context = logStub.firstCall.args[2] as {errorName: unknown; throttled: boolean};
       expect(context.errorName).to.equal(undefined);
       expect(context.throttled).to.equal(false);
+    });
+
+    describe('sharding (MRT_NUM_SHARDS)', () => {
+      const legacyKey = 'my-project my-target';
+
+      it('reads the legacy unsuffixed key when MRT_NUM_SHARDS is unset', async () => {
+        delete process.env.MRT_NUM_SHARDS;
+        mockSend.resolves({Item: {value: {theme: 'dark'}}});
+
+        await DataStore.getDataStore().getEntry('my-key');
+
+        expect(mockSend.callCount).to.equal(1);
+        expect(mockSend.firstCall.args[0].input.Key.projectEnvironment).to.equal(legacyKey);
+      });
+
+      it('reads the legacy unsuffixed key when MRT_NUM_SHARDS is 1', async () => {
+        process.env.MRT_NUM_SHARDS = '1';
+        mockSend.resolves({Item: {value: {theme: 'dark'}}});
+
+        await DataStore.getDataStore().getEntry('my-key');
+
+        expect(mockSend.callCount).to.equal(1);
+        expect(mockSend.firstCall.args[0].input.Key.projectEnvironment).to.equal(legacyKey);
+      });
+
+      it('reads the legacy unsuffixed key when the random pick is shard 0', async () => {
+        process.env.MRT_NUM_SHARDS = '4';
+        DataStore._testRandom = () => 0; // floor(0 * 4) = 0
+        mockSend.resolves({Item: {value: {theme: 'dark'}}});
+
+        await DataStore.getDataStore().getEntry('my-key');
+
+        expect(mockSend.callCount).to.equal(1);
+        expect(mockSend.firstCall.args[0].input.Key.projectEnvironment).to.equal(legacyKey);
+      });
+
+      it('reads a suffixed shard key when the random pick is a non-zero shard', async () => {
+        process.env.MRT_NUM_SHARDS = '4';
+        DataStore._testRandom = () => 0.5; // floor(0.5 * 4) = 2
+        mockSend.resolves({Item: {value: {theme: 'dark'}}});
+
+        await DataStore.getDataStore().getEntry('my-key');
+
+        expect(mockSend.callCount).to.equal(1);
+        expect(mockSend.firstCall.args[0].input.Key.projectEnvironment).to.equal(`${legacyKey} 2`);
+      });
+
+      it('reads the highest shard when random approaches 1', async () => {
+        process.env.MRT_NUM_SHARDS = '4';
+        DataStore._testRandom = () => 0.999; // floor(0.999 * 4) = 3
+        mockSend.resolves({Item: {value: {theme: 'dark'}}});
+
+        await DataStore.getDataStore().getEntry('my-key');
+
+        expect(mockSend.firstCall.args[0].input.Key.projectEnvironment).to.equal(`${legacyKey} 3`);
+      });
+
+      it('honors a large shard count', async () => {
+        process.env.MRT_NUM_SHARDS = '64';
+        DataStore._testRandom = () => 0.5; // floor(0.5 * 64) = 32
+        mockSend.resolves({Item: {value: {theme: 'dark'}}});
+
+        await DataStore.getDataStore().getEntry('my-key');
+
+        expect(mockSend.callCount).to.equal(1);
+        expect(mockSend.firstCall.args[0].input.Key.projectEnvironment).to.equal(`${legacyKey} 32`);
+      });
+
+      it('surfaces a miss on the picked shard as DataStoreNotFoundError with no fallback', async () => {
+        process.env.MRT_NUM_SHARDS = '4';
+        DataStore._testRandom = () => 0.5; // shard 2
+        mockSend.resolves({}); // miss
+
+        try {
+          await DataStore.getDataStore().getEntry('my-key');
+          expect.fail('should have thrown');
+        } catch (e) {
+          expect(e).to.be.an.instanceOf(DataStoreNotFoundError);
+        }
+        // no runtime fallback: exactly one read of the picked shard
+        expect(mockSend.callCount).to.equal(1);
+        expect(mockSend.firstCall.args[0].input.Key.projectEnvironment).to.equal(`${legacyKey} 2`);
+      });
+
+      const invalidCases = ['0', '-1', 'abc', '1.5', ''];
+      for (const value of invalidCases) {
+        it(`defaults to the legacy key when MRT_NUM_SHARDS is invalid (${JSON.stringify(value)})`, async () => {
+          process.env.MRT_NUM_SHARDS = value;
+          DataStore._testRandom = () => 0.999; // would pick a high shard if honored
+          mockSend.resolves({Item: {value: {theme: 'dark'}}});
+
+          await DataStore.getDataStore().getEntry('my-key');
+
+          expect(mockSend.callCount).to.equal(1);
+          expect(mockSend.firstCall.args[0].input.Key.projectEnvironment).to.equal(legacyKey);
+        });
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Makes `DataStore.getEntry` in `@salesforce/mrt-utilities` shard-aware to relieve read pressure on a single hot DynamoDB partition. On each read the client resolves the shard count from `MRT_NUM_SHARDS` (default 1), picks a random shard `i ∈ [0, N)`, and reads that partition key:

- Shard 0 is the legacy unsuffixed key `"<MOBIFY_PROPERTY_ID> <DEPLOY_TARGET>"`.
- Shards `1..N-1` carry a `#<i>` suffix.

## Why

The Data Store reads a single `projectEnvironment` partition per target, which maps to one physical DynamoDB partition capped at ~3000 RCU — DynamoDB adaptive capacity cannot split a single-key hot partition. Spreading reads across N shard partitions gives N× read headroom. Writers in MRT will fan out to every shard, so this is the read side of a write-fan-out + random-shard-read strategy suited to the DAL's read-hot / write-light profile.

## Design notes (per the cross-repo shard-scaling proposal)

- **No runtime fallback.** Every shard a reader can pick is guaranteed to exist via writer fan-out and expand/contract rollout ordering. A miss on the picked shard surfaces as `DataStoreNotFoundError` - callers can fallback to an API.
- **Backward compatible.** When `MRT_NUM_SHARDS` is unset or 1, the resolved key is the legacy unsuffixed key and behavior is identical to today. Invalid values (0, negative, non-integer, garbage) silently default to 1. The `getEntry(key)` signature and return shape are unchanged.
- The error-log context gains the resolved `projectEnvironment` so shard-specific failures are diagnosable (fires only on service error, not on the hot path).

## Testing

- `pnpm --filter @salesforce/mrt-utilities run test:agent` — 546 passing.
- Typecheck and lint clean.
- New tests cover: default (unset/1) → legacy key; random pick of shard 0 → legacy key; non-zero shard → suffixed key; large N; miss → `DataStoreNotFoundError` with exactly one read; and every invalid `MRT_NUM_SHARDS` value defaulting to the legacy key.
- `MRT_NUM_SHARDS` is not set by MRT yet - we'll perform full end-to-end testing when that is available

## Related

- GUS: W-23735176 (epic: [MRT] MRT Scale for Holidays)
- Reader-side change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)