### PR TITLE
Use configured IDs for SLAS client commands

### DIFF
--- a/.changeset/slas-get-config-client.md
+++ b/.changeset/slas-get-config-client.md
@@ -1,0 +1,8 @@
+---
+'@salesforce/b2c-cli': patch
+'@salesforce/b2c-tooling-sdk': patch
+'@salesforce/b2c-dx-docs': patch
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Allow SLAS client `get`, `update`, `delete`, and `open` commands to use the configured SLAS client ID when their positional client ID is omitted, while keeping the positional value as an explicit override.

--- a/docs/cli/slas.md
+++ b/docs/cli/slas.md
@@ -149,6 +149,10 @@ These values can also be set in `dw.json`:
 }
 ```
 
+### Existing Client Selection
+
+The `get`, `update`, `delete`, and `open` commands use the configured `slasClientId` when their positional `CLIENTID` is omitted. The value can come from `dw.json`, `SFCC_SLAS_CLIENT_ID`, `--slas-client-id`, the active instance, or a configuration plugin. A positional `CLIENTID` takes precedence over every configured source.
+
 ---
 
 ## b2c slas client list
@@ -270,19 +274,22 @@ Get details of a SLAS client.
 ### Usage
 
 ```bash
-b2c slas client get <CLIENTID> --tenant-id <TENANT_ID>
+b2c slas client get [CLIENTID] --tenant-id <TENANT_ID>
 ```
 
 ### Arguments
 
 | Argument | Description | Required |
 |----------|-------------|----------|
-| `CLIENTID` | SLAS client ID to retrieve | Yes |
+| `CLIENTID` | SLAS client ID to retrieve. Defaults to the configured `slasClientId` | No |
 
 ### Examples
 
 ```bash
-# Get client details
+# Get details for the configured SLAS client
+b2c slas client get --tenant-id abcd_123
+
+# Override the configured SLAS client ID
 b2c slas client get my-client-id --tenant-id abcd_123
 
 # Output as JSON
@@ -309,14 +316,14 @@ Update an existing SLAS client.
 ### Usage
 
 ```bash
-b2c slas client update <CLIENTID> --tenant-id <TENANT_ID> [FLAGS]
+b2c slas client update [CLIENTID] --tenant-id <TENANT_ID> [FLAGS]
 ```
 
 ### Arguments
 
 | Argument | Description | Required |
 |----------|-------------|----------|
-| `CLIENTID` | SLAS client ID to update | Yes |
+| `CLIENTID` | SLAS client ID to update. Defaults to the configured `slasClientId` | No |
 
 ### Flags
 
@@ -334,7 +341,10 @@ b2c slas client update <CLIENTID> --tenant-id <TENANT_ID> [FLAGS]
 ### Examples
 
 ```bash
-# Update client name
+# Update the configured client name
+b2c slas client update --tenant-id abcd_123 --name "New Name"
+
+# Override the configured SLAS client ID
 b2c slas client update my-client-id --tenant-id abcd_123 --name "New Name"
 
 # Rotate client secret
@@ -369,19 +379,22 @@ Delete a SLAS client.
 ### Usage
 
 ```bash
-b2c slas client delete <CLIENTID> --tenant-id <TENANT_ID>
+b2c slas client delete [CLIENTID] --tenant-id <TENANT_ID>
 ```
 
 ### Arguments
 
 | Argument | Description | Required |
 |----------|-------------|----------|
-| `CLIENTID` | SLAS client ID to delete | Yes |
+| `CLIENTID` | SLAS client ID to delete. Defaults to the configured `slasClientId` | No |
 
 ### Examples
 
 ```bash
-# Delete a client
+# Delete the configured client
+b2c slas client delete --tenant-id abcd_123
+
+# Override the configured SLAS client ID
 b2c slas client delete my-client-id --tenant-id abcd_123
 
 # Output as JSON
@@ -402,14 +415,14 @@ Open the SLAS Admin UI for a client in your browser.
 ### Usage
 
 ```bash
-b2c slas client open <CLIENTID> --tenant-id <TENANT_ID>
+b2c slas client open [CLIENTID] --tenant-id <TENANT_ID>
 ```
 
 ### Arguments
 
 | Argument | Description | Required |
 |----------|-------------|----------|
