### PR TITLE
fix(test): correct job E2E assertions and add failure diagnostics

### DIFF
--- a/.changeset/scapi-migration.md
+++ b/.changeset/scapi-migration.md
@@ -10,7 +10,7 @@ Migrate `job`, `code`, `bm users`, `bm roles`, `sites`, and catalog discovery to
 
 `setup instance create` accepts optional SCAPI coordinates for SCAPI-first active-code-version detection. They are not required in `auto`; missing coordinates select OCAPI, and failed interactive detection reports the reason before allowing manual entry.
 
-This is a major release because SCAPI and OCAPI JSON/results intentionally retain their backend-specific shapes. Consumers that require a stable legacy shape must explicitly select OCAPI or use the exported compatibility/fallback primitives during the migration. SDK high-level code helpers accept an explicit scripts backend; dual-backend factories and `JobsCompatibilityBackend` expose reusable fallback without making implicit backend selection an SDK-wide policy.
+This is a major release because JSON/results can change shape during the migration. `job run`, `job wait`, and `job search` return canonical camelCase fields with either backend, including OCAPI fallback; consumers must update fields such as `execution_status` to `executionStatus`. Other commands can retain backend-specific shapes, for which explicitly selecting OCAPI preserves the legacy shape. SDK high-level code helpers accept an explicit scripts backend; dual-backend factories and `JobsCompatibilityBackend` expose reusable fallback without making implicit backend selection an SDK-wide policy.
 
 SCAPI currently requires client-credentials or JWT Bearer authentication. Browser-based user auth continues through OCAPI/WebDAV and is selected by `auto`; explicit SCAPI with user auth errors clearly until the platform adds support.
 

--- a/.github/workflows/e2e-shell-tests.yml
+++ b/.github/workflows/e2e-shell-tests.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   SFCC_DISABLE_TELEMETRY: ${{ vars.SFCC_DISABLE_TELEMETRY }}
+  SFCC_LOG_LEVEL: debug
 
 jobs:
   e2e-shell-tests:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -112,7 +112,7 @@ jobs:
           SFCC_MRT_API_KEY: ${{ secrets.SFCC_MRT_API_KEY }}
           # Test configuration
           NODE_ENV: test
-          SFCC_LOG_LEVEL: silent
+          SFCC_LOG_LEVEL: debug
         run: |
           echo "Running E2E tests with realm: ${TEST_REALM}"
           echo "Node version: $(node --version)"
@@ -222,7 +222,7 @@ jobs:
           SFCC_MRT_CLOUD_ORIGIN: ${{ vars.SFCC_MRT_CLOUD_ORIGIN }}
           SFCC_MRT_API_KEY: ${{ secrets.SFCC_MRT_API_KEY }}
           NODE_ENV: test
-          SFCC_LOG_LEVEL: silent
+          SFCC_LOG_LEVEL: debug
         run: |
           echo "Running Windows E2E tests with realm: $TEST_REALM"
           echo "Node version: $(node --version)"

--- a/packages/b2c-cli/test/functional/e2e/job-execution.test.ts
+++ b/packages/b2c-cli/test/functional/e2e/job-execution.test.ts
@@ -165,8 +165,8 @@ describe('Job Execution E2E Tests', function () {
       const response = JSON.parse(toString(result.stdout));
       expect(response).to.be.an('object');
       expect(
-        String(response.execution_status),
-        `--wait should leave the job in 'finished' state, but got '${response.execution_status}'`,
+        String(response.executionStatus),
+        `--wait should leave the job in 'finished' state, but got '${response.executionStatus}'`,
       ).to.equal('finished');
     });
   });
@@ -248,8 +248,8 @@ describe('Job Execution E2E Tests', function () {
       const response = JSON.parse(toString(result.stdout));
       expect(response.id).to.equal(executionId);
       expect(
-        String(response.execution_status),
-        `'job wait' should leave the job in 'finished' state, but got '${response.execution_status}'`,
+        String(response.executionStatus),
+        `'job wait' should leave the job in 'finished' state, but got '${response.executionStatus}'`,
       ).to.equal('finished');
     });
   });

