### PR TITLE
@W-23735172: Test new shards in MRT FIT test fixture

### DIFF
--- a/packages/mrt-reference-app/src/utils/isolation-actions.ts
+++ b/packages/mrt-reference-app/src/utils/isolation-actions.ts
@@ -80,17 +80,24 @@ export const isolationDalTest = async (input: {dalKey?: string; dalProjectEnviro
   }
   const tableName = `DataAccessLayer-${process.env.AWS_REGION}`;
   const ddbClient = DynamoDBDocumentClient.from(new DynamoDBClient({region: process.env.AWS_REGION}));
-  try {
-    await ddbClient.send(
-      new GetCommand({
-        TableName: tableName,
-        Key: {projectEnvironment: input.dalProjectEnvironment, key: input.dalKey},
-      }),
-    );
-  } catch (e) {
-    if (hasErrorName(e, 'AccessDeniedException')) return true;
-    console.error(e);
-  }
+  const readIsDenied = async (projectEnvironment: string): Promise<boolean> => {
+    try {
+      await ddbClient.send(
+        new GetCommand({TableName: tableName, Key: {projectEnvironment, key: input.dalKey}}),
+      );
+      return false; // read allowed → NOT isolated
+    } catch (e) {
+      if (hasErrorName(e, 'AccessDeniedException')) return true;
+      console.error(e);
+      return false; // unexpected error → do not count as isolated
+    }
+  };
+  // Both the legacy (shard 0) partition and a suffixed shard partition of
+  // Target A must be denied to Target B (W-23735172 widened LeadingKeys to a
+  // space-anchored StringLike wildcard; this proves it can't cross tenants).
+  const legacyDenied = await readIsDenied(input.dalProjectEnvironment);
+  const shardDenied = await readIsDenied(`${input.dalProjectEnvironment} 1`);
+  if (legacyDenied && shardDenied) return true;
   console.error("DAL isolation test failed: Target B accessed Target A's DAL entry");
   return false;
 };

--- a/packages/mrt-reference-app/src/utils/isolation-actions.ts
+++ b/packages/mrt-reference-app/src/utils/isolation-actions.ts
@@ -82,9 +82,7 @@ export const isolationDalTest = async (input: {dalKey?: string; dalProjectEnviro
   const ddbClient = DynamoDBDocumentClient.from(new DynamoDBClient({region: process.env.AWS_REGION}));
   const readIsDenied = async (projectEnvironment: string): Promise<boolean> => {
     try {
-      await ddbClient.send(
-        new GetCommand({TableName: tableName, Key: {projectEnvironment, key: input.dalKey}}),
-      );
+      await ddbClient.send(new GetCommand({TableName: tableName, Key: {projectEnvironment, key: input.dalKey}}));
       return false; // read allowed → NOT isolated
     } catch (e) {
       if (hasErrorName(e, 'AccessDeniedException')) return true;


### PR DESCRIPTION
## Summary

Updates the FIT fixtures so that both the legacy and new data store shards are exercised by the FIT isolation tests.

## Testing

Deployed the bundle to my Cloud, verified the endpoint returns a successful DAL isolation response:
```
{
    "origin": false,
    "storage": false,
    "logs": true,
    "dal": true
}
```

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [ ] Tests pass (`pnpm test`)
- [ ] Code is formatted (`pnpm run format`)
