### PR TITLE
docs: align Storefront Next guidance and enable main previews

### DIFF
--- a/.changeset/storefront-next-canonical-guidance.md
+++ b/.changeset/storefront-next-canonical-guidance.md
@@ -1,0 +1,7 @@
+---
+'@salesforce/b2c-dx-docs': patch
+'@salesforce/b2c-tooling-sdk': patch
+'@salesforce/b2c-agent-plugins': patch
+---
+
+Refocus Storefront Next guidance on managing existing storefronts with environment-variable updates, logs, deployments, and assistant support. Link to Salesforce's Business Manager setup guides and align the included skills and documentation search with that workflow.

--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -15,6 +15,12 @@ This skill covers documentation for the Agentic B2C Developer Toolkit.
   Describe outcomes people can request from their assistant; keep agent tool
   choreography, runtime internals, and implementation rationale in agent skills
   or contributor docs. Include technical details when they affect a user's choice.
+- Link to canonical Salesforce Developer Center or Help pages for platform setup,
+  requirements, and behavior. Toolkit guides supplement those workflows with our
+  CLI, MCP, IDE, and skills capabilities; avoid maintaining a competing setup
+  sequence. For Storefront Next, lead with Business Manager storefront setup and
+  reuse its resources; link to the template's push workflow for source deployments.
+  Keep matching agent skills aligned with those recommendations.
 - Say "B2C Commerce" rather than "Commerce" alone. Use "IDE Extension" for the
   editor product. The TypeScript SDK is a supporting foundation, not a primary
   toolkit product alongside CLI, IDE, and AI tools.

--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -351,7 +351,7 @@ pnpm run docs:preview
 ## Hosted Builds
 
 `.github/workflows/docs-preview.yml` publishes unreleased docs from `main` at
-`/next/` on the preview host after every push. PR previews use `/pr-<number>/` and
+`/pr-next/` on the preview host after every push. PR previews use `/pr-<number>/` and
 are removed when the PR closes. Both build packages and the docs site; neither
 refreshes published release history from GitHub.
 

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,10 +1,10 @@
 name: Docs Preview
 
 # Publish the VitePress docs site to S3 + CloudFront. Main has a persistent
-# /next/ preview; PR previews live at /pr-<n>/ and are removed when closed.
+# /pr-next/ preview; PR previews live at /pr-<n>/ and are removed when closed.
 #
 # Triggers:
-#   - push to main: refresh the unreleased documentation at /next/.
+#   - push to main: refresh the unreleased documentation at /pr-next/.
 #   - pull_request (docs/** changes): automatic preview build/refresh and cleanup.
 #   - workflow_dispatch: rebuild main, or supply pr_number to rebuild a PR.
 #
@@ -36,7 +36,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'Optional PR number from this repo. Leave blank to build main at /next/.'
+        description: 'Optional PR number from this repo. Leave blank to build main at /pr-next/.'
         required: false
         type: string
 
@@ -86,7 +86,8 @@ jobs:
               core.setOutput('action', 'main');
               core.setOutput('same_repo', 'true');
               core.setOutput('is_draft', 'false');
-              core.setOutput('preview_path', 'next');
+              // Keep the main preview within the deployment role's pr-* namespace.
+              core.setOutput('preview_path', 'pr-next');
               return;
             }
 
@@ -198,7 +199,7 @@ jobs:
         if: steps.cfg.outputs.enabled == 'true'
         run: pnpm -r run build # builds the SDK that TypeDoc reads for API docs
 
-      # DOCS_BASE_PATH prefixes assets and links for /next/ or /pr-<n>/.
+      # DOCS_BASE_PATH prefixes assets and links for /pr-next/ or /pr-<n>/.
       # The uxstudio S3 assets used by the production build are intentionally
       # skipped — no docs source references them.
       - name: Build documentation (preview base path)

--- a/docs/cli/custom-apis.md
+++ b/docs/cli/custom-apis.md
@@ -6,6 +6,8 @@ description: Commands for managing SCAPI Custom API endpoints, checking registra
 
 Check which SCAPI Custom API endpoints are active and investigate registration failures.
 
+See Salesforce's [Custom API Status Reports](https://developer.salesforce.com/docs/commerce/commerce-api/guide/custom-api-status-report.html) for registration behavior and error explanations.
+
 ![B2C CLI showing Custom API names, HTTP methods, and registration status.](/cli-custom-api-status.png)
 
 ## Global Custom APIs Flags

--- a/docs/cli/ecdn.md
+++ b/docs/cli/ecdn.md
@@ -6,6 +6,8 @@ description: Commands for managing eCDN (embedded Content Delivery Network) zone
 
 Commands for managing eCDN (embedded Content Delivery Network) for B2C Commerce storefronts.
 
+For zone setup, DNS, and certificate requirements, see Salesforce's [CDN Zones guide](https://developer.salesforce.com/docs/commerce/commerce-api/guide/cdn-zones.html).
+
 ## Global Flags
 
 All eCDN commands support these flags:
@@ -806,6 +808,8 @@ b2c ecdn page-shield scripts get --zone my-zone --script-id abc123
 
 ## MRT Rules
 
