### PR TITLE
@W-23953663 fix(mrt): improve Brotli streaming performance

### DIFF
--- a/.changeset/fast-brotli-streaming.md
+++ b/.changeset/fast-brotli-streaming.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/mrt-utilities': patch
+---
+
+Improve streamed response performance by using a runtime-appropriate Brotli quality and periodically flushing compressed output.

--- a/.changeset/fast-brotli-streaming.md
+++ b/.changeset/fast-brotli-streaming.md
@@ -2,4 +2,4 @@
 '@salesforce/mrt-utilities': patch
 ---
 
-Improve streamed response performance by using a runtime-appropriate Brotli quality and periodically flushing compressed output.
+Improve streamed response performance by using a runtime-appropriate Brotli quality and periodically flushing compressed output. The Brotli quality and flush threshold can now be tuned via the `MRT_BROTLI_COMPRESSION_QUALITY` (0-11) and `MRT_BROTLI_FLUSH_THRESHOLD_BYTES` (bytes) environment variables, and the periodic flushing behavior can be disabled by setting `MRT_BROTLI_CHUNKING_ENABLED=false`.

--- a/docs/guide/mrt-utilities.md
+++ b/docs/guide/mrt-utilities.md
@@ -27,12 +27,12 @@ npm install @salesforce/mrt-utilities express
 
 ## Package exports
 
-| Export | Description |
-|--------|-------------|
-| **Main** (`@salesforce/mrt-utilities`) | Middleware factories, `isLocal`, and re-exports from subpaths |
-| **Middleware** (`@salesforce/mrt-utilities/middleware`) | MRT-style Express middleware and `ProxyConfig` type |
-| **Metrics** (`@salesforce/mrt-utilities/metrics`) | Metrics sending for MRT (e.g. CloudWatch) |
-| **Streaming** (`@salesforce/mrt-utilities/streaming`) | Lambda streaming adapter, Express request/response helpers, compression config |
+| Export                                                  | Description                                                                    |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| **Main** (`@salesforce/mrt-utilities`)                  | Middleware factories, `isLocal`, and re-exports from subpaths                  |
+| **Middleware** (`@salesforce/mrt-utilities/middleware`) | MRT-style Express middleware and `ProxyConfig` type                            |
+| **Metrics** (`@salesforce/mrt-utilities/metrics`)       | Metrics sending for MRT (e.g. CloudWatch)                                      |
+| **Streaming** (`@salesforce/mrt-utilities/streaming`)   | Lambda streaming adapter, Express request/response helpers, compression config |
 
 ## Basic setup
 
@@ -57,19 +57,17 @@ app.use(createMRTCommonMiddleware());
 
 if (isLocal()) {
   const requestProcessorPath = 'path/to/request-processor.js';
-  const proxyConfigs = [
-    { host: 'https://example.com', path: 'api' },
-  ];
+  const proxyConfigs = [{host: 'https://example.com', path: 'api'}];
 
   app.use(createMRTRequestProcessorMiddleware(requestProcessorPath, proxyConfigs));
 
   const mrtProxies = createMRTProxyMiddlewares(proxyConfigs);
-  mrtProxies.forEach(({ path, fn }) => app.use(path, fn));
+  mrtProxies.forEach(({path, fn}) => app.use(path, fn));
 
   const staticAssetDir = 'path/to/static';
   app.use(
     `/mobify/bundle/${process.env.BUNDLE_ID || '1'}/static/`,
-    createMRTStaticAssetServingMiddleware(staticAssetDir)
+    createMRTStaticAssetServingMiddleware(staticAssetDir),
   );
 }
 
@@ -98,8 +96,8 @@ Returns an array of `{ path, fn }` for mounting proxy middleware. Each entry pro
 
 ```typescript
 interface ProxyConfig {
-  host: string;   // e.g. 'https://example.com'
-  path: string;  // e.g. 'api'
+  host: string; // e.g. 'https://example.com'
+  path: string; // e.g. 'api'
 }
 ```
 