-| `CLIENTID` | SLAS client ID to open in the admin UI | Yes |
+| `CLIENTID` | SLAS client ID to open in the admin UI. Defaults to the configured `slasClientId` | No |
 
 ### Flags
 
@@ -417,13 +430,17 @@ b2c slas client open <CLIENTID> --tenant-id <TENANT_ID>
 |------|---------------------|-------------|----------|
 | `--tenant-id` | `SFCC_TENANT_ID` | SLAS tenant ID (organization ID) | Yes |
 | `--short-code` | `SFCC_SHORTCODE` | SCAPI short code | Yes* |
+| `--slas-client-id` | `SFCC_SLAS_CLIENT_ID` | Configured SLAS client ID | No |
 
 \* `--short-code` can be set via `SFCC_SHORTCODE` environment variable or `short-code` in `dw.json`.
 
 ### Examples
 
 ```bash
-# Open the SLAS Admin UI for a specific client
+# Open the SLAS Admin UI for the configured client
+b2c slas client open --tenant-id abcd_123
+
+# Override the configured SLAS client ID
 b2c slas client open my-client-id --tenant-id abcd_123
 
 # With explicit short code

--- a/packages/b2c-cli/src/commands/slas/client/delete.ts
+++ b/packages/b2c-cli/src/commands/slas/client/delete.ts
@@ -4,7 +4,7 @@
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
 import {Args} from '@oclif/core';
-import {SlasClientCommand, formatApiError} from '../../../utils/slas/client.js';
+import {ExistingSlasClientCommand, formatApiError} from '../../../utils/slas/client.js';
 import {t, withDocs} from '../../../i18n/index.js';
 
 interface DeleteOutput {
@@ -12,11 +12,11 @@ interface DeleteOutput {
   deleted: boolean;
 }
 
-export default class SlasClientDelete extends SlasClientCommand<typeof SlasClientDelete> {
+export default class SlasClientDelete extends ExistingSlasClientCommand<typeof SlasClientDelete> {
   static args = {
     clientId: Args.string({
-      description: 'SLAS client ID to delete',
-      required: true,
+      description: 'SLAS client ID to delete (defaults to configured slasClientId)',
+      required: false,
     }),
   };
 
@@ -28,12 +28,13 @@ export default class SlasClientDelete extends SlasClientCommand<typeof SlasClien
   static enableJsonFlag = true;
 
   static examples = [
+    '<%= config.bin %> <%= command.id %> --tenant-id abcd_123',
     '<%= config.bin %> <%= command.id %> my-client-id --tenant-id abcd_123',
     '<%= config.bin %> <%= command.id %> my-client-id --tenant-id abcd_123 --json',
   ];
 
   static flags = {
-    ...SlasClientCommand.baseFlags,
+    ...ExistingSlasClientCommand.baseFlags,
   };
 
   async run(): Promise<DeleteOutput> {
@@ -43,7 +44,7 @@ export default class SlasClientDelete extends SlasClientCommand<typeof SlasClien
     this.requireOAuthCredentials();
 
     const tenantId = this.requireTenantId();
-    const {clientId} = this.args;
+    const clientId = this.requireSlasClientId(this.args.clientId);
 
     if (!this.jsonEnabled()) {
       this.log(t('commands.slas.client.delete.deleting', 'Deleting SLAS client {{clientId}}...', {clientId}));

--- a/packages/b2c-cli/src/commands/slas/client/get.ts
+++ b/packages/b2c-cli/src/commands/slas/client/get.ts
@@ -5,7 +5,7 @@
  */
 import {Args} from '@oclif/core';
 import {
-  SlasClientCommand,
+  ExistingSlasClientCommand,
   type Client,
   type ClientOutput,
   normalizeClientResponse,
@@ -14,11 +14,11 @@ import {
 } from '../../../utils/slas/client.js';
 import {t, withDocs} from '../../../i18n/index.js';
 
-export default class SlasClientGet extends SlasClientCommand<typeof SlasClientGet> {
+export default class SlasClientGet extends ExistingSlasClientCommand<typeof SlasClientGet> {
   static args = {
     clientId: Args.string({
-      description: 'SLAS client ID to retrieve',
-      required: true,
+      description: 'SLAS client ID to retrieve (defaults to configured slasClientId)',
+      required: false,
     }),
   };
 
@@ -30,19 +30,20 @@ export default class SlasClientGet extends SlasClientCommand<typeof SlasClientGe
   static enableJsonFlag = true;
 
   static examples = [
+    '<%= config.bin %> <%= command.id %> --tenant-id abcd_123',
     '<%= config.bin %> <%= command.id %> my-client-id --tenant-id abcd_123',
     '<%= config.bin %> <%= command.id %> my-client-id --tenant-id abcd_123 --json',
   ];
 
   static flags = {
-    ...SlasClientCommand.baseFlags,
+    ...ExistingSlasClientCommand.baseFlags,
   };
 
   async run(): Promise<ClientOutput> {
     this.requireOAuthCredentials();
 
     const tenantId = this.requireTenantId();
-    const {clientId} = this.args;
+    const clientId = this.requireSlasClientId(this.args.clientId);
 
     if (!this.jsonEnabled()) {
       this.log(t('commands.slas.client.get.fetching', 'Fetching SLAS client {{clientId}}...', {clientId}));

--- a/packages/b2c-cli/src/commands/slas/client/open.ts
+++ b/packages/b2c-cli/src/commands/slas/client/open.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
-import {Args, Flags} from '@oclif/core';
-import {BaseCommand} from '@salesforce/b2c-tooling-sdk/cli';
+import {Args} from '@oclif/core';
+import {ExistingSlasClientCommand} from '../../../utils/slas/client.js';
 import {t, withDocs} from '../../../i18n/index.js';
 
 async function openBrowser(url: string): Promise<void> {
@@ -16,11 +16,11 @@ async function openBrowser(url: string): Promise<void> {
   }
 }
 
-export default class SlasClientOpen extends BaseCommand<typeof SlasClientOpen> {
+export default class SlasClientOpen extends ExistingSlasClientCommand<typeof SlasClientOpen> {
   static args = {
     clientId: Args.string({
-      description: 'SLAS client ID to open in the admin UI',
-      required: true,
+      description: 'SLAS client ID to open in the admin UI (defaults to configured slasClientId)',
+      required: false,
     }),
   };
 
@@ -30,27 +30,19 @@ export default class SlasClientOpen extends BaseCommand<typeof SlasClientOpen> {
   );
 
   static examples = [
+    '<%= config.bin %> <%= command.id %> --tenant-id abcd_123',
     '<%= config.bin %> <%= command.id %> my-client-id --tenant-id abcd_123',
     '<%= config.bin %> <%= command.id %> my-client-id --tenant-id abcd_123 --short-code kv7kzm78',
   ];
 
   static flags = {
-    ...BaseCommand.baseFlags,
-    'tenant-id': Flags.string({
-      description: 'SLAS tenant ID (organization ID)',
-      env: 'SFCC_TENANT_ID',
-      required: true,
-    }),
-    'short-code': Flags.string({
-      description: 'SCAPI short code',
-      env: 'SFCC_SHORTCODE',
-      default: async () => process.env.SFCC_SHORT_CODE || undefined,
-    }),
+    ...ExistingSlasClientCommand.baseFlags,
   };
 
   async run(): Promise<{url: string}> {
-    const {'tenant-id': tenantId, 'short-code': shortCodeFlag} = this.flags;
-    const {clientId} = this.args;
+    const shortCodeFlag = this.flags['short-code'];
+    const tenantId = this.requireTenantId();
+    const clientId = this.requireSlasClientId(this.args.clientId);
 
     const shortCode = shortCodeFlag ?? this.resolvedConfig.values.shortCode;
 

--- a/packages/b2c-cli/src/commands/slas/client/update.ts
+++ b/packages/b2c-cli/src/commands/slas/client/update.ts
@@ -5,7 +5,7 @@
  */
 import {Args, Flags} from '@oclif/core';
 import {
-  SlasClientCommand,
+  ExistingSlasClientCommand,
   type Client,
   type ClientRequest,
   type ClientOutput,
@@ -16,11 +16,11 @@ import {
 } from '../../../utils/slas/client.js';
 import {t, withDocs} from '../../../i18n/index.js';
 
-export default class SlasClientUpdate extends SlasClientCommand<typeof SlasClientUpdate> {
+export default class SlasClientUpdate extends ExistingSlasClientCommand<typeof SlasClientUpdate> {
   static args = {
     clientId: Args.string({
-      description: 'SLAS client ID to update',
-      required: true,
+      description: 'SLAS client ID to update (defaults to configured slasClientId)',
+      required: false,
     }),
   };
 
@@ -32,6 +32,7 @@ export default class SlasClientUpdate extends SlasClientCommand<typeof SlasClien
   static enableJsonFlag = true;
 
   static examples = [
+    '<%= config.bin %> <%= command.id %> --tenant-id abcd_123 --name "New Name"',
     '<%= config.bin %> <%= command.id %> my-client-id --tenant-id abcd_123 --name "New Name"',
     '<%= config.bin %> <%= command.id %> my-client-id --tenant-id abcd_123 --secret new-secret-value',
     '<%= config.bin %> <%= command.id %> my-client-id --tenant-id abcd_123 --scopes sfcc.shopper-baskets',
@@ -40,7 +41,7 @@ export default class SlasClientUpdate extends SlasClientCommand<typeof SlasClien
   ];
 
   static flags = {
-    ...SlasClientCommand.baseFlags,
+    ...ExistingSlasClientCommand.baseFlags,
     name: Flags.string({
       description: 'Display name for the client',
     }),
@@ -89,7 +90,7 @@ export default class SlasClientUpdate extends SlasClientCommand<typeof SlasClien
       'callback-uri': callbackUri,
       replace,
     } = this.flags;
-    const {clientId} = this.args;
+    const clientId = this.requireSlasClientId(this.args.clientId);
     const tenantId = this.requireTenantId();
 
     if (!this.jsonEnabled()) {

--- a/packages/b2c-cli/src/utils/slas/client.ts
+++ b/packages/b2c-cli/src/utils/slas/client.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
-import {Command, ux} from '@oclif/core';
+import {Command, Flags, ux} from '@oclif/core';
 import cliui from 'cliui';
-import {OAuthCommand} from '@salesforce/b2c-tooling-sdk/cli';
+import {OAuthCommand, loadConfig, extractOAuthFlags} from '@salesforce/b2c-tooling-sdk/cli';
+import type {ResolvedB2CConfig} from '@salesforce/b2c-tooling-sdk/config';
 import {
   createSlasClient,
   getApiErrorMessage,
@@ -248,5 +249,43 @@ export abstract class SlasClientCommand<T extends typeof Command> extends OAuthC
 
     const oauthStrategy = this.getOAuthStrategy();
     return createSlasClient({shortCode}, oauthStrategy);
+  }
+}
+
+/**
+ * Base command for operations that target an existing SLAS client.
+ * Resolves the client ID from an explicit positional argument first, then configuration.
+ */
+export abstract class ExistingSlasClientCommand<T extends typeof Command> extends SlasClientCommand<T> {
+  static baseFlags = {
+    ...SlasClientCommand.baseFlags,
+    'slas-client-id': Flags.string({
+      description: 'SLAS client ID (positional argument takes precedence)',
+      env: 'SFCC_SLAS_CLIENT_ID',
+    }),
+  };
+
+  protected override async loadConfiguration(): Promise<ResolvedB2CConfig> {
+    const flags = this.flags as Record<string, unknown>;
+    return loadConfig(
+      {
+        ...extractOAuthFlags(flags),
+        slasClientId: flags['slas-client-id'] as string | undefined,
+      },
+      this.getBaseConfigOptions(),
+    );
+  }
+
+  protected requireSlasClientId(clientId?: string): string {
+    const resolvedClientId = clientId ?? this.resolvedConfig.values.slasClientId;
+    if (!resolvedClientId) {
+      this.error(
+        t(
+          'commands.slas.client.clientIdRequired',
+          'SLAS client ID is required. Provide it as an argument, use --slas-client-id, set SFCC_SLAS_CLIENT_ID, or configure slasClientId in dw.json.',
+        ),
+      );
+    }
+    return resolvedClientId;
   }
 }

--- a/packages/b2c-cli/test/commands/slas/client/delete.test.ts
+++ b/packages/b2c-cli/test/commands/slas/client/delete.test.ts
@@ -35,8 +35,8 @@ describe('slas client delete', () => {
     restoreConfig();
   });
 
-  it('deletes a client via SLAS API', async () => {
-    const command: any = await createCommand({'tenant-id': 'abcd_123'}, {clientId: 'my-client'});
+  it('deletes the configured client via SLAS API when the positional argument is omitted', async () => {
+    const command: any = await createCommand({'tenant-id': 'abcd_123', 'slas-client-id': 'configured-client'}, {});
 
     sinon.stub(command, 'requireOAuthCredentials').returns(void 0);
 
@@ -49,9 +49,9 @@ describe('slas client delete', () => {
     expect(delStub.calledOnce).to.equal(true);
     const [, options] = delStub.firstCall.args as [string, any];
     expect(options.params.path.tenantId).to.equal('abcd_123');
-    expect(options.params.path.clientId).to.equal('my-client');
+    expect(options.params.path.clientId).to.equal('configured-client');
 
-    expect(result.clientId).to.equal('my-client');
+    expect(result.clientId).to.equal('configured-client');
     expect(result.deleted).to.equal(true);
   });
 

--- a/packages/b2c-cli/test/commands/slas/client/get.test.ts
+++ b/packages/b2c-cli/test/commands/slas/client/get.test.ts
@@ -35,8 +35,11 @@ describe('slas client get', () => {
     restoreConfig();
   });
 
-  it('fetches a client via SLAS API and returns normalized output in JSON mode', async () => {
-    const command: any = await createCommand({'tenant-id': 'abcd_123'}, {clientId: 'my-client'});
+  it('prefers a positional client ID over the configured client ID', async () => {
+    const command: any = await createCommand(
+      {'tenant-id': 'abcd_123', 'slas-client-id': 'configured-client'},
+      {clientId: 'my-client'},
+    );
 
     sinon.stub(command, 'requireOAuthCredentials').returns(void 0);
 
@@ -58,9 +61,60 @@ describe('slas client get', () => {
     const result = await command.run();
 
     expect(getStub.calledOnce).to.equal(true);
+    expect(getStub.firstCall.args[1]).to.deep.equal({
+      params: {
+        path: {tenantId: 'abcd_123', clientId: 'my-client'},
+      },
+    });
     expect(result.clientId).to.equal('my-client');
     expect(result.scopes).to.deep.equal(['a', 'b']);
     expect(result.channels).to.deep.equal(['RefArch']);
+  });
+
+  it('uses the configured client ID when the positional argument is omitted', async () => {
+    const command: any = await createCommand({'tenant-id': 'abcd_123', 'slas-client-id': 'configured-client'}, {});
+
+    sinon.stub(command, 'requireOAuthCredentials').returns(void 0);
+
+    const getStub = sinon.stub().resolves({
+      data: {
+        clientId: 'configured-client',
+        name: 'Configured Client',
+        scopes: 'a b',
+        channels: ['RefArch'],
+        redirectUri: ['http://localhost/callback'],
+        isPrivateClient: true,
+      },
+      error: undefined,
+    });
+
+    sinon.stub(command, 'getSlasClient').returns({GET: getStub} as any);
+    sinon.stub(command, 'jsonEnabled').returns(true);
+
+    const result = await command.run();
+
+    expect(getStub.calledOnce).to.equal(true);
+    expect(getStub.firstCall.args[1]).to.deep.equal({
+      params: {
+        path: {tenantId: 'abcd_123', clientId: 'configured-client'},
+      },
+    });
+    expect(result.clientId).to.equal('configured-client');
+  });
+
+  it('calls command.error when no client ID is provided or configured', async () => {
+    const command: any = await createCommand({'tenant-id': 'abcd_123'}, {});
+
+    sinon.stub(command, 'requireOAuthCredentials').returns(void 0);
+    const errorStub = stubErrorToThrow(command);
+
+    try {
+      await command.run();
+      expect.fail('Expected error');
+    } catch {
+      expect(errorStub.calledOnce).to.equal(true);
+      expect(errorStub.firstCall.args[0]).to.include('SLAS client ID is required');
+    }
   });
 
   it('calls command.error on API error', async () => {

--- a/packages/b2c-cli/test/commands/slas/client/open.test.ts
+++ b/packages/b2c-cli/test/commands/slas/client/open.test.ts
@@ -38,7 +38,9 @@ describe('slas client open', () => {
     stubParse(command, {'tenant-id': 'abcd_123'}, {clientId: 'my-client'});
     await command.init();
 
-    sinon.stub(command, 'resolvedConfig').get(() => ({values: {shortCode: undefined}}));
+    sinon
+      .stub(command, 'resolvedConfig')
+      .get(() => ({values: {shortCode: undefined, tenantId: 'abcd_123', slasClientId: 'my-client'}}));
 
     const errorStub = sinon.stub(command, 'error').throws(new Error('Expected error'));
 
@@ -50,20 +52,22 @@ describe('slas client open', () => {
     }
   });
 
-  it('builds URL using short code from resolved config and returns it', async () => {
+  it('builds the URL using the configured client ID and short code', async () => {
     const command: any = new SlasClientOpen([], config);
 
-    stubParse(command, {'tenant-id': 'abcd_123'}, {clientId: 'my-client'});
+    stubParse(command, {'tenant-id': 'abcd_123'}, {});
     await command.init();
 
-    sinon.stub(command, 'resolvedConfig').get(() => ({values: {shortCode: 'kv7kzm78'}}));
+    sinon
+      .stub(command, 'resolvedConfig')
+      .get(() => ({values: {shortCode: 'kv7kzm78', tenantId: 'abcd_123', slasClientId: 'configured-client'}}));
 
     const logStub = sinon.stub(command, 'log').returns(void 0);
 
     const result = await command.run();
 
     expect(result.url).to.include('kv7kzm78.api.commercecloud.salesforce.com');
-    expect(result.url).to.include('clientId=my-client');
+    expect(result.url).to.include('clientId=configured-client');
     expect(result.url).to.include('tenantId=abcd_123');
     expect(logStub.called).to.equal(true);
   });
@@ -74,11 +78,14 @@ describe('slas client open', () => {
     stubParse(command, {'tenant-id': 'abcd_123', 'short-code': 'flagcode'}, {clientId: 'my-client'});
     await command.init();
 
-    sinon.stub(command, 'resolvedConfig').get(() => ({values: {shortCode: 'kv7kzm78'}}));
+    sinon
+      .stub(command, 'resolvedConfig')
+      .get(() => ({values: {shortCode: 'kv7kzm78', tenantId: 'abcd_123', slasClientId: 'configured-client'}}));
 
     sinon.stub(command, 'log').returns(void 0);
 
     const result = await command.run();
     expect(result.url).to.include('flagcode.api.commercecloud.salesforce.com');
+    expect(result.url).to.include('clientId=my-client');
   });
 });

--- a/packages/b2c-cli/test/commands/slas/client/update.test.ts
+++ b/packages/b2c-cli/test/commands/slas/client/update.test.ts
@@ -176,14 +176,17 @@ describe('slas client update', () => {
     expect(options.body.redirectUri).to.deep.equal(['http://r1', 'http://r2']);
   });
 
-  it('includes secret in update body when provided', async () => {
-    const command: any = await createCommand({'tenant-id': 'abcd_123', secret: 'new-secret'}, {clientId: 'my-client'});
+  it('uses the configured client ID and includes the secret when provided', async () => {
+    const command: any = await createCommand(
+      {'tenant-id': 'abcd_123', 'slas-client-id': 'configured-client', secret: 'new-secret'},
+      {},
+    );
 
     stubAuthAndJson(command);
 
     const getStub = sinon.stub().resolves({
       data: {
-        clientId: 'my-client',
+        clientId: 'configured-client',
         name: 'Existing',
         channels: ['Site1'],
         scopes: 'a',
@@ -195,7 +198,7 @@ describe('slas client update', () => {
 
     const putStub = sinon.stub().resolves({
       data: {
-        clientId: 'my-client',
+        clientId: 'configured-client',
         name: 'Existing',
         channels: ['Site1'],
         scopes: 'a',
@@ -211,6 +214,8 @@ describe('slas client update', () => {
     await command.run();
 
     const [, options] = putStub.firstCall.args as [string, any];
+    expect(options.params.path.clientId).to.equal('configured-client');
+    expect(options.body.clientId).to.equal('configured-client');
     expect(options.body.secret).to.equal('new-secret');
   });
 });

--- a/packages/b2c-tooling-sdk/data/tooling/index.json
+++ b/packages/b2c-tooling-sdk/data/tooling/index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generatedAt": "2026-08-25T15:18:34.802Z",
+  "generatedAt": "2026-08-28T16:41:03.775Z",
   "entries": [
     {
       "id": "cli-account-manager",
@@ -233,7 +233,7 @@
       "category": "tooling",
       "url": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/cli/slas.html",
       "sourceUrl": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/cli/slas.md",
-      "headings": "Global SLAS Flags • Authentication • Required Roles • Configuration • b2c slas token • Usage • Flags • Flows • Examples • Output • Configuration • b2c slas client list • Usage • Flags • Examples • Output • b2c slas client create • Usage • Arguments • Flags • Examples • Notes • b2c slas client get • Usage • Arguments • Examples • Output • b2c slas client update • Usage • Arguments • Flags • Examples • Notes • b2c slas client delete • Usage • Arguments • Examples • Notes • b2c slas client open • Usage • Arguments • Flags • Examples • Notes",
+      "headings": "Global SLAS Flags • Authentication • Required Roles • Configuration • b2c slas token • Usage • Flags • Flows • Examples • Output • Configuration • Existing Client Selection • b2c slas client list • Usage • Flags • Examples • Output • b2c slas client create • Usage • Arguments • Flags • Examples • Notes • b2c slas client get • Usage • Arguments • Examples • Output • b2c slas client update • Usage • Arguments • Flags • Examples • Notes • b2c slas client delete • Usage • Arguments • Examples • Notes • b2c slas client open • Usage • Arguments • Flags • Examples • Notes",
       "preview": "Commands for creating, updating, and managing Shopper Login and API Access Service (SLAS) clients."
     },
     {

--- a/skills/b2c-cli/skills/b2c-slas/SKILL.md
+++ b/skills/b2c-cli/skills/b2c-slas/SKILL.md
@@ -24,6 +24,8 @@ Relevant overrides:
 - `--slas-client-id` / `SFCC_SLAS_CLIENT_ID` / `slasClientId`
 - `--slas-client-secret` / `SFCC_SLAS_CLIENT_SECRET` / `slasClientSecret`
 
+Commands that target an existing client (`get`, `update`, `delete`, and `open`) use the configured `slasClientId` when their positional client ID is omitted. A positional client ID takes precedence over configuration.
+
 ## When to Use
 
 Common scenarios requiring SLAS client management:
@@ -50,7 +52,10 @@ b2c slas client list --tenant-id abcd_123
 ### Get SLAS Client Details
 
 ```bash
