### PR TITLE
fix(debug): deemphasize dwsid affinity guidance

### DIFF
--- a/.changeset/quiet-debug-affinity-guidance.md
+++ b/.changeset/quiet-debug-affinity-guidance.md
@@ -1,0 +1,8 @@
+---
+'@salesforce/b2c-tooling-sdk': patch
+'@salesforce/b2c-dx-mcp': patch
+'@salesforce/b2c-dx-docs': patch
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Keep debugger server-affinity guidance as a rare PIG-only troubleshooting note instead of prompting users and agents to use `dwsid` during routine debugging.

--- a/docs/guide/script-debugger.md
+++ b/docs/guide/script-debugger.md
@@ -24,31 +24,7 @@ The **VS Code extension is the recommended interface** for interactive debugging
 
 They all share the same workflow: connect a session, set breakpoints (by local file path, cartridge-prefixed path, or server path), trigger the code on the instance, then inspect the halted thread.
 
-## Server affinity (hitting breakpoints)
-
-A breakpoint only fires when the code runs on the **same application server** the debugger is attached to. On a single-app-server environment this is automatic. But some **Production Instance Group (PIG)** environments run **multiple application servers** behind a load balancer — there, a request that triggers your code may land on a different app server than the debugger, and the breakpoint never fires.
-
-> **Sandboxes (ODS) are single-app-server and are not affected.** This only matters on certain multi-app-server PIG environments.
-
-To pin a triggering request to the correct app server, send it with the debugger's session cookie (`dwsid`). How you obtain the value depends on the interface:
-
-- **MCP:** `debug_start_session` and `debug_list_sessions` return a `session_cookie` (`{name, value}`). See [Script Debugger → Server affinity](/mcp/tools/diagnostics#server-affinity-hitting-breakpoints).
-- **VS Code:** the cookie is logged to the extension output channel when the session connects, and the **Copy Debugger Session ID (dwsid)** command copies it to your clipboard.
-- **CLI:** the cookie is logged when the session connects (`Debug session cookie: dwsid=…`).
-
-Send the request that triggers your code — a browser session, `curl`, an integration test — with that cookie:
-
-```
-Cookie: dwsid=<value>
-```
-
-For headless requests where you can't (or don't want to) set a cookie — server-to-server calls that trigger hooks, custom APIs, or SCAPI/OCAPI endpoints — pass the same value as the `sfdc_dwsid` request header instead:
-
-```
-sfdc_dwsid: <value>
-```
-
-If you cannot set the cookie or header on the triggering request, you may need to retry until the load balancer happens to route to the attached app server.
+> **Rare PIG-only troubleshooting:** If a breakpoint is never hit after confirming the request exercises the expected code and the source mapping is correct, the request may be reaching a different app server on a multi-app-server Production Instance Group. In that case, use **Copy Debugger Session ID (dwsid)** in VS Code or the MCP session's `session_cookie`, then send the triggering request with `Cookie: dwsid=<value>` (or `sfdc_dwsid: <value>` for a headless request). Sandboxes are single-app-server and never need this.
 
 ## See Also
 

--- a/docs/mcp/tools/diagnostics.md
+++ b/docs/mcp/tools/diagnostics.md
@@ -45,7 +45,7 @@ Start a new script debugger session. Connects to the SDAPI, discovers cartridge 
 | `instanceName`       | string | No       | Active/default instance       | Named instance selected from the primary configuration first, then the shared default `dw.json`.                                                             |
 | `cartridgeDirectory` | string | No       | `projectDirectory`            | Cartridge discovery and source-mapping root only. Use when cartridges are outside the project root; relative paths resolve from project root.                |
 
