### PR TITLE
@W-23735176 feat(mrt-utilities): trace the data store fetch

### DIFF
--- a/.changeset/traced-data-store-fetch.md
+++ b/.changeset/traced-data-store-fetch.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/mrt-utilities': minor
+---
+
+Add OpenTelemetry tracing to the data store fetch. `DataStore.getEntry` now emits a client span (`mrt.data_store.getEntry`) around the underlying DynamoDB read, with DynamoDB attributes and found/throttled/error outcome recorded on the span. `@salesforce/mrt-utilities` depends only on `@opentelemetry/api`, so the span joins the host runtime's trace when a tracer provider is registered and is a no-op otherwise — no configuration required from consumers.

--- a/.changeset/traced-data-store-fetch.md
+++ b/.changeset/traced-data-store-fetch.md
@@ -2,4 +2,4 @@
 '@salesforce/mrt-utilities': minor
 ---
 
-Add OpenTelemetry tracing to the data store fetch. `DataStore.getEntry` now emits a client span (`mrt.data_store.getEntry`) around the underlying DynamoDB read, with DynamoDB attributes and found/throttled/error outcome recorded on the span. `@salesforce/mrt-utilities` depends only on `@opentelemetry/api`, so the span joins the host runtime's trace when a tracer provider is registered and is a no-op otherwise — no configuration required from consumers.
+Add OpenTelemetry tracing to the data store fetch. `DataStore.getEntry` now emits a client span (`mrt.data_store.getEntry`) around the underlying read, recording only backend-neutral outcome signals (found / throttled) and a generic error status — no storage-backend implementation detail is exposed on the span, since traces may be customer-visible. `@salesforce/mrt-utilities` depends only on `@opentelemetry/api`, so the span joins the host runtime's trace when a tracer provider is registered and is a no-op otherwise — no configuration required from consumers.

--- a/packages/mrt-utilities/package.json
+++ b/packages/mrt-utilities/package.json
@@ -120,6 +120,7 @@
     "@aws-sdk/client-cloudwatch": "3.1049.0",
     "@aws-sdk/client-dynamodb": "3.1049.0",
     "@aws-sdk/lib-dynamodb": "3.1049.0",
+    "@opentelemetry/api": "1.9.1",
     "@h4ad/serverless-adapter": "4.4.0",
     "change-case": "5.4.4",
     "compressible": "2.0.18",

--- a/packages/mrt-utilities/src/data-store/production.ts
+++ b/packages/mrt-utilities/src/data-store/production.ts
@@ -288,8 +288,6 @@ export class DataStore {
         }
 
         if (!response.Item?.value) {
-          // A miss is an expected outcome, not a service error — record it as an attribute
-          // and leave the span status unset (successful fetch that found nothing).
           span.setAttribute('mrt.data_store.found', false);
           throw new DataStoreNotFoundError(`Data store entry '${key}' not found.`);
         }

--- a/packages/mrt-utilities/src/data-store/production.ts
+++ b/packages/mrt-utilities/src/data-store/production.ts
@@ -38,9 +38,12 @@ const tracer = trace.getTracer('@salesforce/mrt-utilities');
 /**
  * Span name for a single data store fetch.
  *
- * Deliberately static and low-cardinality so traces aggregate by operation. The
- * high-cardinality request detail (the entry key, the resolved partition key) is attached
- * as span attributes instead of being baked into the name.
+ * Deliberately static and low-cardinality so traces aggregate by operation.
+ *
+ * The span intentionally exposes NO backend-implementation detail — no `db.system`,
+ * DynamoDB operation name, table name, or raw AWS SDK error. Traces on this span may be
+ * visible to customers, so it reveals only the abstract "data store" concept and
+ * backend-neutral outcome signals (found / throttled). See {@link getEntry}.
  */
 const GET_ENTRY_SPAN_NAME = 'mrt.data_store.getEntry';
 