-# get details for a specific SLAS client
+# get details for the configured SLAS client
+b2c slas client get
+
+# override the configured client ID
 b2c slas client get my-client-id
 ```
 
@@ -126,10 +131,10 @@ b2c slas token --site-id RefArch --slas-client-id my-client --slas-client-secret
 ### Update SLAS Client
 
 ```bash
-# update the display name
-b2c slas client update my-client-id --name "New Name"
+# update the configured client's display name
+b2c slas client update --name "New Name"
 
-# rotate the client secret
+# override the configured client ID and rotate its secret
 b2c slas client update my-client-id --secret new-secret-value
 
 # add scopes (appends to existing by default)
@@ -145,8 +150,21 @@ b2c slas client update my-client-id --channels RefArch,SiteGenesis --replace
 ### Delete SLAS Client
 
 ```bash
-# delete a SLAS client
+# delete the configured SLAS client
+b2c slas client delete
+
+# override the configured client ID
 b2c slas client delete my-client-id
+```
+
+### Open SLAS Client
+
+```bash
+# open the configured SLAS client in the Admin UI
+b2c slas client open
+
+# override the configured client ID
+b2c slas client open my-client-id
 ```
 
 ### More Commands


### PR DESCRIPTION
## Summary

- add an `ExistingSlasClientCommand` base for SLAS commands that target an existing client
- let `slas client get`, `update`, `delete`, and `open` use the configured `slasClientId` when `CLIENTID` is omitted
- keep positional client IDs as the highest-precedence override and leave `create`, `list`, and `token` behavior unchanged
- update command tests, CLI documentation, the SLAS skill, the tooling documentation index, and changesets

## Testing

- `pnpm run test:agent`
- `pnpm run typecheck:agent`
- `pnpm run lint:agent`
- `pnpm --filter @salesforce/b2c-cli run format:check`
- targeted Prettier checks for changed tests, skill content, and changeset
- `pnpm --filter @salesforce/b2c-tooling-sdk run check:tooling-index`
- help parsing for all four affected commands

The workspace-wide recursive format check still reports the pre-existing `packages/b2c-vs-extension/src/cip-analytics/cip-styles.css` formatting issue. All files changed by this PR pass their applicable format checks.

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm run test:agent`)
- [ ] Code is formatted (`pnpm run -r format`); changed files pass, but the unrelated existing CSS issue above prevents a clean workspace-wide check