@@ -116,7 +114,7 @@ Removes internal MRT headers and sets any remaining response headers. **Use in a
 **isLocal()** returns `true` when not running in AWS Lambda (i.e. when `AWS_LAMBDA_FUNCTION_NAME` is not set). Use it to enable local-only middleware (request processor, proxies, local static assets).
 
 ```typescript
-import { isLocal } from '@salesforce/mrt-utilities';
+import {isLocal} from '@salesforce/mrt-utilities';
 
 if (isLocal()) {
   // Use local request processor, proxies, static assets
@@ -128,10 +126,7 @@ if (isLocal()) {
 For MRT’s Lambda runtime with streaming responses (e.g. SSR), use the **streaming** subpath:
 
 ```typescript
-import {
-  createStreamingLambdaAdapter,
-  type CompressionConfig,
-} from '@salesforce/mrt-utilities/streaming';
+import {createStreamingLambdaAdapter, type CompressionConfig} from '@salesforce/mrt-utilities/streaming';
 ```
 
 - **createStreamingLambdaAdapter**: Wraps your Express app so it can be invoked from Lambda with streaming support.
@@ -139,12 +134,22 @@ import {
 
 See the package source and tests for full adapter usage.
 
+### Tuning Brotli compression
+
+For streamed responses, Brotli defaults to a runtime-appropriate quality (`6`) and periodically flushes compressed output so bytes reach the client sooner. This can be tuned with environment variables:
+
+- `MRT_BROTLI_COMPRESSION_QUALITY`: Brotli quality level, `0`–`11` (defaults to `6`). Higher values compress more but cost more CPU. Values outside the valid range are ignored.
+- `MRT_BROTLI_FLUSH_THRESHOLD_BYTES`: Number of uncompressed bytes to buffer before forcing a Brotli flush (defaults to `32768`). Must be a positive integer; other values are ignored.
+- `MRT_BROTLI_CHUNKING_ENABLED`: Periodic flushing ("chunking") of Brotli output is enabled by default. Set to `false` to disable it and let Brotli buffer output until the response ends.
+
+An explicit Brotli quality set via `CompressionConfig.options.params` takes precedence over `MRT_BROTLI_COMPRESSION_QUALITY`.
+
 ## Metrics
 
 For sending metrics (e.g. to CloudWatch) in an MRT-compatible way:
 
 ```typescript