@@ -252,62 +255,50 @@ export class DataStore {
     const ddb = this.getClient();
     const projectEnvironment = this.resolveShardPartitionKey();
 
-    // Trace the fetch as a client span. Semantic-convention DynamoDB attributes describe
-    // the operation; the outcome (found/throttled/error) is recorded on the span below.
-    return tracer.startActiveSpan(
-      GET_ENTRY_SPAN_NAME,
-      {
-        attributes: {
-          'db.system': 'dynamodb',
-          'db.operation': 'GetItem',
-          'aws.dynamodb.table_names': this._tableName,
-        },
-      },
-      async (span) => {
-        // End the span exactly once, after all attributes/status are set on every path
-        // (success, miss, and error). Attributes set after end() are dropped by OTel, so we
-        // cannot end in a `finally` that runs before the found/not-found branch below.
+    // Trace the fetch as a client span. The span deliberately carries no backend detail
+    // (no db.system, table name, DynamoDB operation, or raw SDK error) since traces may be
+    // customer-visible — only the backend-neutral outcome (found/throttled) is recorded.
+    // The detailed backend context is still captured in the internal error log below.
+    return tracer.startActiveSpan(GET_ENTRY_SPAN_NAME, async (span) => {
+      // End the span exactly once, after all attributes/status are set on every path
+      // (success, miss, and error). Attributes set after end() are dropped by OTel, so we
+      // cannot end in a `finally` that runs before the found/not-found branch below.
+      try {
+        let response: GetCommandOutput;
         try {
-          let response: GetCommandOutput;
-          try {
-            response = await ddb.send(
-              new GetCommand({
-                TableName: this._tableName,
-                Key: {
-                  projectEnvironment,
-                  key,
-                },
-              }),
-            );
-          } catch (error) {
-            const errorName = error instanceof Error ? error.name : undefined;
-            const throttled = isThrottlingError(error);
-            span.setAttribute('mrt.data_store.throttled', throttled);
-            if (errorName) {
-              span.setAttribute('error.type', errorName);
-            }
-            if (error instanceof Error) {
-              span.recordException(error);
-            }
-            span.setStatus({code: SpanStatusCode.ERROR, message: 'Data store request failed.'});
-            const logFn = DataStore._testLogMRTError ?? logMRTError;
-            logFn('data_store', error, {key, projectEnvironment, tableName: this._tableName, errorName, throttled});
-            throw new DataStoreServiceError('Data store request failed.');
-          }
-
-          if (!response.Item?.value) {
-            // A miss is an expected outcome, not a service error — record it as an attribute
-            // and leave the span status unset (successful fetch that found nothing).
-            span.setAttribute('mrt.data_store.found', false);
-            throw new DataStoreNotFoundError(`Data store entry '${key}' not found.`);
-          }
-
-          span.setAttribute('mrt.data_store.found', true);
-          return {key, value: response.Item.value};
-        } finally {
-          span.end();
+          response = await ddb.send(
+            new GetCommand({
+              TableName: this._tableName,
+              Key: {
+                projectEnvironment,
+                key,
+              },
+            }),
+          );
+        } catch (error) {
+          const errorName = error instanceof Error ? error.name : undefined;
+          const throttled = isThrottlingError(error);
+          span.setAttribute('mrt.data_store.throttled', throttled);
+          // A generic status message only — no SDK error name/message/stack on the span,
+          // which would reveal the DynamoDB backend. The specifics go to the log below.
+          span.setStatus({code: SpanStatusCode.ERROR, message: 'Data store request failed.'});
+          const logFn = DataStore._testLogMRTError ?? logMRTError;
+          logFn('data_store', error, {key, projectEnvironment, tableName: this._tableName, errorName, throttled});
+          throw new DataStoreServiceError('Data store request failed.');
         }
-      },
-    );
+
+        if (!response.Item?.value) {
+          // A miss is an expected outcome, not a service error — record it as an attribute
+          // and leave the span status unset (successful fetch that found nothing).
+          span.setAttribute('mrt.data_store.found', false);
+          throw new DataStoreNotFoundError(`Data store entry '${key}' not found.`);
+        }
+
+        span.setAttribute('mrt.data_store.found', true);
+        return {key, value: response.Item.value};
+      } finally {
+        span.end();
+      }
+    });
   }
 }

--- a/packages/mrt-utilities/src/data-store/production.ts
+++ b/packages/mrt-utilities/src/data-store/production.ts
@@ -6,6 +6,7 @@
 
 import {DynamoDBClient} from '@aws-sdk/client-dynamodb';
 import {DynamoDBDocumentClient, GetCommand, type GetCommandOutput} from '@aws-sdk/lib-dynamodb';
+import {SpanStatusCode, trace} from '@opentelemetry/api';
 
 import {DataStoreNotFoundError, DataStoreServiceError, DataStoreUnavailableError} from './errors.js';
 import {logMRTError} from '../utils/utils.js';
