### PR TITLE
fix(vscode): keep instance selection workspace-local

### DIFF
--- a/.changeset/fix-vscode-global-instance-selection.md
+++ b/.changeset/fix-vscode-global-instance-selection.md
@@ -1,0 +1,7 @@
+---
+'b2c-vs-extension': patch
+'@salesforce/b2c-dx-docs': patch
+'@salesforce/b2c-tooling-sdk': patch
+---
+
+Made VS Code instance selection workspace-specific by default, with explicit actions to set or follow the shared default without unexpectedly changing other tools and workspaces. Opening an instance's configuration now reveals its exact named entry.

--- a/docs/vscode-extension/configuration.md
+++ b/docs/vscode-extension/configuration.md
@@ -10,7 +10,7 @@ This page covers:
 
 - [Connecting to a B2C Instance](#connecting-to-a-b2c-instance) — credentials per feature.
 - [How the Extension Chooses a Project](#how-the-extension-chooses-a-project) — parent folders and multi-root workspaces.
-- [Switching the Active Instance](#switching-the-active-instance) — single-workspace, multi-instance.
+- [Selecting an Instance](#selecting-an-instance) — workspace-specific and shared defaults.
 - [Settings Reference](#settings-reference) — the `b2c-dx.*` toggles and verbosity controls.
 
 ## Connecting to a B2C Instance
@@ -87,11 +87,13 @@ If one workspace folder contains more than one B2C project, the project closest 
 
 To keep a particular project directory selected, right-click that folder in Explorer and choose **B2C DX > Use as B2C Commerce Root**. This works for nested folders such as `sfra/` as well as top-level folders in a multi-root workspace. Run **B2C DX: Reset B2C Commerce Root to Auto-Detect** from the Command Palette to return to automatic selection.
 
-## Switching the Active Instance
+## Selecting an Instance
 
-When `dw.json` defines multiple named instances (the recommended pattern for working across dev / staging / sandbox), click the cloud icon in the status bar to open a quick pick of the configured instances. Selecting a new one updates the underlying `dw.json` active-instance pointer and refreshes every view.
+When your configuration defines multiple named instances (the recommended pattern for working across dev / staging / sandbox), click the cloud icon in the status bar to open a quick pick. Selecting an instance applies it only to the current VS Code workspace and refreshes every extension view. Other VS Code workspaces, the CLI, and MCP continue using their own selection or the shared default.
 
-The same pointer is shared with the CLI: switching here is equivalent to running `b2c setup instance set-active <name>`.
+The picker distinguishes the instance **selected for this workspace** with a check mark and the shared **default instance** with a star. Use the star action on a row—or run **B2C DX: Set Default Instance**—to intentionally change the default used by other consumers. Run **B2C DX: Follow Default Instance** to remove the workspace-specific selection.
+
+For named entries, setting the default writes `active: true`; a root configuration without an explicit `active` value remains an implicit default. This is equivalent to running `b2c setup instance set-active <name>` and is separate from selecting an instance only for VS Code.
 
 ## Settings Reference
 

--- a/packages/b2c-tooling-sdk/data/tooling/index.json
+++ b/packages/b2c-tooling-sdk/data/tooling/index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generatedAt": "2026-09-01T14:45:39.398Z",
+  "generatedAt": "2026-09-01T19:50:41.549Z",
   "entries": [
     {
       "id": "cli-account-manager",
@@ -557,7 +557,7 @@
       "category": "tooling",
       "url": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/configuration.html",
       "sourceUrl": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/configuration.md",
-      "headings": "Connecting to a B2C Instance • Per-feature requirements • Example `dw.json` • How the Extension Chooses a Project • Switching the Active Instance • Settings Reference • Feature toggles • Verbosity, polling, telemetry • XML schema validation • Complete defaults (copy-paste) • Next Steps",
+      "headings": "Connecting to a B2C Instance • Per-feature requirements • Example `dw.json` • How the Extension Chooses a Project • Selecting an Instance • Settings Reference • Feature toggles • Verbosity, polling, telemetry • XML schema validation • Complete defaults (copy-paste) • Next Steps",
       "preview": "Connect the Salesforce B2C Commerce VS Code Extension to a B2C Commerce instance — credentials, OAuth, telemetry, and the b2c-dx.* settings reference."
     },
     {

--- a/packages/b2c-vs-extension/.vscode-test.mjs
+++ b/packages/b2c-vs-extension/.vscode-test.mjs
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {defineConfig} from '@vscode/test-cli';
@@ -8,8 +9,32 @@ import {defineConfig} from '@vscode/test-cli';
 // deep path the default socket path overflows that limit and the test host fails
 // to launch ("listen EINVAL ... .sock"). Redirect the user-data-dir to a short
 // path under the OS temp dir so the socket path stays well under the cap. The
-// dir is per-label so the two configs below don't share a control socket.
-const shortUserDataDir = (label) => path.join(os.tmpdir(), `b2cvsct-${label}`);
+// A fresh root per invocation also prevents settings and workspaceState from a
+// prior run from affecting instance-selection tests.
+const shortTempDirectory = process.platform === 'darwin' ? '/tmp' : os.tmpdir();
+const testRoot = fs.mkdtempSync(path.join(shortTempDirectory, 'b2cv-'));
+const configVariables = Object.keys(process.env).filter((key) => key.startsWith('SFCC_') || key.startsWith('MRT_'));
+const testPaths = (label) => {
+  const root = path.join(testRoot, label);
+  return {
+    userData: path.join(root, 'user-data'),
+    extensions: path.join(root, 'extensions'),
+    b2cConfig: path.join(root, 'b2c-config'),
+  };
+};
+const launchArgs = (label) => {
+  const paths = testPaths(label);
+  return ['--user-data-dir', paths.userData, '--extensions-dir', paths.extensions];
+};
+const isolatedEnvironment = (label, extra = {}) => {
+  const paths = testPaths(label);
+  return {
+    ...Object.fromEntries(configVariables.map((key) => [key, undefined])),
+    B2C_CONFIG_DIR: paths.b2cConfig,
+    MRT_CREDENTIALS_FILE: path.join(paths.b2cConfig, 'missing.mobify'),
+    ...extra,
+  };
+};
 
 // Run the integration suite twice against different workspaces. The second run
 // points the test host at a workspace whose dw.json is intentionally malformed:
@@ -22,17 +47,14 @@ export default defineConfig([
     files: 'out/test/**/*.test.js',
     version: 'stable',
     workspaceFolder: 'src/test/fixtures/empty-workspace',
-    launchArgs: ['--user-data-dir', shortUserDataDir('valid-workspace')],
+    launchArgs: launchArgs('valid-workspace'),
     // Forward opt-in ISML formatter dev vars into the extension host (which does
     // not inherit the parent env): B2C_ISML_CORPUS (corpus idempotency probe) and
     // UPDATE_ISML_SNAPSHOTS (regenerate vendored fixture snapshots).
-    env:
-      process.env.B2C_ISML_CORPUS || process.env.UPDATE_ISML_SNAPSHOTS
-        ? {
-            B2C_ISML_CORPUS: process.env.B2C_ISML_CORPUS,
-            UPDATE_ISML_SNAPSHOTS: process.env.UPDATE_ISML_SNAPSHOTS,
-          }
-        : undefined,
+    env: isolatedEnvironment('valid-workspace', {
+      B2C_ISML_CORPUS: process.env.B2C_ISML_CORPUS,
+      UPDATE_ISML_SNAPSHOTS: process.env.UPDATE_ISML_SNAPSHOTS,
+    }),
     mocha: {
       ui: 'tdd',
       timeout: 20000,
@@ -43,7 +65,8 @@ export default defineConfig([
     files: 'out/test/integration/activation.test.js',
     version: 'stable',
     workspaceFolder: 'src/test/fixtures/malformed-workspace',
-    launchArgs: ['--user-data-dir', shortUserDataDir('malformed-dw-json')],
+    launchArgs: launchArgs('malformed-dw-json'),
+    env: isolatedEnvironment('malformed-dw-json'),
     mocha: {
       ui: 'tdd',
       timeout: 20000,
@@ -54,7 +77,8 @@ export default defineConfig([
     files: 'out/test/config-provider.test.js',
     version: 'stable',
     workspaceFolder: 'src/test/fixtures/nested-workspace',
-    launchArgs: ['--user-data-dir', shortUserDataDir('nested-dw-json')],
+    launchArgs: launchArgs('nested-dw-json'),
+    env: isolatedEnvironment('nested-dw-json'),
     mocha: {
       ui: 'tdd',
       timeout: 20000,
@@ -65,7 +89,8 @@ export default defineConfig([
     files: 'out/test/config-provider.test.js',
     version: 'stable',
     workspaceFolder: 'src/test/fixtures/multi-root.code-workspace',
-    launchArgs: ['--user-data-dir', shortUserDataDir('multi-root-dw-json')],
+    launchArgs: launchArgs('multi-root-dw-json'),
+    env: isolatedEnvironment('multi-root-dw-json'),
     mocha: {
       ui: 'tdd',
       timeout: 20000,

--- a/packages/b2c-vs-extension/README.md
+++ b/packages/b2c-vs-extension/README.md
@@ -7,6 +7,7 @@ See the [extension documentation](https://salesforcecommercecloud.github.io/b2c-
 [![Salesforce B2C Commerce activity bar showing the extension's developer tools](https://raw.githubusercontent.com/SalesforceCommerceCloud/b2c-developer-tooling/main/docs/vscode-extension/images/overview.png)](https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/)
 
 ## Highlights
+
 > **Marketplace publishing happens out of [`forcedotcom/b2c-dx`](https://github.com/forcedotcom/b2c-dx).** All extension development, issues, and pull requests stay in this monorepo; the `forcedotcom/b2c-dx` repo holds the marketplace landing page, governance files, and the workflows that publish each release to VS Code Marketplace and Open VSX. See [PUBLISHING.md](./PUBLISHING.md) for the publish flow and the manual fallback.
 
 ## Features (overview)
@@ -48,13 +49,13 @@ Browse the SCAPI schemas available to your instance and try requests in an integ
 
 ### Stay in the development flow
 
-Tail sandbox logs into a VS Code output channel, install Commerce App Packages, manage jobs, and keep the active B2C instance visible in the status bar. Preview features such as Job History, site export, analytics, and guided onboarding can be enabled from the `b2c-dx.features.*` settings.
+Tail sandbox logs into a VS Code output channel, install Commerce App Packages, manage jobs, and keep the selected B2C instance visible in the status bar. Preview features such as Job History, site export, analytics, and guided onboarding can be enabled from the `b2c-dx.features.*` settings.
 
 ## Get started
 
 1. Open a B2C Commerce project in VS Code.
 2. Add a `dw.json` file at the project root or use an existing B2C CLI configuration. The project can be nested inside an open workspace folder.
-3. Select the active instance from the cloud icon in the status bar.
+3. Select an instance for the workspace from the cloud icon in the status bar.
 4. Open an extension view from the activity bar or run an extension command from the Command Palette.
 
 Different features require different credentials. WebDAV workflows can use a Business Manager username and access key, while sandbox and API workflows require OAuth configuration. See [Connecting to a B2C instance](https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/configuration#connecting-to-a-b2c-instance) for the per-feature requirements and an example `dw.json`.

--- a/packages/b2c-vs-extension/package.json
+++ b/packages/b2c-vs-extension/package.json
@@ -148,7 +148,7 @@
         "b2c-dx.features.sandboxFilesystem": {
           "type": "boolean",
           "default": false,
-          "description": "Automatically mount the active instance's WebDAV filesystem as a workspace folder on startup. Requires the WebDAV Browser to be enabled."
+          "description": "Automatically mount the selected instance's WebDAV filesystem as a workspace folder on startup. Requires the WebDAV Browser to be enabled."
         },
         "b2c-dx.features.contentLibraries": {
           "type": "boolean",
@@ -898,7 +898,17 @@
       },
       {
         "command": "b2c-dx.instance.switch",
-        "title": "Switch Active Instance",
+        "title": "Select Instance for This Workspace",
+        "category": "B2C DX"
+      },
+      {
+        "command": "b2c-dx.instance.setDefault",
+        "title": "Set Default Instance",
+        "category": "B2C DX"
+      },
+      {
+        "command": "b2c-dx.instance.followDefault",
+        "title": "Follow Default Instance",
         "category": "B2C DX"
       },
       {
@@ -1356,7 +1366,7 @@
           {
             "id": "connect",
             "title": "Phase 3 · Connect & authenticate",
-            "description": "Verify your config resolves and the extension can reach your instance. The active instance shows in the status bar (bottom-left).\n\nOAuth fields (`client-id`, `client-secret`, `short-code`) unlock the Sandbox Explorer and API Browser; basic auth (`username`, `password`) is enough for WebDAV and cartridge deploys.\n\n[Inspect resolved config](command:b2c-dx.walkthrough.inspectSetup) — runs `b2c setup inspect` and shows where each value came from (file / env / keychain).\n\n[Inspect active instance](command:b2c-dx.instance.inspect) · [Open Realm Explorer](command:workbench.view.extension.b2c-dx-sandboxes)",
+            "description": "Verify your config resolves and the extension can reach your instance. The selected instance shows in the status bar (bottom-left).\n\nOAuth fields (`client-id`, `client-secret`, `short-code`) unlock the Sandbox Explorer and API Browser; basic auth (`username`, `password`) is enough for WebDAV and cartridge deploys.\n\n[Inspect resolved config](command:b2c-dx.walkthrough.inspectSetup) — runs `b2c setup inspect` and shows where each value came from (file / env / keychain).\n\n[Inspect selected instance](command:b2c-dx.instance.inspect) · [Open Realm Explorer](command:workbench.view.extension.b2c-dx-sandboxes)",
             "media": {
               "markdown": "media/walkthrough/oauth-setup.md"
             },

--- a/packages/b2c-vs-extension/src/config-provider.ts
+++ b/packages/b2c-vs-extension/src/config-provider.ts
@@ -19,11 +19,13 @@ import type {B2CInstance} from '@salesforce/b2c-tooling-sdk/instance';
 import {readFile} from 'fs/promises';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import type {WorkspaceInstanceSelection} from './instance-selection.js';
 import {findWorkspaceDwJson, isUnscannableRoot} from './workspace-discovery.js';
 
 const DW_JSON = 'dw.json';
 const DOT_ENV = '.env';
 const PROJECT_ROOT_KEY = 'b2c-dx.projectRoot';
+const WORKSPACE_INSTANCE_KEY = 'b2c-dx.workspaceInstance';
 
 /** Async existence check via vscode.workspace.fs (no sync IO on the hot path). */
 async function pathExists(p: string): Promise<boolean> {
@@ -118,6 +120,8 @@ export class B2CExtensionConfig implements vscode.Disposable {
   private detectedDirectory = '';
   private pinned = false;
   private resolvedEnvironment: Record<string, string | undefined>;
+  private workspaceInstanceSelection: WorkspaceInstanceSelection | undefined;
+  private workspaceInstanceWatcher: vscode.FileSystemWatcher | undefined;
 
   private readonly _onDidReset = new vscode.EventEmitter<void>();
   readonly onDidReset = this._onDidReset.event;
@@ -130,6 +134,7 @@ export class B2CExtensionConfig implements vscode.Disposable {
     private readonly ambientEnvironment: NodeJS.ProcessEnv = process.env,
   ) {
     this.resolvedEnvironment = ambientEnvironment;
+    this.workspaceInstanceSelection = workspaceState?.get<WorkspaceInstanceSelection>(WORKSPACE_INSTANCE_KEY);
     // Watch for dw.json and .env saves made within VS Code (most reliable for in-editor edits)
     this.disposables.push(
       vscode.workspace.onDidSaveTextDocument((doc) => {
@@ -176,6 +181,7 @@ export class B2CExtensionConfig implements vscode.Disposable {
     settingsWatcher.onDidCreate(resetForSettingsChange);
     settingsWatcher.onDidDelete(resetForSettingsChange);
     this.disposables.push(settingsWatcher);
+    this.refreshWorkspaceInstanceWatcher();
   }
 
   getConfig(): ResolvedB2CConfig | null {
@@ -196,6 +202,30 @@ export class B2CExtensionConfig implements vscode.Disposable {
    */
   getWorkingDirectory(): string {
     return this.detectedDirectory;
+  }
+
+  /** Return the instance selected only for this VS Code workspace. */
+  getWorkspaceInstanceSelection(): WorkspaceInstanceSelection | undefined {
+    return this.workspaceInstanceSelection ? {...this.workspaceInstanceSelection} : undefined;
+  }
+
+  /** Select an exact instance for this VS Code workspace without changing shared active state. */
+  async selectInstanceForWorkspace(selection: WorkspaceInstanceSelection): Promise<void> {
+    const normalized = {...selection, location: path.resolve(selection.location)};
+    await this.workspaceState?.update(WORKSPACE_INSTANCE_KEY, normalized);
+    this.workspaceInstanceSelection = normalized;
+    this.log.appendLine(`[Config] Selected instance for this workspace: ${normalized.name}`);
+    this.refreshWorkspaceInstanceWatcher();
+    this.reset();
+  }
+
+  /** Clear the workspace override and resume following the shared default. */
+  async followDefaultInstance(): Promise<void> {
+    await this.workspaceState?.update(WORKSPACE_INSTANCE_KEY, undefined);
+    this.workspaceInstanceSelection = undefined;
+    this.log.appendLine('[Config] Following default instance');
+    this.refreshWorkspaceInstanceWatcher();
+    this.reset();
   }
 
   /** Return the ordered primary and global files used by instance-management features. */
@@ -319,9 +349,30 @@ export class B2CExtensionConfig implements vscode.Disposable {
 
   dispose(): void {
     this._onDidReset.dispose();
+    this.workspaceInstanceWatcher?.dispose();
     for (const d of this.disposables) {
       d.dispose();
     }
+  }
+
+  private refreshWorkspaceInstanceWatcher(): void {
+    this.workspaceInstanceWatcher?.dispose();
+    this.workspaceInstanceWatcher = undefined;
+
+    const location = this.workspaceInstanceSelection?.location;
+    if (!location) return;
+
+    const watcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(vscode.Uri.file(path.dirname(location)), path.basename(location)),
+    );
+    const resetForSelectionChange = (): void => {
+      this.log.appendLine(`[Config] Selected instance configuration changed: ${location}`);
+      this.reset();
+    };
+    watcher.onDidChange(resetForSelectionChange);
+    watcher.onDidCreate(resetForSelectionChange);
+    watcher.onDidDelete(resetForSelectionChange);
+    this.workspaceInstanceWatcher = watcher;
   }
 
   private async resolveAsync(): Promise<void> {
@@ -415,12 +466,26 @@ export class B2CExtensionConfig implements vscode.Disposable {
       this.log.appendLine(`[Config] Global dw.json: ${defaultConfigPath}`);
     }
 
+    const workspaceSelection = this.workspaceInstanceSelection;
+    if (workspaceSelection) {
+      this.log.appendLine(`[Config] Applying workspace instance selection: ${workspaceSelection.name}`);
+    }
+
     const config = await resolveConfig(overrides, {
       workingDirectory,
-      configPath,
-      defaultConfigPath,
+      instance: workspaceSelection?.name,
+      configPath: workspaceSelection?.location ?? configPath,
+      credentialsFile: environment.MRT_CREDENTIALS_FILE || undefined,
+      // An explicit workspace selection identifies an exact file and name. Do
+      // not fall through to a same-name entry in the global fallback.
+      defaultConfigPath: workspaceSelection ? undefined : defaultConfigPath,
       sourcesBefore: [new EnvSource(environment)],
     });
+    if (workspaceSelection && config.values.instanceName !== workspaceSelection.name) {
+      throw new Error(
+        `Selected instance "${workspaceSelection.name}" is no longer available. Choose another instance or follow the default instance.`,
+      );
+    }
     return {config, environment};
   }
 }

--- a/packages/b2c-vs-extension/src/extension.ts
+++ b/packages/b2c-vs-extension/src/extension.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2
  * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
  */
-import {DwJsonSource} from '@salesforce/b2c-tooling-sdk/config';
+import {DwJsonSource, type InstanceInfo} from '@salesforce/b2c-tooling-sdk/config';
 import {setAuthSessionBackend} from '@salesforce/b2c-tooling-sdk/auth';
 import {detectWorkspaceType} from '@salesforce/b2c-tooling-sdk/discovery';
 import {configureLogger} from '@salesforce/b2c-tooling-sdk/logging';
@@ -36,6 +36,13 @@ import {mountSandboxFilesystem, registerWebDavTree} from './webdav-tree/index.js
 import {disposeTelemetry, initTelemetry, sendEvent, sendException} from './telemetry.js';
 import {registerCipAnalytics} from './cip-analytics/index.js';
 import {
+  acceptInstancePickerSelection,
+  buildInstancePickerEntries,
+  findInstanceNameRange,
+  isWorkspaceInstanceSelected,
+  triggerInstancePickerButton,
+} from './instance-selection.js';
+import {
   registerWalkthroughCommands,
   resetWorkspaceOnboardingIfFresh,
   showWalkthroughOnFirstActivation,
@@ -47,6 +54,11 @@ import {
 } from './walkthrough/index.js';
 
 let authSessionBackend: VsCodeSecretsAuthSessionBackend | undefined;
+
+interface InstanceQuickPickItem extends vscode.QuickPickItem {
+  action?: 'follow';
+  instance?: InstanceInfo;
+}
 
 function applyLogLevel(log: vscode.OutputChannel): void {
   const config = vscode.workspace.getConfiguration('b2c-dx');
@@ -598,6 +610,7 @@ async function activateInner(context: vscode.ExtensionContext, log: vscode.Outpu
   const getInstanceCatalogOptions = () => configProvider.getInstanceCatalogOptions();
 
   const instanceStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 50);
+  instanceStatusBar.name = 'B2C Instance';
   instanceStatusBar.command = 'b2c-dx.instance.switch';
   const updateInstanceStatusBar = async () => {
     // This runs on the activation path (awaited below) and on every config
@@ -614,10 +627,10 @@ async function activateInner(context: vscode.ExtensionContext, log: vscode.Outpu
       // otherwise a misconfigured workspace shows "$(cloud) unnamed" instead
       // of the clearer "Not configured" state.
       if (config?.hasB2CInstanceConfig()) {
-        // Find active instance name from dw.json
+        const workspaceSelection = configProvider.getWorkspaceInstanceSelection();
         const instances = await dwJsonSource.listInstances(getInstanceCatalogOptions());
-        const active = instances.find((i) => i.active);
-        const name = active?.name;
+        const defaultInstance = instances.find((instance) => instance.active);
+        const name = workspaceSelection?.name ?? config.values.instanceName ?? defaultInstance?.name;
         const host = config.values.hostname ?? '';
         const truncatedHost = host.length > 40 ? host.slice(0, 37) + '...' : host;
         const display = name || truncatedHost || 'unnamed';
@@ -625,10 +638,13 @@ async function activateInner(context: vscode.ExtensionContext, log: vscode.Outpu
         instanceStatusBar.text = `$(cloud) ${display}${pinnedSuffix}`;
         const tooltipLines = [`B2C Instance: ${name ?? 'unnamed'}`];
         if (host) tooltipLines.push(`Host: ${host}`);
+        tooltipLines.push(
+          workspaceSelection ? 'Selection: This workspace' : 'Selection: Following the default instance',
+        );
         if (configProvider.isProjectRootPinned()) {
           tooltipLines.push(`Project root: ${getWorkingDirectory()} (pinned)`);
         }
-        tooltipLines.push('Click to switch instance');
+        tooltipLines.push('Click to select an instance');
         instanceStatusBar.tooltip = tooltipLines.join('\n');
         instanceStatusBar.show();
       } else {
@@ -688,47 +704,183 @@ async function activateInner(context: vscode.ExtensionContext, log: vscode.Outpu
     await vscode.window.showTextDocument(doc, {preview: true});
   });
 
-  const switchInstanceDisposable = registerSafeCommand('b2c-dx.instance.switch', async () => {
+  const setDefaultButton: vscode.QuickInputButton = {
+    iconPath: new vscode.ThemeIcon('star-empty'),
+    tooltip: 'Set as Default',
+  };
+  const openConfigurationButton: vscode.QuickInputButton = {
+    iconPath: new vscode.ThemeIcon('go-to-file'),
+    tooltip: 'Open Configuration',
+  };
+
+  const getDefaultInstanceSelection = async () => {
+    const result = await dwJsonSource.load(getInstanceCatalogOptions());
+    const name = result?.config.instanceName;
+    return name && result?.location ? {name, location: result.location} : undefined;
+  };
+
+  const buildInstanceQuickPickItems = (
+    instances: InstanceInfo[],
+    defaultSelection: Awaited<ReturnType<typeof getDefaultInstanceSelection>>,
+  ): InstanceQuickPickItem[] => {
+    const workspaceSelection = configProvider.getWorkspaceInstanceSelection();
+    const options = getInstanceCatalogOptions();
+    return buildInstancePickerEntries(instances, workspaceSelection, defaultSelection, options.defaultConfigPath).map(
+      (entry): InstanceQuickPickItem => {
+        if (entry.kind === 'follow') {
+          return {
+            label: '$(sync) Follow Default Instance',
+            description: entry.description,
+            action: 'follow',
+          };
+        }
+        if (entry.kind === 'separator') {
+          return {
+            label: entry.scope === 'global' ? 'Global Configuration' : 'Project Configuration',
+            kind: vscode.QuickPickItemKind.Separator,
+          };
+        }
+
+        const instance = entry.instance!;
+        return {
+          label: `${entry.selected ? '$(check) ' : ''}${instance.name}`,
+          description: [entry.default ? '$(star-full) Default' : '', instance.hostname ?? '']
+            .filter(Boolean)
+            .join('  '),
+          detail:
+            workspaceSelection && isWorkspaceInstanceSelected(instance, workspaceSelection)
+              ? 'Selected for this workspace'
+              : undefined,
+          buttons: [
+            ...(entry.default ? [] : [setDefaultButton]),
+            ...(instance.location ? [openConfigurationButton] : []),
+          ],
+          instance,
+        };
+      },
+    );
+  };
+
+  const setInstanceAsDefault = async (instance: InstanceInfo): Promise<boolean> => {
+    const choice = await vscode.window.showWarningMessage(
+      `Set "${instance.name}" as the default instance? This changes the default used by other tools and workspaces.`,
+      {modal: true},
+      'Set as Default',
+    );
+    if (choice !== 'Set as Default') return false;
+
+    await dwJsonSource.setActiveInstance(instance.name, getInstanceCatalogOptions());
+    configProvider.reset();
+    return true;
+  };
+
+  const openInstanceConfiguration = async (instance: InstanceInfo): Promise<void> => {
+    if (!instance.location) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(instance.location));
+    const editor = await vscode.window.showTextDocument(doc, {preview: true});
+    const entryRange = findInstanceNameRange(doc.getText(), instance.name);
+    if (entryRange) {
+      const range = new vscode.Range(doc.positionAt(entryRange.start), doc.positionAt(entryRange.end));
+      editor.selection = new vscode.Selection(range.start, range.end);
+      editor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+    }
+  };
+
+  const showInstancePicker = async (): Promise<void> => {
     const instances = await dwJsonSource.listInstances(getInstanceCatalogOptions());
+    const defaultSelection = await getDefaultInstanceSelection();
+    const quickPick = vscode.window.createQuickPick<InstanceQuickPickItem>();
+    quickPick.title = 'Select B2C Instance';
+    quickPick.placeholder = 'Select an instance for this workspace';
+    quickPick.matchOnDescription = true;
+    quickPick.matchOnDetail = true;
+    quickPick.items = buildInstanceQuickPickItems(instances, defaultSelection);
 
-    if (instances.length === 0) {
-      vscode.window.showWarningMessage('No instances configured in dw.json.');
-      return;
-    }
+    await new Promise<void>((resolve) => {
+      let finished = false;
+      let running = false;
+      const disposables: vscode.Disposable[] = [];
+      const finish = (): void => {
+        if (finished) return;
+        finished = true;
+        for (const disposable of disposables) disposable.dispose();
+        quickPick.dispose();
+        resolve();
+      };
+      const run = async (operation: () => Promise<void>): Promise<void> => {
+        if (running || finished) return;
+        running = true;
+        quickPick.busy = true;
+        try {
+          await operation();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          await vscode.window.showErrorMessage(`B2C DX: ${message}`);
+        } finally {
+          running = false;
+          if (!finished) quickPick.busy = false;
+        }
+      };
 
-    if (instances.length === 1) {
-      // Only one instance — go straight to inspect
-      await vscode.commands.executeCommand('b2c-dx.instance.inspect');
-      return;
-    }
-
-    const items = instances.map((inst) => ({
-      label: `${inst.active ? '$(check) ' : ''}${inst.name}`,
-      description: inst.hostname ?? '',
-      instance: inst,
-    }));
-
-    const picked = await vscode.window.showQuickPick(items, {
-      title: 'Switch B2C Instance',
-      placeHolder: 'Select an instance to activate',
+      disposables.push(
+        quickPick.onDidAccept(() => {
+          const picked = quickPick.selectedItems[0];
+          if (!picked) return;
+          void run(async () => {
+            await acceptInstancePickerSelection(picked, {
+              followDefault: () => configProvider.followDefaultInstance(),
+              selectForWorkspace: (selection) => configProvider.selectInstanceForWorkspace(selection),
+            });
+            finish();
+          });
+        }),
+        quickPick.onDidTriggerItemButton((event) => {
+          void run(async () => {
+            if (!event.item.instance) return;
+            if (event.button === setDefaultButton) {
+              const close = await triggerInstancePickerButton('setDefault', event.item.instance, {
+                setDefault: setInstanceAsDefault,
+                openConfiguration: openInstanceConfiguration,
+              });
+              if (close) finish();
+            } else if (event.button === openConfigurationButton) {
+              finish();
+              await triggerInstancePickerButton('openConfiguration', event.item.instance, {
+                setDefault: setInstanceAsDefault,
+                openConfiguration: openInstanceConfiguration,
+              });
+            }
+          });
+        }),
+        quickPick.onDidHide(finish),
+      );
+      quickPick.show();
     });
-    if (!picked) return;
+  };
 
-    if (picked.instance.active) {
-      // Already active — just show config
-      await vscode.commands.executeCommand('b2c-dx.instance.inspect');
+  const switchInstanceDisposable = registerSafeCommand('b2c-dx.instance.switch', showInstancePicker);
+
+  const setDefaultInstanceDisposable = registerSafeCommand('b2c-dx.instance.setDefault', async () => {
+    const instances = await dwJsonSource.listInstances(getInstanceCatalogOptions());
+    if (instances.length === 0) {
+      vscode.window.showWarningMessage('No B2C Commerce instances configured.');
       return;
     }
+    const defaultSelection = await getDefaultInstanceSelection();
+    const picked = await vscode.window.showQuickPick(
+      instances.map((instance) => ({
+        label: `${isWorkspaceInstanceSelected(instance, defaultSelection) ? '$(star-full) ' : ''}${instance.name}`,
+        description: instance.hostname ?? '',
+        instance,
+      })),
+      {title: 'Set Default Instance', placeHolder: 'Select the default instance'},
+    );
+    if (picked) await setInstanceAsDefault(picked.instance);
+  });
 
-    try {
-      await dwJsonSource.setActiveInstance(picked.instance.name, getInstanceCatalogOptions());
-      // The FileSystemWatcher will detect the dw.json change and trigger reset,
-      // but fire manually in case the watcher is slow
-      configProvider.reset();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      vscode.window.showErrorMessage(`Failed to switch instance: ${message}`);
-    }
+  const followDefaultInstanceDisposable = registerSafeCommand('b2c-dx.instance.followDefault', async () => {
+    await configProvider.followDefaultInstance();
+    vscode.window.showInformationMessage('B2C DX: Following the default instance.');
   });
 
   const setProjectRootDisposable = registerSafeCommand('b2c-dx.setProjectRoot', async (uri?: vscode.Uri) => {
@@ -828,14 +980,14 @@ async function activateInner(context: vscode.ExtensionContext, log: vscode.Outpu
     registerXmlValidation(context, log);
   });
 
-  // Auto-mount the active instance's WebDAV filesystem as a workspace folder.
+  // Auto-mount the selected instance's WebDAV filesystem as a workspace folder.
   // Requires the WebDAV browser (which registers the b2c-webdav FileSystemProvider)
   // and must happen after activation so the provider is live before VS Code reads
   // the folder.
   if (webdavBrowserEnabled && settings.get<boolean>('features.sandboxFilesystem', false)) {
     try {
       if (mountSandboxFilesystem()) {
-        log.appendLine('[Workspace] Mounted active instance WebDAV filesystem as a workspace folder.');
+        log.appendLine('[Workspace] Mounted selected instance WebDAV filesystem as a workspace folder.');
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -857,6 +1009,8 @@ async function activateInner(context: vscode.ExtensionContext, log: vscode.Outpu
     instanceConfigRegistration,
     inspectInstanceDisposable,
     switchInstanceDisposable,
+    setDefaultInstanceDisposable,
+    followDefaultInstanceDisposable,
     setProjectRootDisposable,
     resetProjectRootDisposable,
     configChangeListener,

--- a/packages/b2c-vs-extension/src/instance-selection.ts
+++ b/packages/b2c-vs-extension/src/instance-selection.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import type {InstanceInfo} from '@salesforce/b2c-tooling-sdk/config';
+import * as path from 'path';
+
+export interface WorkspaceInstanceSelection {
+  name: string;
+  location: string;
+}
+
+export type InstanceConfigurationScope = 'project' | 'global';
+
+export interface InstancePickerEntry {
+  kind: 'follow' | 'separator' | 'instance';
+  scope?: InstanceConfigurationScope;
+  instance?: InstanceInfo;
+  selected?: boolean;
+  default?: boolean;
+  description?: string;
+}
+
+export interface InstancePickerSelection {
+  action?: 'follow';
+  instance?: InstanceInfo;
+}
+
+export interface InstancePickerSelectionActions {
+  followDefault(): Promise<void>;
+  selectForWorkspace(selection: WorkspaceInstanceSelection): Promise<void>;
+}
+
+export type InstancePickerButtonAction = 'setDefault' | 'openConfiguration';
+
+export interface InstancePickerButtonActions {
+  openConfiguration(instance: InstanceInfo): Promise<void>;
+  setDefault(instance: InstanceInfo): Promise<boolean>;
+}
+
+export interface TextOffsetRange {
+  start: number;
+  end: number;
+}
+
+/** Create the stable file-and-name identity persisted for a VS Code workspace. */
+export function createWorkspaceInstanceSelection(instance: InstanceInfo): WorkspaceInstanceSelection | undefined {
+  if (!instance.location) return undefined;
+  return {name: instance.name, location: path.resolve(instance.location)};
+}
+
+export function isWorkspaceInstanceSelected(
+  instance: InstanceInfo,
+  selection: WorkspaceInstanceSelection | undefined,
+): boolean {
+  return Boolean(
+    selection &&
+    instance.location &&
+    instance.name === selection.name &&
+    path.resolve(instance.location) === path.resolve(selection.location),
+  );
+}
+
+export function getInstanceConfigurationScope(
+  instance: InstanceInfo,
+  defaultConfigPath: string | undefined,
+): InstanceConfigurationScope {
+  return instance.location && defaultConfigPath && path.resolve(instance.location) === path.resolve(defaultConfigPath)
+    ? 'global'
+    : 'project';
+}
+
+/** Build the picker state independently from VS Code rendering and event wiring. */
+export function buildInstancePickerEntries(
+  instances: InstanceInfo[],
+  workspaceSelection: WorkspaceInstanceSelection | undefined,
+  defaultSelection: WorkspaceInstanceSelection | undefined,
+  defaultConfigPath: string | undefined,
+): InstancePickerEntry[] {
+  const currentSelection = workspaceSelection ?? defaultSelection;
+  const entries: InstancePickerEntry[] = [
+    {
+      kind: 'follow',
+      description: workspaceSelection
+        ? defaultSelection
+          ? `Use ${defaultSelection.name}`
+          : 'Use the default configuration'
+        : 'Currently following the default',
+    },
+  ];
+
+  for (const scope of ['project', 'global'] as const) {
+    const scopedInstances = instances.filter(
+      (instance) => getInstanceConfigurationScope(instance, defaultConfigPath) === scope,
+    );
+    if (scopedInstances.length === 0) continue;
+
+    entries.push({kind: 'separator', scope});
+    for (const instance of scopedInstances) {
+      entries.push({
+        kind: 'instance',
+        scope,
+        instance,
+        selected: isWorkspaceInstanceSelected(instance, currentSelection),
+        default: isWorkspaceInstanceSelected(instance, defaultSelection),
+      });
+    }
+  }
+
+  return entries;
+}
+
+/** Apply an accepted picker row. Opening or changing the default are separate button actions. */
+export async function acceptInstancePickerSelection(
+  picked: InstancePickerSelection,
+  actions: InstancePickerSelectionActions,
+): Promise<void> {
+  if (picked.action === 'follow') {
+    await actions.followDefault();
+    return;
+  }
+  if (!picked.instance) return;
+
+  const selection = createWorkspaceInstanceSelection(picked.instance);
+  if (!selection) throw new Error(`Could not select "${picked.instance.name}" for this workspace.`);
+  await actions.selectForWorkspace(selection);
+}
+
+/** Apply an instance-row button without conflating it with row selection. */
+export async function triggerInstancePickerButton(
+  action: InstancePickerButtonAction,
+  instance: InstanceInfo,
+  actions: InstancePickerButtonActions,
+): Promise<boolean> {
+  if (action === 'setDefault') return actions.setDefault(instance);
+
+  await actions.openConfiguration(instance);
+  return true;
+}
+
+/** Find the exact named entry to select after opening a multi-instance configuration. */
+export function findInstanceNameRange(text: string, name: string): TextOffsetRange | undefined {
+  const literal = JSON.stringify(name);
+  const escapedLiteral = literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`"name"\\s*:\\s*(${escapedLiteral})`).exec(text);
+  if (!match) return undefined;
+
+  const literalOffset = match[0].lastIndexOf(literal);
+  const start = match.index + literalOffset;
+  return {start, end: start + literal.length};
+}

--- a/packages/b2c-vs-extension/src/test/config-provider.test.ts
+++ b/packages/b2c-vs-extension/src/test/config-provider.test.ts
@@ -9,14 +9,48 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {B2CExtensionConfig} from '../config-provider.js';
+import type {WorkspaceInstanceSelection} from '../instance-selection.js';
+
+function createMemoryMemento(initial: Record<string, unknown> = {}): vscode.Memento {
+  const values = new Map(Object.entries(initial));
+  return {
+    keys: () => [...values.keys()],
+    get: <T>(key: string, defaultValue?: T) => (values.has(key) ? (values.get(key) as T) : defaultValue),
+    update: async (key: string, value: unknown) => {
+      if (value === undefined) values.delete(key);
+      else values.set(key, value);
+    },
+  } as vscode.Memento;
+}
+
+function waitForReset(provider: B2CExtensionConfig): Promise<void> {
+  return new Promise((resolve) => {
+    const disposable = provider.onDidReset(() => {
+      disposable.dispose();
+      resolve();
+    });
+  });
+}
 
 suite('B2CExtensionConfig workspace discovery', () => {
   let ambientEnvironment: NodeJS.ProcessEnv;
+  let log: vscode.OutputChannel;
   let settingsRoot: string;
+
+  suiteSetup(() => {
+    log = vscode.window.createOutputChannel('B2C Config Provider Tests');
+  });
+
+  suiteTeardown(() => {
+    log.dispose();
+  });
 
   setup(() => {
     settingsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-vscode-config-test-'));
-    ambientEnvironment = {B2C_CONFIG_DIR: path.join(settingsRoot, 'settings')};
+    ambientEnvironment = {
+      B2C_CONFIG_DIR: path.join(settingsRoot, 'settings'),
+      MRT_CREDENTIALS_FILE: path.join(settingsRoot, 'missing.mobify'),
+    };
     fs.mkdirSync(path.join(ambientEnvironment.B2C_CONFIG_DIR!, 'b2c'), {recursive: true});
   });
 
@@ -34,7 +68,6 @@ suite('B2CExtensionConfig workspace discovery', () => {
     } else if (workspaceFolders[0].name === 'first-workspace-folder') {
       expected = path.join(expected, 'projects', 'sfra');
     }
-    const log = vscode.window.createOutputChannel('B2C Config Discovery Test');
     const provider = new B2CExtensionConfig(log, undefined, ambientEnvironment);
 
     try {
@@ -42,7 +75,6 @@ suite('B2CExtensionConfig workspace discovery', () => {
       assert.strictEqual(provider.getWorkingDirectory(), expected);
     } finally {
       provider.dispose();
-      log.dispose();
     }
   });
 
@@ -59,7 +91,6 @@ suite('B2CExtensionConfig workspace discovery', () => {
       get: (key: string) => (key === 'b2c-dx.projectRoot' ? pinnedRoot : undefined),
       update: async () => {},
     } as vscode.Memento;
-    const log = vscode.window.createOutputChannel('B2C Config Pin Test');
     const provider = new B2CExtensionConfig(log, workspaceState, ambientEnvironment);
 
     try {
@@ -68,7 +99,6 @@ suite('B2CExtensionConfig workspace discovery', () => {
       assert.strictEqual(provider.isProjectRootPinned(), true);
     } finally {
       provider.dispose();
-      log.dispose();
     }
   });
 
@@ -81,7 +111,6 @@ suite('B2CExtensionConfig workspace discovery', () => {
     const globalDwJson = path.join(dir, 'dw.json');
     fs.writeFileSync(globalDwJson, JSON.stringify({hostname: 'global-config.invalid', username: 'u', password: 'p'}));
 
-    const log = vscode.window.createOutputChannel('B2C Config SFCC_CONFIG Test');
     const provider = new B2CExtensionConfig(log, undefined, {...ambientEnvironment, SFCC_CONFIG: globalDwJson});
 
     try {
@@ -96,7 +125,6 @@ suite('B2CExtensionConfig workspace discovery', () => {
       assert.strictEqual(provider.getConfigError(), null);
     } finally {
       provider.dispose();
-      log.dispose();
       fs.rmSync(dir, {recursive: true, force: true});
     }
   });
@@ -111,7 +139,6 @@ suite('B2CExtensionConfig workspace discovery', () => {
       path.join(dir, '.env'),
       'SFCC_CONFIG=./selected.dw.json\nSFCC_SERVER=project-env.invalid\nSFCC_CODE_VERSION=env-version\nB2C_TEST_PROJECT_ONLY_VARIABLE=available\n',
     );
-    const log = vscode.window.createOutputChannel('B2C Config Project Environment Test');
     const provider = new B2CExtensionConfig(log, undefined, ambientEnvironment);
 
     try {
@@ -131,7 +158,6 @@ suite('B2CExtensionConfig workspace discovery', () => {
       );
     } finally {
       provider.dispose();
-      log.dispose();
       fs.rmSync(dir, {recursive: true, force: true});
     }
   });
@@ -149,7 +175,6 @@ suite('B2CExtensionConfig workspace discovery', () => {
       path.join(settingsDirectory, 'settings.json'),
       JSON.stringify({defaultConfigPath: globalConfigPath}),
     );
-    const log = vscode.window.createOutputChannel('B2C Config Global Default Test');
     const provider = new B2CExtensionConfig(log, undefined, environment);
 
     try {
@@ -157,7 +182,228 @@ suite('B2CExtensionConfig workspace discovery', () => {
       assert.strictEqual(config.values.hostname, 'shared-default.invalid');
     } finally {
       provider.dispose();
-      log.dispose();
+      fs.rmSync(dir, {recursive: true, force: true});
+    }
+  });
+
+  test('uses a workspace-selected global instance without changing the shared default', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-workspace-instance-'));
+    const projectDirectory = path.join(dir, 'project');
+    const globalConfigPath = path.join(dir, 'shared.dw.json');
+    fs.mkdirSync(projectDirectory);
+    fs.writeFileSync(
+      globalConfigPath,
+      JSON.stringify({
+        configs: [
+          {name: 'default-instance', hostname: 'default.invalid', active: true},
+          {name: 'workspace-instance', hostname: 'workspace.invalid'},
+        ],
+      }),
+    );
+    const environment: NodeJS.ProcessEnv = {...ambientEnvironment, SFCC_CONFIG: undefined};
+    fs.writeFileSync(
+      path.join(environment.B2C_CONFIG_DIR!, 'b2c', 'settings.json'),
+      JSON.stringify({defaultConfigPath: globalConfigPath}),
+    );
+    const selected: WorkspaceInstanceSelection = {name: 'workspace-instance', location: globalConfigPath};
+    const workspaceState = {
+      keys: () => ['b2c-dx.workspaceInstance'],
+      get: <T>(key: string) => (key === 'b2c-dx.workspaceInstance' ? (selected as T) : undefined),
+      update: async () => {},
+    } as vscode.Memento;
+    const provider = new B2CExtensionConfig(log, workspaceState, environment);
+
+    try {
+      const config = await provider.resolveForDirectory(projectDirectory);
+      assert.strictEqual(config.values.hostname, 'workspace.invalid');
+      assert.strictEqual(config.values.instanceName, 'workspace-instance');
+      assert.deepStrictEqual(provider.getWorkspaceInstanceSelection(), selected);
+
+      const persisted = JSON.parse(fs.readFileSync(globalConfigPath, 'utf8'));
+      assert.strictEqual(persisted.configs[0].active, true);
+      assert.strictEqual(persisted.configs[1].active, undefined);
+    } finally {
+      provider.dispose();
+      fs.rmSync(dir, {recursive: true, force: true});
+    }
+  });
+
+  const resolutionCases: Array<{
+    name: string;
+    projectConfig?: Record<string, unknown>;
+    projectEnvironment?: string;
+    globalConfig?: Record<string, unknown>;
+    expectedHostname: string;
+  }> = [
+    {
+      name: 'resolves a simple project configuration',
+      projectConfig: {hostname: 'project.invalid'},
+      expectedHostname: 'project.invalid',
+    },
+    {
+      name: 'resolves project environment values without a configuration file',
+      projectEnvironment: 'SFCC_SERVER=environment.invalid\nSFCC_CODE_VERSION=environment-version\n',
+      expectedHostname: 'environment.invalid',
+    },
+    {
+      name: 'prefers a simple project configuration over the shared default',
+      projectConfig: {hostname: 'project.invalid'},
+      globalConfig: {configs: [{name: 'global', hostname: 'global.invalid', active: true}]},
+      expectedHostname: 'project.invalid',
+    },
+    {
+      name: 'uses the shared default when the project root is explicitly inactive',
+      projectConfig: {hostname: 'inactive-project.invalid', active: false},
+      globalConfig: {configs: [{name: 'global', hostname: 'global.invalid', active: true}]},
+      expectedHostname: 'global.invalid',
+    },
+    {
+      name: 'resolves the default from a shared multi-instance configuration alone',
+      globalConfig: {
+        configs: [
+          {name: 'development', hostname: 'development.invalid', active: true},
+          {name: 'staging', hostname: 'staging.invalid'},
+        ],
+      },
+      expectedHostname: 'development.invalid',
+    },
+  ];
+
+  for (const scenario of resolutionCases) {
+    test(scenario.name, async () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-resolution-matrix-'));
+      const projectDirectory = path.join(dir, 'project');
+      fs.mkdirSync(projectDirectory);
+      if (scenario.projectConfig) {
+        fs.writeFileSync(path.join(projectDirectory, 'dw.json'), JSON.stringify(scenario.projectConfig));
+      }
+      if (scenario.projectEnvironment) {
+        fs.writeFileSync(path.join(projectDirectory, '.env'), scenario.projectEnvironment);
+      }
+      if (scenario.globalConfig) {
+        const globalConfigPath = path.join(dir, 'shared.json');
+        fs.writeFileSync(globalConfigPath, JSON.stringify(scenario.globalConfig));
+        fs.writeFileSync(
+          path.join(ambientEnvironment.B2C_CONFIG_DIR!, 'b2c', 'settings.json'),
+          JSON.stringify({defaultConfigPath: globalConfigPath}),
+        );
+      }
+      const provider = new B2CExtensionConfig(log, createMemoryMemento(), ambientEnvironment);
+
+      try {
+        const config = await provider.resolveForDirectory(projectDirectory);
+        assert.strictEqual(config.values.hostname, scenario.expectedHostname);
+      } finally {
+        provider.dispose();
+        fs.rmSync(dir, {recursive: true, force: true});
+      }
+    });
+  }
+
+  test('persists a shared instance selection, survives reload, and follows the default without file changes', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-workspace-selection-lifecycle-'));
+    const projectDirectory = path.join(dir, 'project');
+    const globalConfigPath = path.join(dir, 'shared.json');
+    fs.mkdirSync(projectDirectory);
+    const originalContent = `${JSON.stringify(
+      {
+        configs: [
+          {name: 'development', hostname: 'development.invalid', active: true},
+          {name: 'staging', hostname: 'staging.invalid'},
+        ],
+      },
+      null,
+      2,
+    )}\n`;
+    fs.writeFileSync(globalConfigPath, originalContent);
+    fs.writeFileSync(
+      path.join(ambientEnvironment.B2C_CONFIG_DIR!, 'b2c', 'settings.json'),
+      JSON.stringify({defaultConfigPath: globalConfigPath}),
+    );
+    const workspaceState = createMemoryMemento();
+    let provider = new B2CExtensionConfig(log, workspaceState, ambientEnvironment);
+
+    try {
+      let config = await provider.resolveForDirectory(projectDirectory);
+      assert.strictEqual(config.values.instanceName, 'development');
+
+      let reset = waitForReset(provider);
+      await provider.selectInstanceForWorkspace({name: 'staging', location: globalConfigPath});
+      await reset;
+      config = await provider.resolveForDirectory(projectDirectory);
+      assert.strictEqual(config.values.instanceName, 'staging');
+      assert.strictEqual(fs.readFileSync(globalConfigPath, 'utf8'), originalContent);
+
+      provider.dispose();
+      provider = new B2CExtensionConfig(log, workspaceState, ambientEnvironment);
+      config = await provider.resolveForDirectory(projectDirectory);
+      assert.strictEqual(config.values.instanceName, 'staging');
+
+      reset = waitForReset(provider);
+      await provider.followDefaultInstance();
+      await reset;
+      config = await provider.resolveForDirectory(projectDirectory);
+      assert.strictEqual(config.values.instanceName, 'development');
+      assert.strictEqual(provider.getWorkspaceInstanceSelection(), undefined);
+      assert.strictEqual(fs.readFileSync(globalConfigPath, 'utf8'), originalContent);
+    } finally {
+      provider.dispose();
+      fs.rmSync(dir, {recursive: true, force: true});
+    }
+  });
+
+  test('uses the selected source when local and shared instances have the same name', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-exact-instance-source-'));
+    const projectDirectory = path.join(dir, 'project');
+    const globalConfigPath = path.join(dir, 'shared.json');
+    fs.mkdirSync(projectDirectory);
+    fs.writeFileSync(
+      path.join(projectDirectory, 'dw.json'),
+      JSON.stringify({configs: [{name: 'shared', hostname: 'project.invalid'}]}),
+    );
+    fs.writeFileSync(
+      globalConfigPath,
+      JSON.stringify({configs: [{name: 'shared', hostname: 'global.invalid', active: true}]}),
+    );
+    fs.writeFileSync(
+      path.join(ambientEnvironment.B2C_CONFIG_DIR!, 'b2c', 'settings.json'),
+      JSON.stringify({defaultConfigPath: globalConfigPath}),
+    );
+    const workspaceState = createMemoryMemento({
+      'b2c-dx.workspaceInstance': {name: 'shared', location: globalConfigPath},
+    });
+    const provider = new B2CExtensionConfig(log, workspaceState, ambientEnvironment);
+
+    try {
+      const config = await provider.resolveForDirectory(projectDirectory);
+      assert.strictEqual(config.values.hostname, 'global.invalid');
+    } finally {
+      provider.dispose();
+      fs.rmSync(dir, {recursive: true, force: true});
+    }
+  });
+
+  test('reports a stale workspace selection instead of falling back to another instance', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b2c-stale-workspace-instance-'));
+    const projectDirectory = path.join(dir, 'project');
+    const globalConfigPath = path.join(dir, 'shared.json');
+    fs.mkdirSync(projectDirectory);
+    fs.writeFileSync(
+      globalConfigPath,
+      JSON.stringify({configs: [{name: 'development', hostname: 'development.invalid', active: true}]}),
+    );
+    const workspaceState = createMemoryMemento({
+      'b2c-dx.workspaceInstance': {name: 'removed', location: globalConfigPath},
+    });
+    const provider = new B2CExtensionConfig(log, workspaceState, ambientEnvironment);
+
+    try {
+      await assert.rejects(
+        provider.resolveForDirectory(projectDirectory),
+        /Selected instance "removed" is no longer available/,
+      );
+    } finally {
+      provider.dispose();
       fs.rmSync(dir, {recursive: true, force: true});
     }
   });

--- a/packages/b2c-vs-extension/src/test/instance-selection.test.ts
+++ b/packages/b2c-vs-extension/src/test/instance-selection.test.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ * For full license text, see the license.txt file in the repo root or http://www.apache.org/licenses/LICENSE-2.0
+ */
+import type {InstanceInfo} from '@salesforce/b2c-tooling-sdk/config';
+import * as assert from 'assert';
+import * as path from 'path';
+import {
+  acceptInstancePickerSelection,
+  buildInstancePickerEntries,
+  createWorkspaceInstanceSelection,
+  findInstanceNameRange,
+  getInstanceConfigurationScope,
+  isWorkspaceInstanceSelected,
+  triggerInstancePickerButton,
+} from '../instance-selection.js';
+
+function instance(name: string, location?: string): InstanceInfo {
+  return {name, location, source: 'DwJsonSource'};
+}
+
+suite('instance selection', () => {
+  test('persists a file-and-name identity for workspace selection', () => {
+    const selected = createWorkspaceInstanceSelection(instance('development', './config/global.json'));
+
+    assert.deepStrictEqual(selected, {
+      name: 'development',
+      location: path.resolve('./config/global.json'),
+    });
+  });
+
+  test('does not conflate same-name instances from different configuration files', () => {
+    const selected = createWorkspaceInstanceSelection(instance('development', '/config/global.json'));
+
+    assert.strictEqual(isWorkspaceInstanceSelected(instance('development', '/project/config.json'), selected), false);
+    assert.strictEqual(isWorkspaceInstanceSelected(instance('development', '/config/global.json'), selected), true);
+  });
+
+  test('requires a source location for workspace selection', () => {
+    assert.strictEqual(createWorkspaceInstanceSelection(instance('development')), undefined);
+  });
+
+  test('identifies global and project configuration entries', () => {
+    const defaultPath = '/config/global.json';
+
+    assert.strictEqual(getInstanceConfigurationScope(instance('global', defaultPath), defaultPath), 'global');
+    assert.strictEqual(
+      getInstanceConfigurationScope(instance('project', '/project/config.json'), defaultPath),
+      'project',
+    );
+  });
+
+  test('builds independent workspace-selection and default markers', () => {
+    const projectPath = '/project/dw.json';
+    const globalPath = '/config/shared.json';
+    const local = instance('local', projectPath);
+    const sharedDefault = instance('default', globalPath);
+    const sharedSelected = instance('selected', globalPath);
+    const entries = buildInstancePickerEntries(
+      [local, sharedDefault, sharedSelected],
+      {name: 'selected', location: globalPath},
+      {name: 'default', location: globalPath},
+      globalPath,
+    );
+
+    assert.deepStrictEqual(
+      entries.map((entry) => [entry.kind, entry.scope, entry.instance?.name, entry.selected, entry.default]),
+      [
+        ['follow', undefined, undefined, undefined, undefined],
+        ['separator', 'project', undefined, undefined, undefined],
+        ['instance', 'project', 'local', false, false],
+        ['separator', 'global', undefined, undefined, undefined],
+        ['instance', 'global', 'default', false, true],
+        ['instance', 'global', 'selected', true, false],
+      ],
+    );
+    assert.strictEqual(entries[0].description, 'Use default');
+  });
+
+  test('marks the default as selected while the workspace follows it', () => {
+    const globalPath = '/config/shared.json';
+    const entries = buildInstancePickerEntries(
+      [instance('default', globalPath)],
+      undefined,
+      {name: 'default', location: globalPath},
+      globalPath,
+    );
+    const defaultEntry = entries.find((entry) => entry.instance?.name === 'default');
+
+    assert.strictEqual(entries[0].description, 'Currently following the default');
+    assert.strictEqual(defaultEntry?.selected, true);
+    assert.strictEqual(defaultEntry?.default, true);
+  });
+
+  test('accepting an instance selects it for the workspace and does not follow the default', async () => {
+    const calls: Array<{action: string; selection?: unknown}> = [];
+    await acceptInstancePickerSelection(
+      {instance: instance('development', '/config/shared.json')},
+      {
+        followDefault: async () => {
+          calls.push({action: 'follow'});
+        },
+        selectForWorkspace: async (selection) => {
+          calls.push({action: 'select', selection});
+        },
+      },
+    );
+
+    assert.deepStrictEqual(calls, [
+      {
+        action: 'select',
+        selection: {name: 'development', location: path.resolve('/config/shared.json')},
+      },
+    ]);
+  });
+
+  test('accepting Follow Default invokes only the follow action', async () => {
+    const calls: string[] = [];
+    await acceptInstancePickerSelection(
+      {action: 'follow'},
+      {
+        followDefault: async () => {
+          calls.push('follow');
+        },
+        selectForWorkspace: async () => {
+          calls.push('select');
+        },
+      },
+    );
+
+    assert.deepStrictEqual(calls, ['follow']);
+  });
+
+  test('instance row buttons invoke only their explicit action', async () => {
+    const selectedInstance = instance('development', '/config/shared.json');
+    const calls: string[] = [];
+    const actions = {
+      openConfiguration: async () => {
+        calls.push('open');
+      },
+      setDefault: async () => {
+        calls.push('set-default');
+        return false;
+      },
+    };
+
+    const changedDefault = await triggerInstancePickerButton('setDefault', selectedInstance, actions);
+    assert.strictEqual(changedDefault, false, 'a cancelled default change keeps the picker open');
+    assert.deepStrictEqual(calls, ['set-default']);
+
+    calls.length = 0;
+    const openedConfiguration = await triggerInstancePickerButton('openConfiguration', selectedInstance, actions);
+    assert.strictEqual(openedConfiguration, true);
+    assert.deepStrictEqual(calls, ['open']);
+  });
+
+  test('finds the exact named entry in a multi-instance configuration', () => {
+    const text = JSON.stringify(
+      {
+        configs: [
+          {name: 'development', hostname: 'development.invalid'},
+          {name: 'staging', hostname: 'staging.invalid'},
+        ],
+      },
+      null,
+      2,
+    );
+    const range = findInstanceNameRange(text, 'staging');
+
+    assert.ok(range);
+    assert.strictEqual(text.slice(range.start, range.end), '"staging"');
+  });
+
+  test('finds named root entries and JSON-escaped instance names', () => {
+    const name = 'developer "one"';
+    const text = JSON.stringify({name, hostname: 'development.invalid'}, null, 2);
+    const range = findInstanceNameRange(text, name);
+
+    assert.ok(range);
+    assert.strictEqual(text.slice(range.start, range.end), JSON.stringify(name));
+    assert.strictEqual(findInstanceNameRange(text, 'missing'), undefined);
+  });
+});


### PR DESCRIPTION
## Summary

- keep instance picker selections local to the current VS Code workspace instead of changing the shared default
- distinguish the workspace selection from the shared default in the picker and status bar
- add explicit Set Default, Follow Default, and Open Configuration actions
- reveal the exact named entry when opening a multi-instance configuration
- isolate VS Code test hosts and add coverage for local, environment, shared, multi-instance, precedence, persistence, and stale-selection scenarios

## Testing

- pnpm --filter b2c-vs-extension run test
  - main host: 413 passing, 2 optional pending
  - malformed configuration host: 9 passing
  - nested workspace: 13 passing, 1 workspace-dependent pending
  - multi-root workspace: 14 passing
- pnpm run lint:agent
- pnpm run typecheck:agent
- changed-file Prettier check
- documentation build and tooling-index validation
- packaged and archive-validated the VSIX

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and 3pl-approved is set by a maintainer

---

- [x] Relevant tests pass
- [x] Code is formatted