-**Returns:** `session_id`, `hostname`, discovered `cartridges`, `resolution`, `session_cookie` (see [Server affinity](#server-affinity-hitting-breakpoints)), and `warnings`. The session retains its resolution context; `debug_list_sessions` returns it for later follow-up calls.
+**Returns:** `session_id`, `hostname`, discovered `cartridges`, `resolution`, and `warnings`. The session retains its resolution context; `debug_list_sessions` returns it for later follow-up calls.
 
 ### debug_end_session
 
@@ -58,37 +58,9 @@ End a script debugger session. Disconnects from the SDAPI, stops polling, and cl
 
 ### debug_list_sessions
 
-List all active debug sessions. Returns session IDs, connected hostnames, any currently halted threads, armed breakpoints, and each session's `session_cookie` (see [Server affinity](#server-affinity-hitting-breakpoints)).
+List all active debug sessions. Returns session IDs, connected hostnames, any currently halted threads, and armed breakpoints.
 
 No parameters.
-
----
-
-## Server affinity (hitting breakpoints)
-
-> **Most sessions don't need this.** Set your breakpoint and trigger the request as usual. Only reach for the session cookie when a breakpoint is _never_ hit even though you're sure the request exercises that code — and only in the specific **production instance group** configurations that run multiple app servers. This never applies to sandboxes.
-
-Some production instance group configurations run multiple application servers behind a load balancer. The debugger attaches to **one** app server, and a breakpoint only fires when your code executes on that same server. Sandboxes run a single app server, so this never comes up there.
-
-If a breakpoint won't hit for this reason, pin the triggering request to the correct app server using the `session_cookie` returned by `debug_start_session` and `debug_list_sessions`:
-
-```json
-{"name": "dwsid", "value": "abc123..."}
-```
-
-Send your triggering request — a storefront page load, a SCAPI/OCAPI call, etc. — with this cookie so it lands on the app server holding the debug session:
-
-```
-Cookie: dwsid=abc123...
-```
-
-For headless server-to-server requests that trigger hooks, custom APIs, or SCAPI/OCAPI endpoints — where setting a cookie is awkward — pass the same value as the `sfdc_dwsid` request header instead:
-
-```
-sfdc_dwsid: abc123...
-```
-
-If `session_cookie` is `null`, the debugger did not establish a session cookie; a warning is included and breakpoints may not be reliably hit on multi-app-server instances.
 
 ---
 

--- a/docs/vscode-extension/index.md
+++ b/docs/vscode-extension/index.md
@@ -20,8 +20,6 @@ Step through anything that runs server-side: cartridge controllers, jobs, custom
 
 [![B2C Script Debugger](./images/script-debugger.png)](./images/script-debugger.png)
 
-On multi-app-server environments, a breakpoint only fires when the triggering request reaches the app server the debugger is attached to. While a debug session is active, run **Copy Debugger Session ID (dwsid)** from the Command Palette to copy the session cookie, then send your triggering request (e.g. in the browser) with `Cookie: dwsid=<value>`. See the [Script Debugger guide](../guide/script-debugger#server-affinity-hitting-breakpoints) for details.
-
 ### Scaffolding
 
 Generate new cartridges, controllers, hooks, jobs, and other boilerplate from a curated set of templates. Available from **File → New File...** or by right-clicking a folder in the Explorer.

--- a/packages/b2c-dx-mcp/src/tools/diagnostics/debug-capture-at-breakpoint.ts
+++ b/packages/b2c-dx-mcp/src/tools/diagnostics/debug-capture-at-breakpoint.ts
@@ -47,13 +47,7 @@ interface CaptureOutput {
   evaluations?: Array<{expression: string; result: string}>;
   auto_continued: boolean;
   trigger_status?: number;
-  hint?: string;
 }
-
-const TIMEOUT_HINT =
-  'Breakpoint not hit. First confirm the triggered request actually exercised this code path and the breakpoint line is reachable. ' +
-  'In some production instance group configurations (which can run multiple app servers — this never applies to sandboxes), a breakpoint may be missed because the request landed on a different app server than the one holding the debug session. ' +
-  'Only in that specific case, retrieve session_cookie from debug_list_sessions and resend the triggering request with that cookie (Cookie: <name>=<value>) to pin it to the app server holding the session.';
 
 export function createDebugCaptureAtBreakpointTool(
   loadServices: () => Promise<Services> | Services,
@@ -126,7 +120,6 @@ export function createDebugCaptureAtBreakpointTool(
             halted: false,
             timed_out: true,
             auto_continued: false,
-            hint: TIMEOUT_HINT,
           };
         }
 

--- a/packages/b2c-dx-mcp/src/tools/diagnostics/debug-start-session.ts
+++ b/packages/b2c-dx-mcp/src/tools/diagnostics/debug-start-session.ts
@@ -115,11 +115,6 @@ export function createDebugStartSessionTool(
         for (const c of cartridges) cartridgeMappings[c.name] = c.src;
 
         const dwsid = manager.getSessionCookie();
-        if (!dwsid) {
-          warnings.push(
-            'No session cookie (dwsid) was returned by the debugger. Requests cannot be pinned to this app server; breakpoints may not be hit on multi-app-server instances.',
-          );
-        }
 
         return {
           session_id: entry.sessionId,

--- a/packages/b2c-dx-mcp/src/tools/diagnostics/debug-wait-for-stop.ts
+++ b/packages/b2c-dx-mcp/src/tools/diagnostics/debug-wait-for-stop.ts
@@ -25,13 +25,7 @@ interface WaitForStopOutput {
   timed_out?: boolean;
   thread_id?: number;
   location?: MappedLocation;
-  hint?: string;
 }
-
-const TIMEOUT_HINT =
-  'Breakpoint not hit. First confirm the request actually exercised this code path and the breakpoint line is reachable. ' +
-  'In some production instance group configurations (which can run multiple app servers — this never applies to sandboxes), a breakpoint may be missed because the request landed on a different app server than the one holding the debug session. ' +
-  'Only in that specific case, retrieve session_cookie from debug_list_sessions and resend the triggering request with that cookie (Cookie: <name>=<value>) to pin it to the app server holding the session.';
 
 export function createDebugWaitForStopTool(
   loadServices: () => Promise<Services> | Services,
@@ -58,7 +52,7 @@ export function createDebugWaitForStopTool(
         const timeout = Math.min(args.timeout_ms ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 
         const thread = await getRegistry(context).waitForHalt(entry, timeout);
-        if (!thread) return {halted: false, timed_out: true, hint: TIMEOUT_HINT};
+        if (!thread) return {halted: false, timed_out: true};
 
         const location = projectThreadLocation(thread, entry.sourceMapper);
         return {

--- a/packages/b2c-dx-mcp/test/tools/diagnostics/debug-tools.test.ts
+++ b/packages/b2c-dx-mcp/test/tools/diagnostics/debug-tools.test.ts
@@ -715,6 +715,7 @@ describe('tools/diagnostics', () => {
       const json = getResultJson<{halted: boolean; timed_out?: boolean}>(result);
       expect(json.halted).to.be.false;
       expect(json.timed_out).to.be.true;
+      expect(json).not.to.have.property('hint');
     });
 
     it('should resolve when onThreadStopped callback fires', async () => {
@@ -875,6 +876,7 @@ describe('tools/diagnostics', () => {
       const json = getResultJson<{halted: boolean; timed_out?: boolean}>(result);
       expect(json.halted).to.be.false;
       expect(json.timed_out).to.be.true;
+      expect(json).not.to.have.property('hint');
     });
 
     it('should fire trigger_url in background', async () => {
@@ -1138,14 +1140,14 @@ describe('tools/diagnostics', () => {
       expect(json).to.not.have.own.property('projectDirectory');
     });
 
-    it('should return null session_cookie and warn when no dwsid is set', async () => {
+    it('should return null session_cookie without warning when no dwsid is set', async () => {
       (DebugSessionManager.prototype.getSessionCookie as sinon.SinonStub).returns(undefined);
       const tool = createDebugStartSessionTool(loadServices, serverContext);
       const result = await tool.handler({projectDirectory: tmpDir});
 
       const json = getResultJson<{session_cookie: unknown; warnings: string[]}>(result);
       expect(json.session_cookie).to.be.null;
-      expect(json.warnings.some((w) => w.includes('dwsid'))).to.be.true;
+      expect(json.warnings).to.be.empty;
     });
 
     it('should warn when no cartridges found', async () => {

--- a/packages/b2c-tooling-sdk/data/tooling/index.json
+++ b/packages/b2c-tooling-sdk/data/tooling/index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generatedAt": "2026-08-20T01:15:39.329Z",
+  "generatedAt": "2026-08-24T03:39:37.510Z",
   "entries": [
     {
       "id": "cli-account-manager",
@@ -395,7 +395,7 @@
       "category": "tooling",
       "url": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/script-debugger.html",
       "sourceUrl": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/script-debugger.md",
-      "headings": "Requirements • Choosing an interface • Server affinity (hitting breakpoints) • See Also",
+      "headings": "Requirements • Choosing an interface • See Also",
       "preview": "Debug server-side B2C Commerce scripts (controllers, hooks, jobs, custom APIs) with the Script Debugger — via the VS Code extension, the CLI DAP debug adapter, or the MCP diagnostics tools."
     },
     {
@@ -485,7 +485,7 @@
       "category": "tooling",
       "url": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/mcp/tools/diagnostics.html",
       "sourceUrl": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/mcp/tools/diagnostics.md",
-      "headings": "Authentication • Recovery from broken or orphaned sessions • Session Lifecycle • debug_start_session • debug_end_session • debug_list_sessions • Server affinity (hitting breakpoints) • Breakpoints • debug_set_breakpoints • Execution Control • debug_wait_for_stop • debug_continue • debug_step_over • debug_step_into • debug_step_out • Inspection • debug_get_stack • debug_get_variables • debug_evaluate • Higher-Level Tools • debug_capture_at_breakpoint • See Also",
+      "headings": "Authentication • Recovery from broken or orphaned sessions • Session Lifecycle • debug_start_session • debug_end_session • debug_list_sessions • Breakpoints • debug_set_breakpoints • Execution Control • debug_wait_for_stop • debug_continue • debug_step_over • debug_step_into • debug_step_out • Inspection • debug_get_stack • debug_get_variables • debug_evaluate • Higher-Level Tools • debug_capture_at_breakpoint • See Also",
       "preview": "MCP tools for script debugging on B2C Commerce instances via the Script Debugger API (SDAPI)."
     },
     {

--- a/packages/b2c-tooling-sdk/src/operations/debug/debug-session.ts
+++ b/packages/b2c-tooling-sdk/src/operations/debug/debug-session.ts
@@ -76,17 +76,6 @@ export class DebugSessionManager {
 
       this.logger.debug('Script debugger connected');
 
-      // Surface the session cookie at info level so users driving the debugger
-      // from the CLI or VS Code (B2C DX output channel) can route a triggering
-      // request to the same app server — required to hit breakpoints on
-      // multi-app-server PIG environments. See getSessionCookie().
-      const dwsid = this.client.getCookie('dwsid');
-      if (dwsid) {
-        this.logger.info(
-          `Debug session cookie: dwsid=${dwsid} — send your triggering request (storefront page, SCAPI/OCAPI call) with this cookie to hit breakpoints on multi-app-server instances.`,
-        );
-      }
-
       this.callbacks.onConnected?.(this.config.hostname);
     } catch (err) {
       // Ensure timers are cleared if anything (incl. onConnected callback) throws

--- a/skills/b2c-cli/skills/b2c-debug/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-debug/SKILL.md
@@ -131,20 +131,6 @@ b2c debug
 
 This starts a DAP debug adapter over stdio, used by IDE launch configurations.
 
-## Server Affinity (Hitting Breakpoints)
-
-A breakpoint only fires when the triggering code runs on the **same application server** the debugger is attached to. Some **Production Instance Group (PIG)** environments run **multiple application servers** behind a load balancer, so a request that should hit your breakpoint may land on a different app server and the breakpoint never fires.
-
-> **Sandboxes (ODS) are single-app-server and are not affected.** This only matters on certain multi-app-server PIG environments. If breakpoints are not hitting on a sandbox, the cause is something else (wrong path mapping, code version, or the code simply not running).
-
-To pin a triggering request to the correct app server, send it with the debugger's session cookie (`dwsid`):
-
-- **MCP:** `debug_start_session` and `debug_list_sessions` return a `session_cookie` (`{name, value}`). Send the request that triggers your code (storefront page load, SCAPI/OCAPI call) with `Cookie: dwsid=<value>`.
-- **Any trigger:** whatever issues the request — a browser, `curl`, an integration test — must carry the same `dwsid` value.
-- **Headless requests (hooks, custom APIs, server-to-server SCAPI/OCAPI):** instead of a cookie, pass the value as the `sfdc_dwsid` request header (`sfdc_dwsid: <value>`).
-
-If the cookie or header cannot be set on the triggering request, retry until the load balancer routes to the attached app server.
-
 ## Related Skills
 
 - `b2c-cli:b2c-logs` - Retrieve server logs for investigating errors found during debugging


### PR DESCRIPTION
## Summary

- remove dwsid server-affinity instructions from the debug agent skill and routine MCP/runtime guidance
- keep one compact PIG-only troubleshooting note in the Script Debugger guide
- preserve the underlying session cookie capability for the rare applicable configuration

## Validation

- pnpm --filter @salesforce/b2c-dx-mcp run test:agent (534 passing)
- pnpm --filter @salesforce/b2c-tooling-sdk run test:agent (2,259 passing, 7 pending)
- pnpm run lint:agent
- pnpm run typecheck:agent
- pnpm --filter @salesforce/b2c-tooling-sdk run check:tooling-index
- debug skill validation
- targeted Prettier formatting passed

The full workspace format check still reports the existing unmodified packages/b2c-vs-extension/src/cip-analytics/cip-styles.css file.