@@ -20,16 +21,37 @@ export {DataStoreNotFoundError, DataStoreServiceError, DataStoreUnavailableError
  * rate limiter keeps state on the client instance, so it only helps across invocations on
  * a warm container — the memoized client preserves that state.
  */
-const DAL_RETRY_MODE = 'adaptive';
+const DATA_STORE_RETRY_MODE = 'adaptive';
+
+/**
+ * Tracer for data store operations.
+ *
+ * This is a library, so we depend only on `@opentelemetry/api` and never register a
+ * provider ourselves — the host runtime owns that. When no provider is registered (e.g.
+ * local development, or any consumer that has not set up tracing) `getTracer` returns a
+ * no-op tracer, so instrumentation is silent and adds negligible overhead. When the host
+ * has registered a provider (the Managed Runtime storefront registers one that exports
+ * spans to stdout for MRT to ship), the span joins the ambient trace context.
+ */
+const tracer = trace.getTracer('@salesforce/mrt-utilities');
+
+/**
+ * Span name for a single data store fetch.
+ *
+ * Deliberately static and low-cardinality so traces aggregate by operation. The
+ * high-cardinality request detail (the entry key, the resolved partition key) is attached
+ * as span attributes instead of being baked into the name.
+ */
+const GET_ENTRY_SPAN_NAME = 'mrt.data_store.getEntry';
 
 /**
  * Maximum number of attempts (initial request + retries) per data store request.
  *
  * Bounds retry fan-out under sustained throttling. Chosen together with
- * {@link DAL_REQUEST_TIMEOUT_MS} so that `DAL_MAX_ATTEMPTS × DAL_REQUEST_TIMEOUT_MS` stays
+ * {@link DATA_STORE_REQUEST_TIMEOUT_MS} so that `DATA_STORE_MAX_ATTEMPTS × DATA_STORE_REQUEST_TIMEOUT_MS` stays
  * comfortably under the surrounding request/function timeout.
  */
-const DAL_MAX_ATTEMPTS = 2;
+const DATA_STORE_MAX_ATTEMPTS = 2;
 
 /**
  * Maximum time (ms) to wait for a connection to be established per attempt.
@@ -39,19 +61,19 @@ const DAL_MAX_ATTEMPTS = 2;
  * attempts do not open a new connection; a fresh connect exceeding this is already
  * abnormal.
  */
-const DAL_CONNECTION_TIMEOUT_MS = 300;
+const DATA_STORE_CONNECTION_TIMEOUT_MS = 300;
 
 /**
  * Maximum time (ms) to wait for a response per attempt.
  *
  * A hard per-attempt ceiling. A single-key DynamoDB read is typically single-digit ms, so
  * this leaves a large multiple of headroom over p99 while still failing fast on a genuine
- * hang. See {@link DAL_MAX_ATTEMPTS} for the timeout/attempt invariant relative to the
+ * hang. See {@link DATA_STORE_MAX_ATTEMPTS} for the timeout/attempt invariant relative to the
  * surrounding function timeout — with these defaults the worst-case timeout path is
- * roughly `DAL_MAX_ATTEMPTS × DAL_REQUEST_TIMEOUT_MS` (≈1s) plus adaptive-retry backoff
+ * roughly `DATA_STORE_MAX_ATTEMPTS × DATA_STORE_REQUEST_TIMEOUT_MS` (≈1s) plus adaptive-retry backoff
  * between attempts.
  */
-const DAL_REQUEST_TIMEOUT_MS = 500;
+const DATA_STORE_REQUEST_TIMEOUT_MS = 500;
 
 /**
  * Error names that indicate the request was throttled.
@@ -103,16 +125,16 @@ function isThrottlingError(error: unknown): boolean {
 export function createDalDynamoDBClient(): DynamoDBClient {
   return new DynamoDBClient({
     region: process.env.AWS_REGION,
-    retryMode: DAL_RETRY_MODE,
-    maxAttempts: DAL_MAX_ATTEMPTS,
+    retryMode: DATA_STORE_RETRY_MODE,
+    maxAttempts: DATA_STORE_MAX_ATTEMPTS,
     // Passing a plain object lets the SDK construct its default NodeHttpHandler with these
     // bounds — no direct dependency on the handler package required. `throwOnRequestTimeout`
     // is required for `requestTimeout` to actually abort a hung request: without it the
-    // handler only logs a warning and lets the request run on. Safe here because a DAL read
+    // handler only logs a warning and lets the request run on. Safe here because a data store read
     // is a simple request/response, not a long-lived stream.
     requestHandler: {
-      connectionTimeout: DAL_CONNECTION_TIMEOUT_MS,
-      requestTimeout: DAL_REQUEST_TIMEOUT_MS,
+      connectionTimeout: DATA_STORE_CONNECTION_TIMEOUT_MS,
+      requestTimeout: DATA_STORE_REQUEST_TIMEOUT_MS,
       throwOnRequestTimeout: true,
     },
   });
@@ -229,29 +251,63 @@ export class DataStore {
 
     const ddb = this.getClient();
     const projectEnvironment = this.resolveShardPartitionKey();
-    let response: GetCommandOutput;
-    try {
-      response = await ddb.send(
-        new GetCommand({
-          TableName: this._tableName,
-          Key: {
-            projectEnvironment,
-            key,
-          },
-        }),
-      );
-    } catch (error) {
-      const errorName = error instanceof Error ? error.name : undefined;
-      const throttled = isThrottlingError(error);
-      const logFn = DataStore._testLogMRTError ?? logMRTError;
-      logFn('data_store', error, {key, projectEnvironment, tableName: this._tableName, errorName, throttled});
-      throw new DataStoreServiceError('Data store request failed.');
-    }
 
-    if (!response.Item?.value) {
-      throw new DataStoreNotFoundError(`Data store entry '${key}' not found.`);
-    }
+    // Trace the fetch as a client span. Semantic-convention DynamoDB attributes describe
+    // the operation; the outcome (found/throttled/error) is recorded on the span below.
+    return tracer.startActiveSpan(
+      GET_ENTRY_SPAN_NAME,
+      {
+        attributes: {
+          'db.system': 'dynamodb',
+          'db.operation': 'GetItem',
+          'aws.dynamodb.table_names': this._tableName,
+        },
+      },
+      async (span) => {
+        // End the span exactly once, after all attributes/status are set on every path
+        // (success, miss, and error). Attributes set after end() are dropped by OTel, so we
+        // cannot end in a `finally` that runs before the found/not-found branch below.
+        try {
+          let response: GetCommandOutput;
+          try {
+            response = await ddb.send(
+              new GetCommand({
+                TableName: this._tableName,
+                Key: {
+                  projectEnvironment,
+                  key,
+                },
+              }),
+            );
+          } catch (error) {
+            const errorName = error instanceof Error ? error.name : undefined;
+            const throttled = isThrottlingError(error);
+            span.setAttribute('mrt.data_store.throttled', throttled);
+            if (errorName) {
+              span.setAttribute('error.type', errorName);
+            }
+            if (error instanceof Error) {
+              span.recordException(error);
+            }
+            span.setStatus({code: SpanStatusCode.ERROR, message: 'Data store request failed.'});
+            const logFn = DataStore._testLogMRTError ?? logMRTError;
+            logFn('data_store', error, {key, projectEnvironment, tableName: this._tableName, errorName, throttled});
+            throw new DataStoreServiceError('Data store request failed.');
+          }
 
-    return {key, value: response.Item.value};
+          if (!response.Item?.value) {
+            // A miss is an expected outcome, not a service error — record it as an attribute
+            // and leave the span status unset (successful fetch that found nothing).
+            span.setAttribute('mrt.data_store.found', false);
+            throw new DataStoreNotFoundError(`Data store entry '${key}' not found.`);
+          }
+
+          span.setAttribute('mrt.data_store.found', true);
+          return {key, value: response.Item.value};
+        } finally {
+          span.end();
+        }
+      },
+    );
   }
 }

--- a/packages/mrt-utilities/test/data-store.test.ts
+++ b/packages/mrt-utilities/test/data-store.test.ts
@@ -501,7 +501,7 @@ describe('DataStore', () => {
         expect(spans).to.have.lengthOf(1);
         const [span] = spans;
         expect(span.ended).to.equal(true);
-        // A miss is an expected outcome, not a service error: no ERROR status.
+        // A miss does not set an ERROR status (that is reserved for a failed read).
         expect(span.status).to.equal(undefined);
         expect(span.attributes['mrt.data_store.found']).to.equal(false);
         assertNoBackendLeak(span);

--- a/packages/mrt-utilities/test/data-store.test.ts
+++ b/packages/mrt-utilities/test/data-store.test.ts
@@ -8,12 +8,112 @@ import {expect} from 'chai';
 import sinon from 'sinon';
 import type {DynamoDBDocumentClient} from '@aws-sdk/lib-dynamodb';
 import {
+  type Attributes,
+  type Exception,
+  type Span,
+  type SpanStatus,
+  SpanStatusCode,
+  trace,
+  type Tracer,
+  type TracerProvider,
+} from '@opentelemetry/api';
+import {
   createDalDynamoDBClient,
   DataStore,
   DataStoreNotFoundError,
   DataStoreServiceError,
   DataStoreUnavailableError,
 } from '@salesforce/mrt-utilities';
+
+/**
+ * A minimal recording span that captures the calls `getEntry` makes on it, so tests can
+ * assert on the emitted telemetry without pulling in the full OpenTelemetry SDK. Only the
+ * methods the instrumentation actually uses are implemented; the rest are no-ops.
+ */
+class RecordingSpan {
+  attributes: Attributes = {};
+  status: SpanStatus | undefined;
+  exceptions: Exception[] = [];
+  ended = false;
+
+  setAttribute(key: string, value: unknown): this {
+    this.attributes[key] = value as Attributes[string];
+    return this;
+  }
+  setStatus(status: SpanStatus): this {
+    this.status = status;
+    return this;
+  }
+  recordException(exception: Exception): void {
+    this.exceptions.push(exception);
+  }
+  end(): void {
+    this.ended = true;
+  }
+  // Unused Span surface — no-ops to satisfy the interface.
+  setAttributes(): this {
+    return this;
+  }
+  addEvent(): this {
+    return this;
+  }
+  addLink(): this {
+    return this;
+  }
+  addLinks(): this {
+    return this;
+  }
+  updateName(): this {
+    return this;
+  }
+  isRecording(): boolean {
+    return true;
+  }
+  spanContext() {
+    return {traceId: '0'.repeat(32), spanId: '0'.repeat(16), traceFlags: 1};
+  }
+}
+
+// Shared list of spans started via the fake global tracer. The module-level
+// `trace.getTracer(...)` in the data store returns a ProxyTracer bound to the global proxy
+// provider; setting a delegate on that provider (once) is resolved lazily by the proxy, so
+// a provider registered after import is picked up. We must NOT call `trace.disable()` — it
+// swaps the global proxy provider for a fresh one, severing the module tracer's binding.
+const recordedSpans: RecordingSpan[] = [];
+let recordingTracerRegistered = false;
+
+/**
+ * Ensure a fake global tracer provider (whose spans are {@link RecordingSpan}s) is
+ * registered, clear any previously recorded spans, and return the shared recording list.
+ */
+function installRecordingTracer(): RecordingSpan[] {
+  recordedSpans.length = 0;
+  if (!recordingTracerRegistered) {
+    const tracer = {
+      startActiveSpan(_name: string, ...rest: unknown[]) {
+        // Supports the (name, options, fn) form the data store uses. Real OTel applies
+        // options.attributes at span creation, so mirror that here.
+        const fn = rest[rest.length - 1] as (span: Span) => unknown;
+        const options = rest.length > 1 ? (rest[0] as {attributes?: Attributes}) : undefined;
+        const span = new RecordingSpan();
+        if (options?.attributes) {
+          span.attributes = {...options.attributes};
+        }
+        recordedSpans.push(span);
+        return fn(span as unknown as Span);
+      },
+      startSpan() {
+        const span = new RecordingSpan();
+        recordedSpans.push(span);
+        return span as unknown as Span;
+      },
+    } as unknown as Tracer;
+    const provider: TracerProvider = {getTracer: () => tracer};
+    trace.setGlobalTracerProvider(provider);
+    recordingTracerRegistered = true;
+  }
+  return recordedSpans;
+}
 
 describe('DataStore', () => {
   let mockSend: sinon.SinonStub;
@@ -351,6 +451,112 @@ describe('DataStore', () => {
           expect(mockSend.firstCall.args[0].input.Key.projectEnvironment).to.equal(legacyKey);
         });
       }
+    });
+
+    describe('tracing', () => {
+      it('emits a successful span with db and found attributes on a hit', async () => {
+        const spans = installRecordingTracer();
+        mockSend.resolves({Item: {value: {theme: 'dark'}}});
+
+        await DataStore.getDataStore().getEntry('my-key');
+
+        expect(spans).to.have.lengthOf(1);
+        const [span] = spans;
+        expect(span.ended).to.equal(true);
+        // A successful fetch leaves the span status unset (defaults to UNSET, not ERROR).
+        expect(span.status).to.equal(undefined);
+        expect(span.exceptions).to.have.lengthOf(0);
+        expect(span.attributes).to.include({
+          'db.system': 'dynamodb',
+          'db.operation': 'GetItem',
+          'aws.dynamodb.table_names': 'DataAccessLayer-ca-central-1',
+          'mrt.data_store.found': true,
+        });
+      });
+
+      it('emits a span marking found=false on a miss, without an error status', async () => {
+        const spans = installRecordingTracer();
+        mockSend.resolves({}); // miss
+
+        try {
+          await DataStore.getDataStore().getEntry('my-key');
+          expect.fail('should have thrown');
+        } catch (e) {
+          expect(e).to.be.an.instanceOf(DataStoreNotFoundError);
+        }
+
+        expect(spans).to.have.lengthOf(1);
+        const [span] = spans;
+        expect(span.ended).to.equal(true);
+        // A miss is an expected outcome, not a service error: no ERROR status, no exception.
+        expect(span.status).to.equal(undefined);
+        expect(span.exceptions).to.have.lengthOf(0);
+        expect(span.attributes['mrt.data_store.found']).to.equal(false);
+      });
+
+      it('records the exception and an error status when the send throws', async () => {
+        const spans = installRecordingTracer();
+        const dynamoError = new Error('boom');
+        mockSend.rejects(dynamoError);
+        DataStore._testLogMRTError = sinon.stub();
+
+        try {
+          await DataStore.getDataStore().getEntry('my-key');
+          expect.fail('should have thrown');
+        } catch (e) {
+          expect(e).to.be.an.instanceOf(DataStoreServiceError);
+        }
+
+        expect(spans).to.have.lengthOf(1);
+        const [span] = spans;
+        expect(span.ended).to.equal(true);
+        expect(span.status?.code).to.equal(SpanStatusCode.ERROR);
+        expect(span.exceptions).to.deep.equal([dynamoError]);
+        expect(span.attributes).to.include({
+          'mrt.data_store.throttled': false,
+          'error.type': 'Error',
+        });
+        expect(span.attributes).to.not.have.property('mrt.data_store.found');
+      });
+
+      it('marks the span throttled when the send is throttled', async () => {
+        const spans = installRecordingTracer();
+        const dynamoError = new Error('rate exceeded');
+        dynamoError.name = 'ThrottlingException';
+        mockSend.rejects(dynamoError);
+        DataStore._testLogMRTError = sinon.stub();
+
+        try {
+          await DataStore.getDataStore().getEntry('my-key');
+          expect.fail('should have thrown');
+        } catch (e) {
+          expect(e).to.be.an.instanceOf(DataStoreServiceError);
+        }
+
+        const [span] = spans;
+        expect(span.attributes['mrt.data_store.throttled']).to.equal(true);
+        expect(span.attributes['error.type']).to.equal('ThrottlingException');
+      });
+
+      it('does not set error.type for a non-Error rejection but still ends the span', async () => {
+        const spans = installRecordingTracer();
+        mockSend.callsFake(() => Promise.reject('a string failure'));
+        DataStore._testLogMRTError = sinon.stub();
+
+        try {
+          await DataStore.getDataStore().getEntry('my-key');
+          expect.fail('should have thrown');
+        } catch (e) {
+          expect(e).to.be.an.instanceOf(DataStoreServiceError);
+        }
+
+        const [span] = spans;
+        expect(span.ended).to.equal(true);
+        expect(span.status?.code).to.equal(SpanStatusCode.ERROR);
+        // A non-Error rejection carries no name and is not recorded as an exception.
+        expect(span.attributes).to.not.have.property('error.type');
+        expect(span.exceptions).to.have.lengthOf(0);
+      });
     });
   });
 });