+For the routing sequence and Business Manager options, see [eCDN Rules for a Phased Headless Rollout](https://developer.salesforce.com/docs/commerce/commerce-api/guide/ecdn-rules-for-phased-headless-rollout.html).
+
 ### b2c ecdn mrt-rules get
 
 Get MRT ruleset for a zone.
@@ -960,6 +964,8 @@ b2c ecdn cipher-suites update --zone my-zone --suite-type Custom --ciphers "ECDH
 ---
 
 ## Origin Headers
+
+For setting the matching header in MRT and forwarding it from eCDN, follow [Send the Access Control Header from eCDN to the MRT Origin](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-launch-storefront.html#send-the-access-control-header-from-ecdn-to-the-mrt-origin).
 
 ### b2c ecdn origin-headers get
 

--- a/docs/cli/sfnext.md
+++ b/docs/cli/sfnext.md
@@ -6,15 +6,19 @@ description: Build, run, and deploy Storefront Next (SFNext) projects with B2C C
 
 The `b2c sfnext` commands help you scaffold, develop, and deploy Storefront Next (SFNext) projects. The commands are provided by the `@salesforce/storefront-next-dev` package and run under the B2C CLI.
 
-## Bootstrap a New Project
+For a storefront connected to your B2C Commerce instance, start with [storefront setup in Business Manager](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-quick-start-create-bm.html). It creates the API and MRT resources along with your storefront configuration. See our [Storefront Next guide](/guide/storefront-next) for ongoing CLI and assistant workflows.
 
-To scaffold a new Storefront Next project from outside an existing project, use `npx` so you don't need to install the B2C CLI globally first:
+<span id="bootstrap-a-new-project"></span>
+
+## Explore a Project Locally
+
+To explore the template locally, use `npx` from outside an existing project:
 
 ```bash
 npx @salesforce/b2c-cli sfnext create-storefront
 ```
 
-This creates a new project directory with everything you need: a Storefront Next template, scripts for development and deployment, and the B2C CLI as a development dependency.
+This creates local project files; it does not provision the storefront's B2C Commerce and MRT resources. See [Explore Storefront Next Code Locally](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-quick-start-create-sf.html) for the local workflow.
 
 ## In-Project Commands
 
@@ -22,16 +26,16 @@ Once you have a project, the scaffolded `package.json` includes scripts that wra
 
 ```bash
 pnpm run dev               # start the local dev server
-pnpm run push              # build and deploy a bundle to Managed Runtime
 pnpm run cartridge:generate
 pnpm run cartridge:deploy
 pnpm run config:inspect
 ```
 
-You can also invoke any command directly:
+For building and uploading bundles, use the template's `push` script and follow the [Storefront Next deployment guide](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-push-mrt-auto.html).
+
+You can also invoke development commands directly:
 
 ```bash
-b2c sfnext push
 b2c sfnext extensions list
 b2c sfnext scapi add
 b2c sfnext locales aggregate-extensions

--- a/docs/cli/slas.md
+++ b/docs/cli/slas.md
@@ -4,7 +4,7 @@ description: Commands for creating, updating, and managing Shopper Login and API
 
 # SLAS Commands
 
-Commands for managing Shopper Login and API Security (SLAS) clients.
+Commands for managing Shopper Login and API Access Service (SLAS) clients. For client types, user roles, and shopper authentication flows, see Salesforce's [Authorization for Shopper APIs](https://developer.salesforce.com/docs/commerce/commerce-api/guide/authorization-for-shopper-apis.html).
 
 ## Global SLAS Flags
 

--- a/docs/guide/commerce-apps.md
+++ b/docs/guide/commerce-apps.md
@@ -6,7 +6,7 @@ description: Use the B2C CLI and agent skills to validate, package, install, uni
 
 Commerce App Packages (CAPs) are the standard format for distributing B2C Commerce integrations. A CAP bundles back-end cartridges, IMPEX configuration data, and Storefront Next UI extensions into a single installable unit, deployed to an instance with a platform job.
 
-This page covers what the **B2C CLI** does for CAPs and the **agent skills** we recommend. It is intentionally brief: the [Commerce Apps ISV Developer Guide](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/commerce-apps-overview.html) on Salesforce Developers is the authoritative source for the CAP format, manifest schema, architectures, domains and extension points, the installation state machine, and the submission/registry process. Use this page for the CLI workflow; follow the links for the spec.
+Use the CLI workflows below to work with CAPs. For the package format, platform requirements, and submission process, see the [Commerce Apps ISV Developer Guide](https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/commerce-apps-overview.html).
 
 ## Develop CAPs with AI Agent Skills
 
@@ -81,7 +81,7 @@ The pull request contains the storefront changes the app provides, so a develope
 
 ### Inspecting Installed State
 
-After install, complete the setup wizard tasks in Business Manager or follow the deep links from `b2c cap tasks`. `b2c cap list` reports each installed app's **install status** and **configuration status** per site. For the full installation state machine (the `INSTALLING → INSTALLED → NOT_CONFIGURED → CONFIGURING → CONFIGURED` happy path plus the error and uninstall flows), see the [Architecture guide](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/architecture.html).
+After install, complete the setup wizard tasks in Business Manager or follow the deep links from `b2c cap tasks`. `b2c cap list` reports each installed app's **install status** and **configuration status** per site. For the full installation state machine (the `INSTALLING → INSTALLED → NOT_CONFIGURED → CONFIGURING → CONFIGURED` happy path plus the error and uninstall flows), see the [Architecture guide](https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/architecture.html).
 
 ## VS Code Extension Integration
 
@@ -131,8 +131,8 @@ Because `validate` and `package` are local-only, a typical pipeline validates an
 ## Reference
 
 - [CAP CLI Commands](/cli/cap) — full `b2c cap` command and flag reference
-- [Commerce Apps ISV Developer Guide](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/commerce-apps-overview.html) — the authoritative CAP specification, covering:
-  - [Architecture](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/architecture.html) — the three app architectures, extension points (e.g. `sfcc.app.tax.calculate`), UI targets, CAP directory structure, and the installation state machine
-  - [Development environment](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/development-environment.html) — sandbox setup, the `cap-dev` Claude Code skills, and the end-to-end lifecycle
-  - [Packaging](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/packaging.html) — required files, the `commerce-app.json` manifest, and zip layout
-  - [Testing & validation](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/testing-validation.html) and [submission & review](https://developer.salesforce.com/docs/commerce/commerce-solutions/guide/submission-review.html) — the registry review checklist and submission process
+- [Commerce Apps ISV Developer Guide](https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/commerce-apps-overview.html) — the authoritative CAP specification, covering:
+  - [Architecture](https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/architecture.html) — the three app architectures, extension points (e.g. `sfcc.app.tax.calculate`), UI targets, CAP directory structure, and the installation state machine
+  - [Development environment](https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/development-environment.html) — sandbox setup, the `cap-dev` Claude Code skills, and the end-to-end lifecycle
+  - [Packaging](https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/packaging.html) — required files, the `commerce-app.json` manifest, and zip layout
+  - [Testing & validation](https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/testing-validation.html) and [submission & review](https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/submission-review.html) — the registry review checklist and submission process

--- a/docs/guide/mrt-utilities.md
+++ b/docs/guide/mrt-utilities.md
@@ -188,4 +188,4 @@ The development pseudo store keeps production parity for missing keys and throws
 ## Related
 
 - [MRT CLI commands](/cli/mrt) — manage MRT projects, environments, and bundles from the CLI.
-- [Storefront Next](/guide/storefront-next) — end-to-end setup including MRT and local development.
+- [Storefront Next](/guide/storefront-next) — environment variables, logs, deployments, and assistant support.

--- a/docs/guide/storefront-next.md
+++ b/docs/guide/storefront-next.md
@@ -1,219 +1,125 @@
 ---
-description: Set up Storefront Next development environments using the B2C CLI to create sandboxes, SLAS clients, MRT environments, and deploy.
+description: Support Storefront Next development and operations with the B2C CLI, MCP, and agent skills. Manage environment variables, tail logs, and work with deployments.
 ---
 
 # Storefront Next
 
-Set up Storefront Next development environments using the B2C CLI to create sandboxes, SLAS clients, MRT environments, and deploy.
+Develop and operate your Storefront Next storefront with the B2C CLI and your AI assistant. Manage environment variables together, investigate runtime errors, and get help with routing, data fetching, and Page Designer components.
 
-To learn more about Storefront Next, see the [Storefront Next](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-get-started.html) documentation.
+<span id="step-1-create-an-on-demand-sandbox-optional"></span>
+<span id="step-2-create-a-slas-client"></span>
+<span id="step-3-create-an-mrt-environment"></span>
+<span id="connect-the-b2c-commerce-instance"></span>
+
+## Start with Storefront Setup
+
+Use **storefront setup in Business Manager** to create your storefront and its API clients, Managed Runtime project, default environment, and initial configuration. Follow the Salesforce guide for your source-code workflow:
+
+- [Create Storefront Next with a GitHub repository](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-quick-start-create-bm-github.html)
+- [Create Storefront Next with local code](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-quick-start-create-bm.html)
+
+Use the generated configuration for local development and the existing MRT resources for the operations below. For additional environments and production launch, follow [Launch Your Storefront Next](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-launch-storefront.html).
 
 ## Prerequisites
 
-- [B2C CLI installed](/guide/installation) or use `npx @salesforce/b2c-cli` to run commands without installing
-- Commerce Cloud realm access
-- A Storefront Next project
-- Appropriate Account Manager roles (detailed per step below)
+Use an existing Storefront Next project and an MRT API key with access to its project and target environment. See [CLI installation](/guide/installation) and [MRT configuration](/guide/configuration#mrt-api-key) for credentials and defaults. You can also replace `b2c` in these examples with `npx @salesforce/b2c-cli`.
 
-## Step 1: Create an On-Demand Sandbox (Optional)
+Replace `my-storefront` and `staging` with your MRT project and environment IDs.
 
-If you need a new sandbox instance for development, create one with the CLI.
+<span id="step-4-set-environment-variables"></span>
+<span id="variable-reference"></span>
+<span id="multi-site-configuration"></span>
 
-**Required Role:** Sandbox API User (see [Authentication Setup](/guide/authentication))
+## Manage Environment Variables
 
-```bash
-b2c sandbox create --realm <REALM> --wait
-```
+Storefront setup configures the initial MRT variables. Use the CLI to inspect or change selected values as your storefront evolves. Salesforce's [Environment Variables guide](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-environment-vars.html) covers naming, visibility, and supported configuration paths.
 
-Note the hostname from the output — you'll need it for later configuration.
-
-After creating a sandbox, you'll need to create or import sites. You can import SFRA in Business Manager under **Administration > Site Development > Site Import & Export**.
-
-See [Sandbox Commands](/cli/sandbox) for more options.
-
-## Step 2: Create a SLAS Client
-
-Create a SLAS client for your storefront to handle shopper authentication.
-
-**Required Role:** SLAS Organization Administrator with a tenant filter matching your tenant.
-
-Your tenant ID is found in Business Manager under **Administration > Site Development > Salesforce Commerce API Settings**. It is the organization ID without the `f_ecom_` prefix — for example, if your organization ID is `f_ecom_abcd_001`, your tenant ID is `abcd_001`. You can pass either form to the `--tenant-id` flag and the CLI will handle it.
+### Update Several Values Together
 
 ```bash
-b2c slas client create \
-  --tenant-id <TENANT_ID> \
-  --channels <SITE_ID> \
-  --redirect-uri "http://localhost:5173,https://*.exp-delivery.com/callback" \
-  --default-scopes
-```
+# Inspect the target environment's variables.
+b2c mrt env var list --project my-storefront --environment staging
 
-The client is created as a private client by default (no `--public` flag needed).
-
-::: warning
-Save the client ID and secret from the output — the secret is only shown once and cannot be retrieved later.
-:::
-
-See [SLAS Commands](/cli/slas) for more options.
-
-## Step 3: Create an MRT Environment
-
-Set up a Managed Runtime environment to host your storefront.
-
-**Prerequisites:**
-- An MRT API key from [runtime.commercecloud.com](https://runtime.commercecloud.com/)
-- An MRT project (see [`b2c mrt project create`](/cli/mrt#b2c-mrt-project-create) to create one)
-
-::: tip
-Configure your API key in `~/.mobify`, `dw.json`, or via the `MRT_API_KEY` environment variable so you don't need to pass it on every command. See [Configuration](/guide/configuration) for all available options.
-:::
-
-Find your short code in Business Manager under **Administration > Salesforce Commerce API Settings**.
-
-```bash
-b2c mrt env create <SLUG> \
-  --project <PROJECT> \
-  --name "<NAME>" \
-  --allow-cookies \
-  --proxy "api=<SHORT_CODE>.api.commercecloud.salesforce.com" \
-  --wait
-```
-
-### Connect the B2C Commerce Instance
-
-After creating the environment, link it to your B2C Commerce instance by setting the tenant and site IDs:
-
-```bash
-b2c mrt env b2c -p <PROJECT> -e <ENVIRONMENT> \
-  --instance-id <TENANT_ID> \
-  --sites <SITE_ID>
-```
-
-See [MRT Commands](/cli/mrt) for more options.
-
-## Step 4: Set Environment Variables
-
-Configure your MRT environment with the required Storefront Next variables.
-
-Your organization ID and short code are found in Business Manager under **Administration > Site Development > Salesforce Commerce API Settings**. The organization ID has the form `f_ecom_abcd_001`.
-
-```bash
+# Set locale defaults together in one update.
 b2c mrt env var set \
-  PUBLIC__app__commerce__api__clientId=<SLAS_CLIENT_ID> \
-  PUBLIC__app__commerce__api__organizationId=<ORG_ID> \
-  PUBLIC__app__commerce__api__siteId=<SITE_ID> \
-  PUBLIC__app__commerce__api__shortCode=<SHORT_CODE> \
-  PUBLIC__app__commerce__api__proxy=/mobify/proxy/api \
-  PUBLIC__app__commerce__api__callback=/callback \
-  PUBLIC__app__commerce__api__privateKeyEnabled=true \
-  PUBLIC__app__defaultSiteId=<SITE_ID> \
-  PUBLIC__app__i18n__fallbackLng="en-US" \
-  PUBLIC__app__i18n__supportedLngs='["en-US"]' \
-  PUBLIC__app__commerce__sites='[{"id": "<SITE_ID>", "defaultLocale": "en-US", "defaultCurrency": "USD", "supportedLocales": [{"id": "en-US", "preferredCurrency": "USD"}], "supportedCurrencies": ["USD"]}]' \
-  COMMERCE_API_SLAS_SECRET=<SLAS_CLIENT_SECRET> \
-  -p <PROJECT> -e <ENVIRONMENT>
+  PUBLIC__app__i18n__fallbackLng=en-US \
+  'PUBLIC__app__i18n__supportedLngs=["en-US","fr-FR"]' \
+  --project my-storefront --environment staging
 ```
 
-::: tip Push from a local `.env` file
-If you keep these values in a local `.env`, use [`b2c mrt env var push`](/cli/mrt#b2c-mrt-env-var-push) instead. It diffs the local file against the remote environment, shows what would change, and prompts before applying.
-:::
+Use locales supported by your storefront and sites. Variable changes redeploy the environment; wait for that deployment before checking the result. Keep secrets out of `PUBLIC__` variables, which are exposed to the browser.
 
-### Variable Reference
+### Apply an Environment File
 
-| Variable | Description |
-|----------|-------------|
-| `PUBLIC__app__commerce__api__clientId` | SLAS client ID from Step 2 |
-| `PUBLIC__app__commerce__api__organizationId` | Commerce Cloud organization ID (e.g., `f_ecom_aaaa_prd`) |
-| `PUBLIC__app__commerce__api__siteId` | Site ID (e.g., `RefArch`) |
-| `PUBLIC__app__commerce__api__shortCode` | Short code from Business Manager |
-| `PUBLIC__app__commerce__api__proxy` | Proxy path for API requests |
-| `PUBLIC__app__commerce__api__callback` | OAuth callback path |
-| `PUBLIC__app__commerce__api__privateKeyEnabled` | Must be `true` for private SLAS clients |
-| `PUBLIC__app__defaultSiteId` | Default site ID for the storefront |
-| `PUBLIC__app__i18n__fallbackLng` | Fallback locale (e.g., `en-US`) |
-| `PUBLIC__app__i18n__supportedLngs` | JSON array of supported locales (e.g., `["en-US"]`) |
-| `PUBLIC__app__commerce__sites` | JSON array of site configurations (see below) |
-| `COMMERCE_API_SLAS_SECRET` | SLAS client secret from Step 2 |
-
-Most of these values match what's in your project's `.env` file. The `privateKeyEnabled` variable must be set to `true` when using a private SLAS client.
-
-::: warning
-The `COMMERCE_API_SLAS_SECRET` contains sensitive credentials. Treat it accordingly and avoid committing it to source control.
-:::
-
-### Multi-Site Configuration
-
-The `PUBLIC__app__commerce__sites` variable defines the sites, locales, and currencies for your storefront. Each site entry includes:
-
-```json
-[
-  {
-    "id": "SiteID",
-    "defaultLocale": "en-US",
-    "defaultCurrency": "USD",
-    "supportedLocales": [
-      { "id": "en-US", "preferredCurrency": "USD" }
-    ],
-    "supportedCurrencies": ["USD"]
-  }
-]
-```
-
-Add additional objects to the array for multi-site setups.
-
-## Step 5: Deploy
-
-Deploy your Storefront Next project from the project directory.
-
-**Primary method** using the Storefront Next CLI:
+Keep the values intended for each MRT environment in a separate file. Review the proposed changes before applying them:
 
 ```bash
-pnpm sfnext push --project-slug <PROJECT> --target <ENVIRONMENT>
+b2c mrt env var push --file .env.staging \
+  --project my-storefront --environment staging
 ```
 
-This is run from your Storefront Next project directory.
+The command compares the file with the target, shows the differences, and asks for confirmation. It leaves remote variables absent from the file unchanged and excludes `MRT_` variables by default. Review local-only values and instance-specific credentials before sharing configuration across environments; keep files containing secrets out of source control.
 
-**Alternative** using the B2C CLI directly (builds and deploys):
+See [MRT environment variable commands](/cli/mrt#environment-variable-commands) for individual updates, removal, and file options.
+
+<span id="step-6-debugging-with-log-tailing"></span>
+
+## Tail Application Logs
+
+Stream logs while reproducing a server-rendering error or checking a deployment:
 
 ```bash
-b2c mrt bundle deploy -p <PROJECT> -e <ENVIRONMENT> \
-  --ssr-only '["server/**/*", "loader.js", "sfnext-server-*.mjs", "streamingHandler.{js,mjs,cjs}", "streamingHandler.{js,mjs,cjs}.map", "!static/**/*", "!**/*.stories.tsx", "!**/*.stories.ts", "!**/*-snapshot.tsx", "!.storybook/**/*", "!storybook-static/**/*", "!**/__mocks__/**/*", "!**/__snapshots__/**/*"]' \
-  --ssr-shared '["client/**/*", "static/**/*", "**/*.css", "**/*.png", "**/*.jpg", "**/*.jpeg", "**/*.gif", "**/*.svg", "**/*.ico", "**/*.woff", "**/*.woff2", "**/*.ttf", "**/*.eot", "!**/*.stories.tsx", "!**/*.stories.ts", "!**/*-snapshot.tsx", "!.storybook/**/*", "!storybook-static/**/*", "!**/__mocks__/**/*", "!**/__snapshots__/**/*"]'
+b2c mrt tail-logs --project my-storefront --environment staging
+
+# Show errors and warnings.
+b2c mrt tail-logs --project my-storefront --environment staging \
+  --level ERROR --level WARN
+
+# Match an error or request pattern.
+b2c mrt tail-logs --project my-storefront --environment staging \
+  --search 'timeout|500'
 ```
 
-These patterns match the defaults used by `pnpm sfnext push`. The `--ssr-only` and `--ssr-shared` flags accept either a JSON array (for patterns with brace expansion) or a comma-separated string, and can be overridden if your project structure differs.
+Press Ctrl+C to stop. See [Logging in Storefront Next](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-logging.html) for application logging conventions. For historical investigation across MRT, SLAS, and eCDN, follow [Debug Your Storefront Next Site Using Log Center](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-debug-log-center.html).
 
-## Step 6: Debugging with Log Tailing
+<span id="step-5-deploy"></span>
 
-After deploying, you can tail application logs in real time to debug runtime issues.
+## Work with Deployments
+
+For source builds and uploads, follow the [Storefront Next deployment workflow](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-push-mrt-auto.html) using the template's `push` package script (`sfnext push`). It uses the MRT resources created during setup.
+
+Use the B2C CLI to inspect uploaded bundles or deploy an existing bundle to a selected environment:
 
 ```bash
-# Tail all logs from your environment
-b2c mrt tail-logs -p <PROJECT> -e <ENVIRONMENT>
+b2c mrt bundle list --project my-storefront
 
-# Show only errors and warnings
-b2c mrt tail-logs -p <PROJECT> -e <ENVIRONMENT> --level ERROR --level WARN
-
-# Search for specific patterns
-b2c mrt tail-logs -p <PROJECT> -e <ENVIRONMENT> --search "timeout|500"
+# Deploy a reviewed bundle; replace 12345 with its ID.
+b2c mrt bundle deploy 12345 --project my-storefront --environment staging
 ```
 
-This is useful for diagnosing deployment failures, SSR errors, and API connectivity issues. See [MRT Commands](/cli/mrt#b2c-mrt-tail-logs) for all options.
+For release automation, see [MRT commands](/cli/mrt#bundle-commands) and [CI/CD with GitHub Actions](/guide/ci-cd). For vanity domains, routing, and access-control headers, use the [Storefront Next launch guide](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-launch-storefront.html) alongside the [eCDN commands](/cli/ecdn).
 
-## Summary
+## Work with Your AI Assistant
 
-| Step | Command | Required? |
-|------|---------|-----------|
-| 1. Create Sandbox | `b2c sandbox create` | Optional |
-| 2. Create SLAS Client | `b2c slas client create` | Yes |
-| 3. Create MRT Environment | `b2c mrt env create` | Yes |
-| 4. Set Environment Variables | `b2c mrt env var set` | Yes |
-| 5. Deploy | `pnpm sfnext push` or `b2c mrt bundle deploy` | Yes |
-| 6. Debug with Log Tailing | `b2c mrt tail-logs` | Optional |
+The [B2C MCP](/mcp/) includes Storefront Next skills for routing, data fetching, configuration, Page Designer, testing, and deployment. Your assistant can use that guidance alongside documentation search and the toolkit's operations. No separate skills installation is needed; [standalone Agent Skills](/guide/agent-skills) are also available.
+
+<ExamplePrompt>
+
+> Review my Storefront Next project's configuration and the staging MRT environment. Identify differences relevant to this deployment and explain the proposed changes before applying them.
+
+</ExamplePrompt>
+
+<ExamplePrompt>
+
+> Add a Page Designer component with an editable heading, image, and link. Follow the patterns in this Storefront Next project and explain how to preview it.
+
+</ExamplePrompt>
+
+MRT environment-variable management and log tailing use the B2C CLI, so make it available when asking your assistant to perform those tasks.
 
 ## Next Steps
 
-- [Configuration](/guide/configuration) — configure CLI defaults and credentials
-- [Authentication Setup](/guide/authentication) — detailed auth setup for all commands
-- [Sandbox Commands](/cli/sandbox) — manage on-demand sandboxes
-- [SLAS Commands](/cli/slas) — manage SLAS clients and tenants
-- [MRT Commands](/cli/mrt) — manage MRT projects, environments, and deployments
+- [Storefront Next documentation](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-get-started.html) - Platform setup and development guides.
+- [Manage Sites for Storefront Next](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-manage-sites.html) - Site assignments in Business Manager.
+- [Deploy the Page Designer cartridge](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-pd-deploy-cartridge.html) - Publish component metadata to your B2C Commerce instance.
+- [Operations](/guide/operations) - Investigate job health and checkout incidents with your assistant.

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -9,7 +9,7 @@ New to the toolkit? Start with the [Introduction](./index) for installation and 
 
 ## Development
 
-- [Storefront Next](./storefront-next) - Set up a storefront development workflow.
+- [Storefront Next](./storefront-next) - Manage environment variables, tail logs, and develop with your AI assistant.
 - [Scaffolding](./scaffolding) - Generate projects, cartridges, and components.
 - [Script debugger](./script-debugger) - Inspect live cartridge code with your editor or AI assistant.
 - [IDE integration](./ide-integration) - Connect editor tooling and Script API IntelliSense.

--- a/packages/b2c-tooling-sdk/data/tooling/index.json
+++ b/packages/b2c-tooling-sdk/data/tooling/index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generatedAt": "2026-09-12T00:57:43.925Z",
+  "generatedAt": "2026-09-12T03:40:30.210Z",
   "entries": [
     {
       "id": "cli-account-manager",
@@ -224,7 +224,7 @@
       "category": "tooling",
       "url": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/cli/sfnext.html",
       "sourceUrl": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/cli/sfnext.md",
-      "headings": "Bootstrap a New Project • In-Project Commands • Topics",
+      "headings": "Explore a Project Locally • In-Project Commands • Topics",
       "preview": "Build, run, and deploy Storefront Next (SFNext) projects with B2C CLI plugin commands for scaffolding new storefronts, generating cartridges, managing extensions, and pushing bundles to Managed Runtime."
     },
     {
@@ -449,8 +449,8 @@
       "category": "tooling",
       "url": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/storefront-next.html",
       "sourceUrl": "https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/storefront-next.md",
-      "headings": "Prerequisites • Step 1: Create an On-Demand Sandbox (Optional) • Step 2: Create a SLAS Client • Step 3: Create an MRT Environment • Connect the B2C Commerce Instance • Step 4: Set Environment Variables • Variable Reference • Multi-Site Configuration • Step 5: Deploy • Step 6: Debugging with Log Tailing • Summary • Next Steps",
-      "preview": "Set up Storefront Next development environments using the B2C CLI to create sandboxes, SLAS clients, MRT environments, and deploy."
+      "headings": "Start with Storefront Setup • Prerequisites • Manage Environment Variables • Update Several Values Together • Apply an Environment File • Tail Application Logs • Work with Deployments • Work with Your AI Assistant • Next Steps",
+      "preview": "Support Storefront Next development and operations with the B2C CLI, MCP, and agent skills. Manage environment variables, tail logs, and work with deployments."
     },
     {
       "id": "guide-third-party-plugins",

--- a/skills/storefront-next/skills/sfnext-deployment/SKILL.md
+++ b/skills/storefront-next/skills/sfnext-deployment/SKILL.md
@@ -11,6 +11,12 @@ This skill covers building and deploying Storefront Next storefronts to Managed 
 
 Storefront Next storefronts are deployed to MRT as bundles. The `sfnext` CLI handles building and pushing bundles, while environment configuration is managed through MRT environment variables.
 
+Reuse the MRT project, environment, and credentials created by Business Manager
+storefront setup. Follow the [deployment guide](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-push-mrt-auto.html)
+for source deployments and the [launch guide](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-launch-storefront.html)
+for staging/production rollout. Creating new SLAS clients or MRT resources is not
+a prerequisite to each deployment.
+
 ## Production Build
 
 ```bash
@@ -29,23 +35,26 @@ The production build:
 
 ## Deploying to MRT
 
-### Using sfnext CLI
+### Using the Template's Push Script
+
+Use the project's `push` script (`sfnext push --project-directory .`). Build first;
+the push command requires existing build output. With the template's pnpm setup:
 
 ```bash
 # Push the current build to MRT
-pnpm push
+pnpm run push
 
 # Push with a specific message
-pnpm sfnext push -m "Release v1.2.0"
+pnpm run push --message "Release v1.2.0"
 
 # Push to a specific environment
-pnpm sfnext push --environment staging --wait
+pnpm run push --environment staging --wait
 ```
 
 ### Deployment Flow
 
 ```
-pnpm build → pnpm push → MRT receives bundle → Deployed to environment
+pnpm run build → pnpm run push → MRT receives bundle → Deployed to environment
 ```
 
 See [MRT Deployment Reference](references/MRT-DEPLOYMENT.md) for detailed deployment options.
@@ -54,9 +63,15 @@ See [MRT Deployment Reference](references/MRT-DEPLOYMENT.md) for detailed deploy
 
 Environment variables for MRT are configured through:
 
-1. **MRT Dashboard** — Set `PUBLIC__` variables per environment (baked into the app at build time)
+1. **Runtime Admin or `b2c mrt env var set/push`** — Set application variables per environment; `PUBLIC__` values merge into runtime configuration and are browser-visible. Changes redeploy the environment.
 2. **CLI flags or `MRT_*` environment variables** — Control push/deploy targets
 3. **`.env` files** — Local development only (not deployed)
+
+Use `b2c mrt env var push --file .env.staging --project <project> --environment <environment>`
+to explicitly apply a reviewed file. It shows a diff and prompts; omit local-only
+values and use credentials for the target instance. See [Environment Variables](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-environment-vars.html)
+for visibility, naming, and limits. MRT variable management and log tailing use
+the B2C CLI; there are no equivalent dedicated MCP tools.
 
 ### MRT Deployment Variables
 

--- a/skills/storefront-next/skills/sfnext-deployment/references/MRT-DEPLOYMENT.md
+++ b/skills/storefront-next/skills/sfnext-deployment/references/MRT-DEPLOYMENT.md
@@ -12,14 +12,14 @@ MRT is the hosting platform for Storefront Next storefronts. It provides:
 ## Deployment Commands
 
 ```bash
-# Build and push in one step
-pnpm build && pnpm push
+# Build, then run the template's push script
+pnpm run build && pnpm run push
 
 # Push with deployment message
-pnpm sfnext push -m "Fix checkout flow"
+pnpm run push --message "Fix checkout flow"
 
 # Push to specific environment
-pnpm sfnext push --environment production --wait
+pnpm run push --environment production --wait
 
 # Create a bundle without deploying (inspection/custom pipelines)
 pnpm sfnext create-bundle -d . -o .bundle
@@ -31,16 +31,14 @@ pnpm sfnext create-bundle -d . -o .bundle
 
 Environment variables are set per-environment through:
 
-1. **MRT Dashboard** — UI for managing environment variables
-2. **CLI/.env values** — `SFCC_MRT_*` values used by `pnpm sfnext push`
+1. **Runtime Admin or `b2c mrt env var set/push`** — Application variables on the selected environment; changes redeploy it.
+2. **`MRT_PROJECT`, `MRT_TARGET`, `MRT_API_KEY`** — Deployment target and credentials for `pnpm sfnext push`; these do not upload application variables from `.env`.
 
 ### Variable Limits
 
-| Constraint              | Limit              |
-| ----------------------- | ------------------ |
-| Variable name length    | 512 characters max |
-| Total `PUBLIC__` values | 32KB max           |
-| Nesting depth           | 10 levels max      |
+See Salesforce's [Environment Variables constraints](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-environment-vars.html#constraints)
+for current limits. The 32 KB value-size limit covers all environment variables,
+not only `PUBLIC__` values. Public configuration paths must exist in `config.server.ts`.
 
 ### Production Configuration Example
 

--- a/skills/storefront-next/skills/sfnext-project-setup/SKILL.md
+++ b/skills/storefront-next/skills/sfnext-project-setup/SKILL.md
@@ -9,11 +9,23 @@ This skill guides you through creating and configuring a Storefront Next project
 
 ## Overview
 
-Storefront Next storefronts run on Managed Runtime (MRT) with all SCAPI requests executing server-side. Projects are created with `create-storefront` from `@salesforce/storefront-next-dev` and use TypeScript exclusively (`.ts`/`.tsx` files only — `.js`/`.jsx`/`.mjs`/`.cjs` are forbidden).
+Storefront Next storefronts run on Managed Runtime (MRT) with all SCAPI requests executing server-side. Use Business Manager storefront setup for an instance-connected storefront; use `create-storefront` for local exploration. Project application source uses TypeScript (`.ts`/`.tsx`); follow the project's configuration for build scripts.
 
 ## Creating a Project
 
-### Via CLI (local development)
+### Via Business Manager (instance-connected storefront)
+
+Prefer storefront setup: it creates API clients, MRT resources, initial configuration,
+and a deployment. Reuse those resources; do not create replacement SLAS clients or
+MRT projects as routine setup. Choose the [GitHub workflow](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-quick-start-create-bm-github.html)
+or [local-code workflow](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-quick-start-create-bm.html).
+Use the downloaded `env.txt` as the project's `.env`; do not invent tenant/site IDs
+or expose its secrets. Guide the user through Business Manager when setup is needed.
+
+### Via CLI (local exploration)
+
+Use for template exploration without provisioning instance resources. To connect
+to the user's instance, follow storefront setup above and use its configuration.
 
 ```bash
 # Create a new storefront project (interactive)
@@ -31,10 +43,6 @@ pnpm install
 # Start development server
 pnpm dev
 ```
-
-### Via Business Manager
-
-Projects can also be created from Business Manager, which sets up the storefront with Commerce Cloud credentials pre-configured.
 
 ## Project Structure
 
@@ -79,13 +87,18 @@ See [Project Structure Reference](references/PROJECT-STRUCTURE.md) for detailed 
 
 ## Environment Setup
 
-Copy `.env.default` to `.env` and configure required Commerce Cloud credentials:
+For Business Manager-created storefronts, use the downloaded configuration.
+For local CLI exploration, copy `.env.default` to `.env`:
 
 ```bash
 cp .env.default .env
 ```
 
 ### Required Variables
+
+Use values from the selected storefront. This is a configuration example, not a
+request to provision new credentials. See Salesforce's [Environment Variables](https://developer.salesforce.com/docs/commerce/sfnext/guide/sfnext-mrt-environment-vars.html)
+for public/server-only visibility and supported paths.
 
 ```bash
 PUBLIC__app__commerce__api__clientId=your-client-id


### PR DESCRIPTION
## Summary

Refocus the Storefront Next guide on operating an existing storefront with the B2C CLI and an AI assistant. Direct initial setup to Business Manager's storefront setup and source builds/uploads to the Storefront Next template's push workflow. Keep practical examples for environment-variable updates, file synchronization, log tailing, and existing-bundle operations.

- Align the bundled Storefront Next setup and deployment skills with the same workflows, and refresh the documentation search index.
- Add canonical Salesforce links for eCDN, SLAS, Custom APIs, and Commerce Apps; update related guide descriptions and documentation authoring guidance.
- Publish persistent main docs previews at `/pr-next/`. The existing deployment role rejects `next/*`; the working PR prefix supports automatic refreshes from main without IAM changes.

Includes a changeset for the documentation, bundled search index, and agent skills.

## Testing

- Production documentation build passes; verified built guide links, section anchors, example prompts, and Markdown export.
- Eight guide CLI examples parse against current command schemas; shell syntax checks pass.
- MCP guidance tests: 7 passing. Both modified skills pass validation; regenerated guidance and tooling-index checks pass.
- Salesforce documentation links return HTTP 200.
- Repository lint and diff whitespace checks pass.
- Previously validated the main preview workflow by dispatching against main: S3 upload and CloudFront invalidation succeeded, and the homepage and an asset returned HTTP 200 with `/pr-next/` paths.

Main preview: https://d3uhw92m2zac57.cloudfront.net/pr-next/

## Dependencies

- [x] No net-new third-party dependencies were added

---

- [x] Relevant tests and validation pass (listed above; full unit suite not run for documentation changes)
- [x] Formatting checked for the rewritten guide; repository lint passes