--- a/packages/b2c-cli/test/functional/e2e/test-utils.ts
+++ b/packages/b2c-cli/test/functional/e2e/test-utils.ts
@@ -147,8 +147,10 @@ export async function runCLI(args: string[], options: CLIOptions = {}): Promise<
     env: {
       ...process.env,
       ...env,
-      SFCC_LOG_LEVEL: env.SFCC_LOG_LEVEL || process.env.SFCC_LOG_LEVEL || 'silent',
+      SFCC_LOG_LEVEL: env.SFCC_LOG_LEVEL || process.env.SFCC_LOG_LEVEL || 'debug',
     },
+    // Preserve stderr for assertions while also showing diagnostics in CI logs.
+    stderr: ['pipe', 'inherit'],
     reject: false,
     timeout,
     cwd,

--- a/packages/b2c-cli/test/functional/e2e_cli_test.sh
+++ b/packages/b2c-cli/test/functional/e2e_cli_test.sh
@@ -12,6 +12,7 @@
 # SFCC_SANDBOX_API_HOST     - Sandbox API hostname (default: admin.dx.commercecloud.salesforce.com)
 
 set -e
+export SFCC_LOG_LEVEL="${SFCC_LOG_LEVEL:-debug}"
 
 # Script directory for relative paths
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -24,6 +25,29 @@ SITE_ARCHIVE_PATH="$SCRIPT_DIR/fixtures/site_archive"
 # Test configuration
 SITE_ID="TestSite"
 TTL_HOURS=4  # 4 hours in case test fails and needs manual cleanup