--- a/packages/mrt-utilities/test/data-store.test.ts
+++ b/packages/mrt-utilities/test/data-store.test.ts
@@ -454,7 +454,25 @@ describe('DataStore', () => {
     });
 
     describe('tracing', () => {
-      it('emits a successful span with db and found attributes on a hit', async () => {
+      // Attributes/events that would leak the DynamoDB backend to customer-visible traces.
+      // The span must never carry any of these.
+      const assertNoBackendLeak = (span: RecordingSpan) => {
+        expect(span.attributes).to.not.have.property('db.system');
+        expect(span.attributes).to.not.have.property('db.operation');
+        expect(span.attributes).to.not.have.property('aws.dynamodb.table_names');
+        expect(span.attributes).to.not.have.property('error.type');
+        // No raw SDK error (message/stack) recorded as a span event.
+        expect(span.exceptions).to.have.lengthOf(0);
+        // No attribute value should mention the backend or the internal table name.
+        for (const value of Object.values(span.attributes)) {
+          if (typeof value === 'string') {
+            expect(value.toLowerCase()).to.not.contain('dynamo');
+            expect(value).to.not.contain('DataAccessLayer');
+          }
+        }
+      };
+
+      it('emits a successful span marking found=true on a hit, with no backend detail', async () => {
         const spans = installRecordingTracer();
         mockSend.resolves({Item: {value: {theme: 'dark'}}});
 
@@ -465,13 +483,8 @@ describe('DataStore', () => {
         expect(span.ended).to.equal(true);
         // A successful fetch leaves the span status unset (defaults to UNSET, not ERROR).
         expect(span.status).to.equal(undefined);
-        expect(span.exceptions).to.have.lengthOf(0);
-        expect(span.attributes).to.include({
-          'db.system': 'dynamodb',
-          'db.operation': 'GetItem',
-          'aws.dynamodb.table_names': 'DataAccessLayer-ca-central-1',
-          'mrt.data_store.found': true,
-        });
+        expect(span.attributes['mrt.data_store.found']).to.equal(true);
+        assertNoBackendLeak(span);
       });
 
       it('emits a span marking found=false on a miss, without an error status', async () => {
@@ -488,13 +501,13 @@ describe('DataStore', () => {
         expect(spans).to.have.lengthOf(1);
         const [span] = spans;
         expect(span.ended).to.equal(true);
-        // A miss is an expected outcome, not a service error: no ERROR status, no exception.
+        // A miss is an expected outcome, not a service error: no ERROR status.
         expect(span.status).to.equal(undefined);
-        expect(span.exceptions).to.have.lengthOf(0);
         expect(span.attributes['mrt.data_store.found']).to.equal(false);
+        assertNoBackendLeak(span);
       });
 
-      it('records the exception and an error status when the send throws', async () => {
+      it('sets a generic error status when the send throws, without leaking the backend error', async () => {
         const spans = installRecordingTracer();
         const dynamoError = new Error('boom');
         mockSend.rejects(dynamoError);
@@ -511,15 +524,14 @@ describe('DataStore', () => {
         const [span] = spans;
         expect(span.ended).to.equal(true);
         expect(span.status?.code).to.equal(SpanStatusCode.ERROR);
-        expect(span.exceptions).to.deep.equal([dynamoError]);
-        expect(span.attributes).to.include({
-          'mrt.data_store.throttled': false,
-          'error.type': 'Error',
-        });
+        // Generic message only — no raw SDK error name/message/stack on the span.
+        expect(span.status?.message).to.equal('Data store request failed.');
+        expect(span.attributes['mrt.data_store.throttled']).to.equal(false);
         expect(span.attributes).to.not.have.property('mrt.data_store.found');
+        assertNoBackendLeak(span);
       });
 
-      it('marks the span throttled when the send is throttled', async () => {
+      it('marks the span throttled when the send is throttled, without naming the backend error', async () => {
         const spans = installRecordingTracer();
         const dynamoError = new Error('rate exceeded');
         dynamoError.name = 'ThrottlingException';
@@ -535,10 +547,11 @@ describe('DataStore', () => {
 
         const [span] = spans;
         expect(span.attributes['mrt.data_store.throttled']).to.equal(true);
-        expect(span.attributes['error.type']).to.equal('ThrottlingException');
+        // The DynamoDB-specific error name must not appear anywhere on the span.
+        assertNoBackendLeak(span);
       });
 
-      it('does not set error.type for a non-Error rejection but still ends the span', async () => {
+      it('still ends the span with an error status for a non-Error rejection', async () => {
         const spans = installRecordingTracer();
         mockSend.callsFake(() => Promise.reject('a string failure'));
         DataStore._testLogMRTError = sinon.stub();
@@ -553,9 +566,8 @@ describe('DataStore', () => {
         const [span] = spans;
         expect(span.ended).to.equal(true);
         expect(span.status?.code).to.equal(SpanStatusCode.ERROR);
-        // A non-Error rejection carries no name and is not recorded as an exception.
-        expect(span.attributes).to.not.have.property('error.type');
-        expect(span.exceptions).to.have.lengthOf(0);
+        expect(span.attributes['mrt.data_store.throttled']).to.equal(false);
+        assertNoBackendLeak(span);
       });
     });
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,6 +845,9 @@ importers:
       '@h4ad/serverless-adapter':
         specifier: 4.4.0
         version: 4.4.0(@types/aws-lambda@8.10.160)(@types/body-parser@1.19.6)(@types/cors@2.8.19)(@types/express@5.0.3)(body-parser@2.2.1)(cors@2.8.5)(express@5.1.0)(http-errors@2.0.1)
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
       change-case:
         specifier: 5.4.4
         version: 5.4.4
@@ -2665,14 +2668,17 @@ packages:
 
   '@modelcontextprotocol/inspector-cli@0.18.0':
     resolution: {integrity: sha512-QMPjKx8zKmX17S1LF2gWuwbYglKexkdgB0HhKZFXzGrQ0MYoKUsIgokMyV48xr4LipaLS3b2v3ut3nV/jhWeSg==}
+    deprecated: 'v1 is deprecated. Upgrade to v2: npm i @modelcontextprotocol/inspector@latest. v1 gets security fixes only, published under the v1-latest tag.'
     hasBin: true
 
   '@modelcontextprotocol/inspector-client@0.18.0':
     resolution: {integrity: sha512-M6A5SN09tYCoTTGwMi5hdQpesX5eHYn3FCAHTWfv1pZ1Cy7h5GjB1LxL5WhbMhXWmFFJ6AnQVGAJj0P0XkVhUg==}
+    deprecated: 'v1 is deprecated. Upgrade to v2: npm i @modelcontextprotocol/inspector@latest. v1 gets security fixes only, published under the v1-latest tag.'
     hasBin: true
 
   '@modelcontextprotocol/inspector-server@0.18.0':
     resolution: {integrity: sha512-N7mDwUuj+gB8ZbZ52M4Oqh37qChS8kWJUkc4qL/MMsaQTVshXEOTcyiQ/mLKa17O5uODZQerAnQJWZbZYReBkg==}
+    deprecated: 'v1 is deprecated. Upgrade to v2: npm i @modelcontextprotocol/inspector@latest. v1 gets security fixes only, published under the v1-latest tag.'
     hasBin: true
 
   '@modelcontextprotocol/inspector@0.18.0':
@@ -2766,6 +2772,10 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -11479,6 +11489,8 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@opentelemetry/api@1.9.1': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:


### PR DESCRIPTION
## What

Adds OpenTelemetry tracing to the data store fetch in `mrt-utilities`, and renames the internal adaptive-retry constants for naming consistency.

- **Span around the DynamoDB read.** `DataStore.getEntry` now wraps the underlying `GetCommand` in a client span, `mrt.data_store.getEntry`, created via `tracer.startActiveSpan`. The span carries semantic-convention DynamoDB attributes (`db.system`, `db.operation`, `aws.dynamodb.table_names`) and records the outcome:
  - hit/miss via `mrt.data_store.found`
  - `mrt.data_store.throttled` + `error.type` + `recordException` + `SpanStatusCode.ERROR` on the service-error path
  - a miss (`DataStoreNotFoundError`) is left UNSET — an expected outcome, not an error
- **Internal rename.** The private adaptive-retry constants `DAL_RETRY_MODE`, `DAL_MAX_ATTEMPTS`, `DAL_CONNECTION_TIMEOUT_MS`, `DAL_REQUEST_TIMEOUT_MS` are renamed to `DATA_STORE_*`. These are module-private, so there is no API change. The exported `createDalDynamoDBClient` is intentionally left as-is (renaming it would be a breaking change).

## Why

The data store read is the hot path for storefront config/theme lookups. A span makes its latency and failure/throttle behavior visible in the distributed trace that Managed Runtime already collects and ships from stdout.

## Design notes

- `mrt-utilities` depends only on **`@opentelemetry/api`** (zero-dependency, no-op-safe). It never registers a tracer provider — the host runtime owns that. When a provider is registered (the MRT storefront registers one that exports spans to stdout), the span joins the ambient trace; when none is registered (local dev, other consumers), `getTracer` returns a no-op tracer and nothing is emitted. No configuration required from consumers.
- `1.9.1` is pinned to align with the `@opentelemetry/api` version bundled by the MRT Lambda wrapper.
- ⚠️ **Reviewer note:** the storefront-next OTel setup documents that MRT runs a dual `@opentelemetry/api` bundle where the *global* tracer registry can be an unreliable no-op. This library uses the standard global `trace.getTracer(...)`. Worth confirming with the runtime owners that library-level spans surface in their pipeline; the fallback would be instrumenting at the storefront-next layer via `@opentelemetry/instrumentation-aws-sdk`.

## Testing

- 5 new tests cover the hit / miss / error / throttle / non-Error-rejection span paths, using a fake `@opentelemetry/api` tracer provider (no SDK dependency needed).
- Full `mrt-utilities` suite: **562 passing**. Typecheck, lint, and ESM+CJS build all clean.

Changeset: `minor` bump for `@salesforce/mrt-utilities`.