### PR TITLE
@W-23999479: allow embedded: true for arch_type:controller

### DIFF
--- a/.changeset/controller-embedded-component-types.md
+++ b/.changeset/controller-embedded-component-types.md
@@ -1,0 +1,5 @@
+---
+'@salesforce/b2c-tooling-sdk': minor
+---
+
+Allow `embedded: true` component types on `arch_type: controller`. Previously the component type schema required `arch_type` to be `headless` whenever `embedded` was `true`; embedded content blocks (ECBs) are now supported on both headless and controller storefronts. The `embedded` ⟺ `component_id` requirement is unchanged.

--- a/packages/b2c-tooling-sdk/data/content-schemas/componenttype.json
+++ b/packages/b2c-tooling-sdk/data/content-schemas/componenttype.json
@@ -69,36 +69,6 @@
       "anyOf": [
         {
           "not": {
-            "properties": {
-              "embedded": {
-                "enum": [
-                  true
-                ]
-              }
-            },
-            "required": [
-              "embedded"
-            ]
-          }
-        },
-        {
-          "properties": {
-            "arch_type": {
-              "enum": [
-                "headless"
-              ]
-            }
-          },
-          "required": [
-            "arch_type"
-          ]
-        }
-      ]
-    },
-    {
-      "anyOf": [
-        {
-          "not": {
             "required": [
               "component_id"
             ]

--- a/packages/b2c-tooling-sdk/test/operations/content/validate.test.ts
+++ b/packages/b2c-tooling-sdk/test/operations/content/validate.test.ts
@@ -356,7 +356,7 @@ describe('content metadefinition validation', () => {
       expect(result.errors.some((e) => e.message.includes('requires property "component_id"'))).to.equal(true);
     });
 
-    it('fails when embedded is true and arch_type is not headless', () => {
+    it('passes when embedded is true with arch_type controller and component_id set', () => {
       const result = validateMetaDefinition(
         {
           group: 'content',
@@ -368,11 +368,10 @@ describe('content metadefinition validation', () => {
         },
         {type: 'componenttype'},
       );
-      expect(result.valid).to.equal(false);
-      expect(result.errors.some((e) => e.message.includes('headless'))).to.equal(true);
+      expect(result.valid).to.equal(true);
     });
 
-    it('fails when embedded is true and arch_type is missing', () => {
+    it('passes when embedded is true and arch_type is missing', () => {
       const result = validateMetaDefinition(
         {
           group: 'content',
@@ -383,8 +382,7 @@ describe('content metadefinition validation', () => {
         },
         {type: 'componenttype'},
       );
-      expect(result.valid).to.equal(false);
-      expect(result.errors.some((e) => e.message.includes('requires property "arch_type"'))).to.equal(true);
+      expect(result.valid).to.equal(true);
     });
 
     it('passes when embedded is false and component_id is missing', () => {


### PR DESCRIPTION
## Summary

### @W-23999479: Allow `embedded: true` for `arch_type: controller`

Relaxes the local component-type schema so `embedded: true` no longer requires `arch_type: headless`, mirroring the platform (digital) change so client-side `b2c content validate` stays in sync — otherwise the tooling would reject definitions the platform now accepts. 

- Removes the `embedded ⟹ arch_type: headless` `allOf` block from `packages/b2c-tooling-sdk/data/content-schemas/componenttype.json`
- inverts the two tests in `packages/b2c-tooling-sdk/test/operations/content/validate.test.ts` that previously asserted `embedded+controller` and `embedded` with missing `arch_type` were invalid (now expect `valid === true`)
- and adds a `@salesforce/b2c-tooling-sdk: minor` changeset. 

## Testing

2 tests were updated to assert the new logic and I ran the affected unit test suite for the content-validation operation:
`npx mocha "packages/b2c-tooling-sdk/test/operations/content/validate.test.ts"`

All 51 tests pass, including the two updated cases that now assert embedded: true + arch_type: controller and embedded: true with arch_type omitted are valid.

## Dependencies

- [ ] No net-new third-party dependencies were added
- [ ] If net-new third-party dependencies were added, rationale/discussion is included and `3pl-approved` is set by a maintainer

---

- [ ] Tests pass (`pnpm test`)
- [ ] Code is formatted (`pnpm run format`)