+HTTP_DIAGNOSTICS_DIR=$(mktemp -d)
+
+# Keep response bodies on stdout for callers; log status and safe tracing headers on stderr.
+curl_with_diagnostics() {
+    local http_status curl_exit=0
+    : > "$HTTP_DIAGNOSTICS_DIR/headers"
+    : > "$HTTP_DIAGNOSTICS_DIR/body"
+    http_status=$(curl --silent --show-error \
+        --dump-header "$HTTP_DIAGNOSTICS_DIR/headers" \
+        --output "$HTTP_DIAGNOSTICS_DIR/body" \
+        --write-out '%{http_code}' "$@") || curl_exit=$?
+
+    echo "DEBUG: curl exit=$curl_exit HTTP status=$http_status" >&2
+    if [ -f "$HTTP_DIAGNOSTICS_DIR/headers" ]; then
+        # Allowlist diagnostic headers so Set-Cookie and other credentials stay private.
+        awk 'tolower($0) ~ /^(http\/|date:|server:|content-type:|www-authenticate:|[a-z0-9-]*request-id:|[a-z0-9-]*correlation-id:|sfdc_correlation_id:|x-dw-request-base-id:|traceparent:|tracestate:|x-amzn-trace-id:)/' \
+            "$HTTP_DIAGNOSTICS_DIR/headers" >&2
+    fi
+    if [ -f "$HTTP_DIAGNOSTICS_DIR/body" ]; then
+        cat "$HTTP_DIAGNOSTICS_DIR/body"
+    fi
+    return "$curl_exit"
+}
 
 # Cleanup function for error handling
 cleanup() {
@@ -45,6 +69,7 @@ cleanup() {
         $CLI ods delete "$ODS_ID" --force || true
     fi
 
+    rm -rf "$HTTP_DIAGNOSTICS_DIR"
     exit $exit_code
 }
 
@@ -116,7 +141,7 @@ echo "Step 3: Deploying code to sandbox..."
 
 $CLI code deploy "$CARTRIDGE_PATH" \
     --server "$SERVER" \
-    --code-version "e2e-test-version" --log-level trace --json
+    --code-version "e2e-test-version" --json
 
 echo "SUCCESS: Code deployed"
 echo ""
@@ -161,12 +186,11 @@ SLAS_CREATE_RESULT=$($CLI slas client create \
     --tenant-id "$TENANT_ID" \
     --channels "$SITE_ID" \
     --default-scopes \
-    --log-level trace \
     --redirect-uri "http://localhost:3000/callback" \
     --json)
 
 echo "DEBUG: SLAS create result:"
-echo "$SLAS_CREATE_RESULT" | jq .
+echo "$SLAS_CREATE_RESULT" | jq 'del(.secret)'
 
 # Extract client ID and secret from response
 SLAS_CLIENT_ID=$(echo "$SLAS_CREATE_RESULT" | jq -r '.clientId')
@@ -174,7 +198,7 @@ SLAS_SECRET=$(echo "$SLAS_CREATE_RESULT" | jq -r '.secret')
 
 if [ -z "$SLAS_SECRET" ] || [ "$SLAS_SECRET" == "null" ]; then
     echo "FAILED: Could not create SLAS client"
-    echo "$SLAS_CREATE_RESULT"
+    echo "$SLAS_CREATE_RESULT" | jq 'del(.secret)'
     exit 1
 fi
 
@@ -207,7 +231,7 @@ if [ -n "$CURL_EXTRA_HEADERS" ]; then
 fi
 
 # Get shopper token via client credentials (guest login)
-TOKEN_RESPONSE=$(curl -s "${SLAS_BASE}/shopper/auth/v1/organizations/${ORG_ID}/oauth2/token" \
+TOKEN_RESPONSE=$(curl_with_diagnostics "${SLAS_BASE}/shopper/auth/v1/organizations/${ORG_ID}/oauth2/token" \
     "${CURL_HEADER_ARGS[@]}" \
     -u "${SLAS_CLIENT_ID}:${SLAS_SECRET}" \
     -d "grant_type=client_credentials&channel_id=${SITE_ID}")
@@ -216,7 +240,7 @@ SHOPPER_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r '.access_token')
 
 if [ -z "$SHOPPER_TOKEN" ] || [ "$SHOPPER_TOKEN" == "null" ]; then
     echo "FAILED: Could not obtain shopper token"
-    echo "$TOKEN_RESPONSE" | jq
+    echo "$TOKEN_RESPONSE" | jq 'del(.access_token, .refresh_token, .id_token)'
     exit 1
 fi
 
@@ -228,7 +252,7 @@ echo ""
 ################################################################################
 echo "Step 8: Testing shopper product search..."
 
-SEARCH_RESPONSE=$(curl -s "${SLAS_BASE}/search/shopper-search/v1/organizations/${ORG_ID}/product-search?siteId=${SITE_ID}&limit=5&q=sample" \
+SEARCH_RESPONSE=$(curl_with_diagnostics "${SLAS_BASE}/search/shopper-search/v1/organizations/${ORG_ID}/product-search?siteId=${SITE_ID}&limit=5&q=sample" \
     "${CURL_HEADER_ARGS[@]}" \
     -H "Authorization: Bearer ${SHOPPER_TOKEN}")
 


### PR DESCRIPTION
## Summary

The scheduled CLI E2E suite still expects `execution_status` from `job run --wait` and `job wait`, which now return `executionStatus` with either backend. Update both assertions and clarify the intentional JSON changes in the pending SCAPI migration changeset.

Enable debug logging for Linux and Windows E2E runs and stream captured CLI stderr to the CI log. The shell shopper requests now record the actual HTTP status, curl exit code, and selected request/correlation headers. Omit the generated SLAS secret from result dumps and use debug rather than hardcoded trace logging.

The shell suite's Unauthorized shopper-token response remains under investigation. This change adds diagnostics for the next occurrence; it does not change authentication or retry behavior.

## Testing

- All local unit suites pass via `pnpm run test:agent`.
- Workspace build and `pnpm run lint:agent` pass.
- CLI test type-check, tooling-index verification, changed TypeScript/Markdown formatting, shell syntax, and workflow YAML parsing pass.
- Local HTTP probe verifies 401 response-body preservation, status/correlation logging, cookie exclusion, and transport-failure handling without stale response data.
- Execa probe verifies stderr is both streamed and retained while JSON stdout stays separate.
- Live reproduction using installed `b2c` on `bjml-dev`: a temporary private SLAS client with default scopes obtained a guest token after 10 seconds (HTTP 200); cleanup was verified. Full live E2E has not been rerun.

## Dependencies

- [x] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [x] Tests pass (`pnpm run test:agent`; full live E2E pending)
- [x] Code is formatted (changed-file Prettier checks and repository lint)