-import { MetricsSender } from '@salesforce/mrt-utilities/metrics';
+import {MetricsSender} from '@salesforce/mrt-utilities/metrics';
 ```
 
 Use when you need to emit metrics from the same process that serves requests (e.g. custom middleware or request processor).

--- a/packages/b2c-tooling-sdk/data/tooling/index.json
+++ b/packages/b2c-tooling-sdk/data/tooling/index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generatedAt": "2026-08-24T03:39:37.510Z",
+  "generatedAt": "2026-08-25T15:18:34.802Z",
   "entries": [
     {
       "id": "cli-account-manager",
@@ -368,7 +368,7 @@
       "category": "tooling",
       "url": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/mrt-utilities.html",
       "sourceUrl": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/mrt-utilities.md",
-      "headings": "When to use • Prerequisites • Installation • Package exports • Basic setup • Middleware • createMRTCommonMiddleware() • createMRTRequestProcessorMiddleware(requestProcessorPath, proxyConfigs) • createMRTProxyMiddlewares(proxyConfigs) • createMRTStaticAssetServingMiddleware(staticAssetDir) • createMRTCleanUpMiddleware() • Environment detection • Streaming (Lambda) • Metrics • Data Store In Development • Related",
+      "headings": "When to use • Prerequisites • Installation • Package exports • Basic setup • Middleware • createMRTCommonMiddleware() • createMRTRequestProcessorMiddleware(requestProcessorPath, proxyConfigs) • createMRTProxyMiddlewares(proxyConfigs) • createMRTStaticAssetServingMiddleware(staticAssetDir) • createMRTCleanUpMiddleware() • Environment detection • Streaming (Lambda) • Tuning Brotli compression • Metrics • Data Store In Development • Related",
       "preview": "Use the mrt-utilities package to simulate a deployed Managed Runtime environment locally with Express middleware and streaming adapters."
     },
     {

--- a/packages/mrt-utilities/src/streaming/create-lambda-adapter.ts
+++ b/packages/mrt-utilities/src/streaming/create-lambda-adapter.ts
@@ -28,6 +28,11 @@ import {ServerlessRequest} from '@h4ad/serverless-adapter';
  */
 const REQUEST_HEADERS_TO_COPY = ['x-correlation-id'] as const;
 
+// Node's Brotli default is quality 11, which is optimized for offline compression
+// and can consume seconds of Lambda CPU for large streamed HTML responses.
+const DEFAULT_BROTLI_QUALITY = 6;
+const BROTLI_FLUSH_THRESHOLD_BYTES = 32 * 1024;
+
 // Check if zstd compression is available (Node.js v22.15.0+)
 let createZstdCompress: ((options?: ZstdOptions) => ZstdCompress) | undefined;
 try {
@@ -306,7 +311,7 @@ function isCompressible(contentType: string | undefined): boolean {
   return !!compressible(contentType);
 }
 
-const isNullOrUndefined = (value: unknown): boolean => value == null;
+const isNullOrUndefined = (value: unknown): value is null | undefined => value == null;
 
 /**
  * Determines the best encoding based on Accept-Encoding header using the negotiator package
@@ -357,8 +362,22 @@ function getBestEncoding(
 function createCompressionStream(encoding: string, compressionConfig?: CompressionConfig): CompressionStream {
   const options = compressionConfig?.options || undefined;
   switch (encoding) {
-    case 'br':
-      return zlib.createBrotliCompress(options as BrotliOptions);
+    case 'br': {
+      const brotliOptions = options as BrotliOptions | undefined;
+      const qualityParameter = zlib.constants.BROTLI_PARAM_QUALITY;
+
+      if (brotliOptions?.params?.[qualityParameter] !== undefined) {
+        return zlib.createBrotliCompress(brotliOptions);
+      }
+
+      return zlib.createBrotliCompress({
+        ...brotliOptions,
+        params: {
+          ...brotliOptions?.params,
+          [qualityParameter]: DEFAULT_BROTLI_QUALITY,
+        },
+      });
+    }
     case 'zstd':
       if (!createZstdCompress) {
         throw new Error('zstd compression is not available in this Node.js version (requires v22.15.0+)');
@@ -414,6 +433,7 @@ export function createExpressResponse(
   let compressionStream: CompressionStream | null = null;
   let shouldCompress = false;
   let compressionInitialized = false;
+  let uncompressedBytesSinceBrotliFlush = 0;
 
   // Helper function to check if stream is still writable
   const isStreamOpen = (): boolean => {
@@ -471,7 +491,16 @@ export function createExpressResponse(
     try {
       if (shouldCompress && compressionStream && compressionStream.writable) {
         // Write to compression stream, which will compress and pipe to httpResponseStream
-        return compressionStream.write(chunk);
+        const accepted = compressionStream.write(chunk);
+        if (selectedEncoding === 'br' && typeof compressionStream.flush === 'function') {
+          uncompressedBytesSinceBrotliFlush += typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.byteLength;
+
+          if (uncompressedBytesSinceBrotliFlush >= BROTLI_FLUSH_THRESHOLD_BYTES) {
+            compressionStream.flush(zlib.constants.BROTLI_OPERATION_FLUSH);
+            uncompressedBytesSinceBrotliFlush = 0;
+          }
+        }
+        return accepted;
       } else if (httpResponseStream && httpResponseStream.writable) {
         // No compression, write directly to httpResponseStream
         return httpResponseStream.write(chunk);

--- a/packages/mrt-utilities/src/streaming/create-lambda-adapter.ts
+++ b/packages/mrt-utilities/src/streaming/create-lambda-adapter.ts
@@ -43,7 +43,6 @@ const DEFAULT_BROTLI_FLUSH_THRESHOLD_BYTES = 32 * 1024;
 function resolveBrotliQuality(): number {
   const raw = process.env.MRT_BROTLI_COMPRESSION_QUALITY;
   if (raw === undefined || raw.trim() === '') {
-    console.log('Using default Brotli quality:', DEFAULT_BROTLI_QUALITY);
     return DEFAULT_BROTLI_QUALITY;
   }
 
@@ -53,11 +52,9 @@ function resolveBrotliQuality(): number {
     parsed >= zlib.constants.BROTLI_MIN_QUALITY &&
     parsed <= zlib.constants.BROTLI_MAX_QUALITY
   ) {
-    console.log('Resolved Brotli quality:', parsed);
     return parsed;
   }
 
-  console.log('Default Brotli quality:', DEFAULT_BROTLI_QUALITY);
   return DEFAULT_BROTLI_QUALITY;
 }
 
@@ -71,17 +68,14 @@ function resolveBrotliQuality(): number {
 function resolveBrotliFlushThresholdBytes(): number {
   const raw = process.env.MRT_BROTLI_FLUSH_THRESHOLD_BYTES;
   if (raw === undefined || raw.trim() === '') {
-    console.log('Using default Brotli flush threshold bytes:', DEFAULT_BROTLI_FLUSH_THRESHOLD_BYTES);
     return DEFAULT_BROTLI_FLUSH_THRESHOLD_BYTES;
   }
 
   const parsed = Number(raw);
   if (Number.isInteger(parsed) && parsed > 0) {
-    console.log('Resolved Brotli flush threshold bytes:', parsed);
     return parsed;
   }
 
-  console.log('Default Brotli flush threshold bytes:', DEFAULT_BROTLI_FLUSH_THRESHOLD_BYTES);
   return DEFAULT_BROTLI_FLUSH_THRESHOLD_BYTES;
 }
 
@@ -94,11 +88,9 @@ function resolveBrotliFlushThresholdBytes(): number {
  */
 function isBrotliChunkingEnabled(): boolean {
   const raw = process.env.MRT_BROTLI_CHUNKING_ENABLED;
-  console.log('Brotli chunking enabled?:', raw);
   if (!raw) {
     return true;
   }
-  console.log('Using Brotli chunking:', raw);
   return raw.toLowerCase() !== 'false';
 }
 

--- a/packages/mrt-utilities/src/streaming/create-lambda-adapter.ts
+++ b/packages/mrt-utilities/src/streaming/create-lambda-adapter.ts
@@ -31,7 +31,76 @@ const REQUEST_HEADERS_TO_COPY = ['x-correlation-id'] as const;
 // Node's Brotli default is quality 11, which is optimized for offline compression
 // and can consume seconds of Lambda CPU for large streamed HTML responses.
 const DEFAULT_BROTLI_QUALITY = 6;
-const BROTLI_FLUSH_THRESHOLD_BYTES = 32 * 1024;
+const DEFAULT_BROTLI_FLUSH_THRESHOLD_BYTES = 32 * 1024;
+
+/**
+ * Resolves the Brotli compression quality from the MRT_BROTLI_COMPRESSION_QUALITY
+ * environment variable, falling back to DEFAULT_BROTLI_QUALITY. Values that are not
+ * integers within the valid Brotli quality range (0-11) are ignored.
+ *
+ * @returns The Brotli quality level to use.
+ */
+function resolveBrotliQuality(): number {
+  const raw = process.env.MRT_BROTLI_COMPRESSION_QUALITY;
+  if (raw === undefined || raw.trim() === '') {
+    console.log('Using default Brotli quality:', DEFAULT_BROTLI_QUALITY);
+    return DEFAULT_BROTLI_QUALITY;
+  }
+
+  const parsed = Number(raw);
+  if (
+    Number.isInteger(parsed) &&
+    parsed >= zlib.constants.BROTLI_MIN_QUALITY &&
+    parsed <= zlib.constants.BROTLI_MAX_QUALITY
+  ) {
+    console.log('Resolved Brotli quality:', parsed);
+    return parsed;
+  }
+
+  console.log('Default Brotli quality:', DEFAULT_BROTLI_QUALITY);
+  return DEFAULT_BROTLI_QUALITY;
+}
+
+/**
+ * Resolves the Brotli flush threshold (in bytes) from the MRT_BROTLI_FLUSH_THRESHOLD_BYTES
+ * environment variable, falling back to DEFAULT_BROTLI_FLUSH_THRESHOLD_BYTES.
+ * Values that are not positive integers are ignored.
+ *
+ * @returns The number of uncompressed bytes to buffer before forcing a Brotli flush.
+ */
+function resolveBrotliFlushThresholdBytes(): number {
+  const raw = process.env.MRT_BROTLI_FLUSH_THRESHOLD_BYTES;
+  if (raw === undefined || raw.trim() === '') {
+    console.log('Using default Brotli flush threshold bytes:', DEFAULT_BROTLI_FLUSH_THRESHOLD_BYTES);
+    return DEFAULT_BROTLI_FLUSH_THRESHOLD_BYTES;
+  }
+
+  const parsed = Number(raw);
+  if (Number.isInteger(parsed) && parsed > 0) {
+    console.log('Resolved Brotli flush threshold bytes:', parsed);
+    return parsed;
+  }
+
+  console.log('Default Brotli flush threshold bytes:', DEFAULT_BROTLI_FLUSH_THRESHOLD_BYTES);
+  return DEFAULT_BROTLI_FLUSH_THRESHOLD_BYTES;
+}
+
+/**
+ * Resolves whether periodic Brotli flushing ("chunking") is enabled from the
+ * MRT_BROTLI_CHUNKING_ENABLED environment variable. Defaults to enabled; set the
+ * variable to "false" to disable it and let Brotli buffer output until the response ends.
+ *
+ * @returns true if periodic Brotli flushing should be performed.
+ */
+function isBrotliChunkingEnabled(): boolean {
+  const raw = process.env.MRT_BROTLI_CHUNKING_ENABLED;
+  console.log('Brotli chunking enabled?:', raw);
+  if (!raw) {
+    return true;
+  }
+  console.log('Using Brotli chunking:', raw);
+  return raw.toLowerCase() !== 'false';
+}
 
 // Check if zstd compression is available (Node.js v22.15.0+)
 let createZstdCompress: ((options?: ZstdOptions) => ZstdCompress) | undefined;
@@ -374,7 +443,7 @@ function createCompressionStream(encoding: string, compressionConfig?: Compressi
         ...brotliOptions,
         params: {
           ...brotliOptions?.params,
-          [qualityParameter]: DEFAULT_BROTLI_QUALITY,
+          [qualityParameter]: resolveBrotliQuality(),
         },
       });
     }
@@ -434,6 +503,8 @@ export function createExpressResponse(
   let shouldCompress = false;
   let compressionInitialized = false;
   let uncompressedBytesSinceBrotliFlush = 0;
+  const brotliFlushThresholdBytes = resolveBrotliFlushThresholdBytes();
+  const brotliChunkingEnabled = isBrotliChunkingEnabled();
 
   // Helper function to check if stream is still writable
   const isStreamOpen = (): boolean => {
@@ -492,10 +563,10 @@ export function createExpressResponse(
       if (shouldCompress && compressionStream && compressionStream.writable) {
         // Write to compression stream, which will compress and pipe to httpResponseStream
         const accepted = compressionStream.write(chunk);
-        if (selectedEncoding === 'br' && typeof compressionStream.flush === 'function') {
+        if (brotliChunkingEnabled && selectedEncoding === 'br' && typeof compressionStream.flush === 'function') {
           uncompressedBytesSinceBrotliFlush += typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.byteLength;
 
-          if (uncompressedBytesSinceBrotliFlush >= BROTLI_FLUSH_THRESHOLD_BYTES) {
+          if (uncompressedBytesSinceBrotliFlush >= brotliFlushThresholdBytes) {
             compressionStream.flush(zlib.constants.BROTLI_OPERATION_FLUSH);
             uncompressedBytesSinceBrotliFlush = 0;
           }

--- a/packages/mrt-utilities/test/streaming/create-lambda-adapter-compression.test.ts
+++ b/packages/mrt-utilities/test/streaming/create-lambda-adapter-compression.test.ts
@@ -263,6 +263,152 @@ describe('Compression Streaming', () => {
       );
     });
 
+    describe('environment variable overrides', () => {
+      const originalQuality = process.env.MRT_BROTLI_COMPRESSION_QUALITY;
+      const originalFlushThreshold = process.env.MRT_BROTLI_FLUSH_THRESHOLD_BYTES;
+      const originalChunkingEnabled = process.env.MRT_BROTLI_CHUNKING_ENABLED;
+
+      afterEach(() => {
+        sinon.restore();
+        if (originalQuality === undefined) {
+          delete process.env.MRT_BROTLI_COMPRESSION_QUALITY;
+        } else {
+          process.env.MRT_BROTLI_COMPRESSION_QUALITY = originalQuality;
+        }
+        if (originalFlushThreshold === undefined) {
+          delete process.env.MRT_BROTLI_FLUSH_THRESHOLD_BYTES;
+        } else {
+          process.env.MRT_BROTLI_FLUSH_THRESHOLD_BYTES = originalFlushThreshold;
+        }
+        if (originalChunkingEnabled === undefined) {
+          delete process.env.MRT_BROTLI_CHUNKING_ENABLED;
+        } else {
+          process.env.MRT_BROTLI_CHUNKING_ENABLED = originalChunkingEnabled;
+        }
+      });
+
+      it('should use MRT_BROTLI_COMPRESSION_QUALITY when set to a valid value', async () => {
+        process.env.MRT_BROTLI_COMPRESSION_QUALITY = '11';
+        const stream = createCollectingStream();
+        const event = createMockEvent({headers: {'Accept-Encoding': 'br'}});
+        const context = createMockContext();
+        const request = createExpressRequest(event, context);
+        const createBrotliStub = sinon.stub(zlib, 'createBrotliCompress').callThrough();
+        const response = createExpressResponse(stream, event, context, request);
+
+        response.setHeader('Content-Type', 'text/html');
+        response.end('test data');
+
+        await stream.waitForEnd();
+
+        expect(
+          createBrotliStub.calledWith({
+            params: {
+              [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+            },
+          }),
+        ).to.be.true;
+      });
+
+      it('should ignore an out-of-range MRT_BROTLI_COMPRESSION_QUALITY and fall back to the default', async () => {
+        process.env.MRT_BROTLI_COMPRESSION_QUALITY = '99';
+        const stream = createCollectingStream();
+        const event = createMockEvent({headers: {'Accept-Encoding': 'br'}});
+        const context = createMockContext();
+        const request = createExpressRequest(event, context);
+        const createBrotliStub = sinon.stub(zlib, 'createBrotliCompress').callThrough();
+        const response = createExpressResponse(stream, event, context, request);
+
+        response.setHeader('Content-Type', 'text/html');
+        response.end('test data');
+
+        await stream.waitForEnd();
+
+        expect(
+          createBrotliStub.calledWith({
+            params: {
+              [zlib.constants.BROTLI_PARAM_QUALITY]: 6,
+            },
+          }),
+        ).to.be.true;
+      });
+
+      it('should flush Brotli output sooner when MRT_BROTLI_FLUSH_THRESHOLD_BYTES is small', async () => {
+        process.env.MRT_BROTLI_FLUSH_THRESHOLD_BYTES = '16';
+        const stream = createCollectingStream();
+        const event = createMockEvent({headers: {'Accept-Encoding': 'br'}});
+        const context = createMockContext();
+        const request = createExpressRequest(event, context);
+        const response = createExpressResponse(stream, event, context, request);
+        const firstCompressedChunk = new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(() => reject(new Error('Brotli output was not flushed before end()')), 500);
+          stream.once('data', () => {
+            clearTimeout(timeout);
+            resolve();
+          });
+        });
+
+        response.setHeader('Content-Type', 'text/html');
+        // Well above the 16-byte threshold, so the write forces an early flush
+        response.write('x'.repeat(200));
+
+        await firstCompressedChunk;
+        expect(stream.getData().length).to.be.greaterThan(0);
+
+        response.end('done');
+        await stream.waitForEnd();
+
+        expect(zlib.brotliDecompressSync(stream.getData()).toString()).to.equal(`${'x'.repeat(200)}done`);
+      });
+
+      it('should not flush Brotli output early when MRT_BROTLI_FLUSH_THRESHOLD_BYTES is large', async () => {
+        // 10 MiB threshold is well above the default 32 KiB, so a 40 KiB write should
+        // not trigger an early flush the way it would under the default threshold.
+        process.env.MRT_BROTLI_FLUSH_THRESHOLD_BYTES = String(10 * 1024 * 1024);
+        const stream = createCollectingStream();
+        const event = createMockEvent({headers: {'Accept-Encoding': 'br'}});
+        const context = createMockContext();
+        const request = createExpressRequest(event, context);
+        const response = createExpressResponse(stream, event, context, request);
+
+        response.setHeader('Content-Type', 'text/html');
+        response.write('x'.repeat(40 * 1024));
+
+        // Give any asynchronous flush a chance to emit before asserting nothing was written yet
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(stream.getData().length).to.equal(0);
+
+        response.end();
+        await stream.waitForEnd();
+
+        expect(zlib.brotliDecompressSync(stream.getData()).toString()).to.equal('x'.repeat(40 * 1024));
+      });
+
+      it('should not flush Brotli output early when MRT_BROTLI_CHUNKING_ENABLED is false', async () => {
+        // Chunking disabled: even a write that exceeds the (small) flush threshold must not
+        // force an early flush, so no compressed bytes are emitted until the response ends.
+        process.env.MRT_BROTLI_CHUNKING_ENABLED = 'false';
+        process.env.MRT_BROTLI_FLUSH_THRESHOLD_BYTES = '16';
+        const stream = createCollectingStream();
+        const event = createMockEvent({headers: {'Accept-Encoding': 'br'}});
+        const context = createMockContext();
+        const request = createExpressRequest(event, context);
+        const response = createExpressResponse(stream, event, context, request);
+
+        response.setHeader('Content-Type', 'text/html');
+        response.write('x'.repeat(200));
+
+        // Give any asynchronous flush a chance to emit before asserting nothing was written yet
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(stream.getData().length).to.equal(0);
+
+        response.end('done');
+        await stream.waitForEnd();
+
+        expect(zlib.brotliDecompressSync(stream.getData()).toString()).to.equal(`${'x'.repeat(200)}done`);
+      });
+    });
+
     it('should compress content with brotli when br is preferred', async () => {
       const stream = createCollectingStream();
       const event = createMockEvent({headers: {'Accept-Encoding': 'br, gzip, deflate'}});

--- a/packages/mrt-utilities/test/streaming/create-lambda-adapter-compression.test.ts
+++ b/packages/mrt-utilities/test/streaming/create-lambda-adapter-compression.test.ts
@@ -212,6 +212,57 @@ describe('Compression Streaming', () => {
   });
 
   describe('Brotli compression', () => {
+    it('should default to a streaming-appropriate compression quality', async () => {
+      const stream = createCollectingStream();
+      const event = createMockEvent({headers: {'Accept-Encoding': 'br'}});
+      const context = createMockContext();
+      const request = createExpressRequest(event, context);
+      const createBrotliStub = sinon.stub(zlib, 'createBrotliCompress').callThrough();
+      const response = createExpressResponse(stream, event, context, request);
+
+      response.setHeader('Content-Type', 'text/html');
+      response.end('test data');
+
+      await stream.waitForEnd();
+
+      expect(
+        createBrotliStub.calledWith({
+          params: {
+            [zlib.constants.BROTLI_PARAM_QUALITY]: 6,
+          },
+        }),
+      ).to.be.true;
+      createBrotliStub.restore();
+    });
+
+    it('should emit compressed bytes before the response ends', async () => {
+      const stream = createCollectingStream();
+      const event = createMockEvent({headers: {'Accept-Encoding': 'br'}});
+      const context = createMockContext();
+      const request = createExpressRequest(event, context);
+      const response = createExpressResponse(stream, event, context, request);
+      const firstCompressedChunk = new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('Brotli output was not flushed before end()')), 500);
+        stream.once('data', () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+
+      response.setHeader('Content-Type', 'text/html');
+      response.write('streamed html '.repeat(3_000));
+
+      await firstCompressedChunk;
+      expect(stream.getData().length).to.be.greaterThan(0);
+
+      response.end('final chunk');
+      await stream.waitForEnd();
+
+      expect(zlib.brotliDecompressSync(stream.getData()).toString()).to.equal(
+        `${'streamed html '.repeat(3_000)}final chunk`,
+      );
+    });
+
     it('should compress content with brotli when br is preferred', async () => {
       const stream = createCollectingStream();
       const event = createMockEvent({headers: {'Accept-Encoding': 'br, gzip, deflate'}});


### PR DESCRIPTION
## Summary

- use Brotli quality 6 by default for dynamic streaming responses instead of Node's implicit quality 11
- flush Brotli after each 32 KiB of uncompressed input so progressive SSR chunks reach the client promptly
- preserve an explicitly configured Brotli quality and all other caller-supplied options
- add regression coverage for the default quality and pre-`end()` compressed output

## Why

Node's implicit Brotli quality 11 is optimized for offline compression. On a production-like 1.6 MB Storefront Next PLP response, it consumed seconds of Lambda time and buffered useful compressed output until the response completed. This also affects traffic through an upstream CDN because the CDN requests Brotli/Gzip from MRT before passing through or transforming the response for the visitor.

Controlled warmed A/B measurements using the same application bundle showed:

| Measurement | Original | Patched | Improvement |
| --- | ---: | ---: | ---: |
| MRT-origin Brotli total | 3.659 s | 0.709 s | **5.2× faster** |
| MRT-origin post-header tail | 3.074 s | 0.077 s | **39.9× shorter** |
| CDN Brotli total | 3.810 s | 0.775 s | **4.9× faster** |

The compressed response grew from approximately 102 KB to 125 KB (about 23%) in exchange for eliminating roughly three seconds of response time and restoring progressive delivery. A local compression-only benchmark of the same 1.6 MB document improved from 1,641 ms at quality 11 to 9.45 ms at quality 6.

## Validation

- `pnpm --filter @salesforce/mrt-utilities test:agent` — 559 passing
- `pnpm --filter @salesforce/mrt-utilities typecheck:agent`
- `pnpm --filter @salesforce/mrt-utilities lint:agent`
- `pnpm --filter @salesforce/mrt-utilities format:check`
- `pnpm --filter @salesforce/mrt-utilities build`

## Companion change

Storefront Next currently bundles a separate copy of this streaming adapter. The companion draft PR applies and tests the same fix there: commerce-emu/storefront-next#2648.
